### PR TITLE
Use KRaft for example install, support node pool storage metrics

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/KafkaClustersResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/KafkaClustersResource.java
@@ -72,6 +72,7 @@ public class KafkaClustersResource {
                         KafkaCluster.Fields.KAFKA_VERSION,
                         KafkaCluster.Fields.STATUS,
                         KafkaCluster.Fields.CONDITIONS,
+                        KafkaCluster.Fields.NODE_POOLS,
                     },
                     message = "list contains a value that is not valid or not available for the operation",
                     payload = ErrorCategory.InvalidQueryParameter.class)
@@ -90,6 +91,7 @@ public class KafkaClustersResource {
                                 KafkaCluster.Fields.KAFKA_VERSION,
                                 KafkaCluster.Fields.STATUS,
                                 KafkaCluster.Fields.CONDITIONS,
+                                KafkaCluster.Fields.NODE_POOLS,
                             }))
             List<String> fields,
 
@@ -134,6 +136,7 @@ public class KafkaClustersResource {
                         KafkaCluster.Fields.KAFKA_VERSION,
                         KafkaCluster.Fields.STATUS,
                         KafkaCluster.Fields.CONDITIONS,
+                        KafkaCluster.Fields.NODE_POOLS,
                     },
                     payload = ErrorCategory.InvalidQueryParameter.class)
             @Parameter(
@@ -155,6 +158,7 @@ public class KafkaClustersResource {
                                 KafkaCluster.Fields.KAFKA_VERSION,
                                 KafkaCluster.Fields.STATUS,
                                 KafkaCluster.Fields.CONDITIONS,
+                                KafkaCluster.Fields.NODE_POOLS,
                             }))
             List<String> fields) {
 

--- a/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
@@ -38,6 +38,7 @@ public class KafkaCluster {
         public static final String KAFKA_VERSION = "kafkaVersion";
         public static final String STATUS = "status";
         public static final String CONDITIONS = "conditions";
+        public static final String NODE_POOLS = "nodePools";
 
         static final Comparator<KafkaCluster> ID_COMPARATOR =
                 comparing(KafkaCluster::getId, nullsLast(String::compareTo));
@@ -59,7 +60,8 @@ public class KafkaCluster {
                 + LISTENERS + ", "
                 + KAFKA_VERSION + ", "
                 + STATUS + ", "
-                + CONDITIONS + ", ";
+                + CONDITIONS + ", "
+                + NODE_POOLS;
 
         public static final String DESCRIBE_DEFAULT =
                 NAME + ", "
@@ -71,7 +73,8 @@ public class KafkaCluster {
                 + LISTENERS + ", "
                 + KAFKA_VERSION + ", "
                 + STATUS + ", "
-                + CONDITIONS + ", ";
+                + CONDITIONS + ", "
+                + NODE_POOLS;
 
         private Fields() {
             // Prevent instances
@@ -133,6 +136,7 @@ public class KafkaCluster {
     List<Condition> conditions;
     @JsonIgnore
     boolean configured;
+    List<String> nodePools;
 
     public KafkaCluster(String id, List<Node> nodes, Node controller, List<String> authorizedOperations) {
         super();
@@ -257,5 +261,13 @@ public class KafkaCluster {
 
     public void setConfigured(boolean configured) {
         this.configured = configured;
+    }
+
+    public List<String> getNodePools() {
+        return nodePools;
+    }
+
+    public void setNodePools(List<String> nodePools) {
+        this.nodePools = nodePools;
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
@@ -161,6 +161,8 @@ public class KafkaClusterService {
                                     c -> cluster.setStatus("NotReady"),
                                     () -> cluster.setStatus("Ready"));
                     });
+                Optional.ofNullable(status.getKafkaNodePools())
+                    .ifPresent(pools -> cluster.setNodePools(pools.stream().map(pool -> pool.getName()).toList()));
             });
     }
 

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
@@ -143,6 +143,9 @@ class KafkaClustersResourceIT {
                         .withType("Ready")
                         .withStatus("True")
                     .endCondition()
+                    .addNewKafkaNodePool()
+                        .withName("my-node-pool")
+                    .endKafkaNodePool()
                 .endStatus()
                 .build())
             .create();
@@ -187,6 +190,7 @@ class KafkaClustersResourceIT {
             .body("data.id", containsInAnyOrder(clusterId1, clusterId2))
             .body("data.attributes.name", containsInAnyOrder("test-kafka1", "test-kafka2"))
             .body("data.find { it.attributes.name == 'test-kafka1'}.attributes.status", is("Ready"))
+            .body("data.find { it.attributes.name == 'test-kafka1'}.attributes.nodePools", contains("my-node-pool"))
             .body("data.find { it.attributes.name == 'test-kafka1'}.attributes.listeners", hasItem(allOf(
                     hasEntry("bootstrapServers", k1Bootstrap),
                     hasEntry("authType", "custom"))))

--- a/install/README.md
+++ b/install/README.md
@@ -38,6 +38,14 @@ a ConfigMap to export metrics in the way expected by the Prometheus instance cre
 002-deploy-console-kafka.sh ${TARGET_NAMESPACE} ${CLUSTER_DOMAIN}
 ```
 
+By default, the Kafka cluster will be created in KRaft mode (Zookeeper-less). If you would like to create a cluster
+that uses ZooKeeper, an additional third argument with the value `zk` may be given. The value may also be `kraft` to
+explicitly request a KRaft cluster.
+
+```shell
+002-deploy-console-kafka.sh ${TARGET_NAMESPACE} ${CLUSTER_DOMAIN} zk
+```
+
 ### Authorization
 
 In order to allow the necessary access for the console to function, a minimum level of authorization must be configured

--- a/install/resources/kafka/console-kafka-zk.kafka.yaml
+++ b/install/resources/kafka/console-kafka-zk.kafka.yaml
@@ -2,9 +2,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: console-kafka
-  annotations:
-    strimzi.io/kraft: enabled
-    strimzi.io/node-pools: enabled
 spec:
   entityOperator:
     topicOperator: {}
@@ -15,6 +12,7 @@ spec:
     config:
       allow.everyone.if.no.acl.found: 'true'
       default.replication.factor: 3
+      inter.broker.protocol.version: '3.7'
       min.insync.replicas: 2
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
@@ -38,6 +36,14 @@ spec:
             host: broker-1.console-kafka.${CLUSTER_DOMAIN}
           - broker: 2
             host: broker-2.console-kafka.${CLUSTER_DOMAIN}
+    replicas: 3
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 10Gi
+        deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:
@@ -45,3 +51,15 @@ spec:
           name: console-kafka-metrics
           key: kafka-metrics-config.yml
     version: 3.7.0
+  zookeeper:
+    replicas: 3
+    storage:
+      deleteClaim: false
+      size: 10Gi
+      type: persistent-claim
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: console-kafka-metrics
+          key: zookeeper-metrics-config.yml

--- a/install/resources/kafka/console-nodepool.kafkanodepool.yaml
+++ b/install/resources/kafka/console-nodepool.kafkanodepool.yaml
@@ -1,0 +1,18 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: console-nodepool
+  labels:
+    strimzi.io/cluster: console-kafka
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - deleteClaim: false
+        id: 0
+        size: 10Gi
+        type: persistent-claim

--- a/ui/api/kafka/cluster.promql.ts
+++ b/ui/api/kafka/cluster.promql.ts
@@ -34,11 +34,11 @@ export const memory = (namespace: string, cluster: string) => `
   )
 `;
 
-export const volumeCapacity = (namespace: string, cluster: string) => `
+export const volumeCapacity = (namespace: string, cluster: string, nodePools: string) => `
   sum by (nodeId, __console_metric_name__) (
     label_replace(
       label_replace(
-        kubelet_volume_stats_capacity_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-kafka-\\\\d+"},
+        kubelet_volume_stats_capacity_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-(kafka|${nodePools})-\\\\d+"},
         "nodeId",
         "$1",
         "persistentvolumeclaim",
@@ -52,11 +52,11 @@ export const volumeCapacity = (namespace: string, cluster: string) => `
   )
 `;
 
-export const volumeUsed = (namespace: string, cluster: string) => `
+export const volumeUsed = (namespace: string, cluster: string, nodePools: string) => `
   sum by (nodeId, __console_metric_name__) (
     label_replace(
       label_replace(
-        kubelet_volume_stats_used_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-kafka-\\\\d+"},
+        kubelet_volume_stats_used_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-(kafka|${nodePools})-\\\\d+"},
         "nodeId",
         "$1",
         "persistentvolumeclaim",

--- a/ui/api/kafka/kpi.promql.ts
+++ b/ui/api/kafka/kpi.promql.ts
@@ -2,6 +2,7 @@ export const values = (
   namespace: string,
   cluster: string,
   controller: number,
+  nodePools: string,
 ) => `
 sum by (__console_metric_name__, nodeId) (
   label_replace(
@@ -101,7 +102,7 @@ or
 sum by (__console_metric_name__, nodeId) (
   label_replace(
     label_replace(
-      kubelet_volume_stats_capacity_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-kafka-\\\\d+"},
+      kubelet_volume_stats_capacity_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-(kafka|${nodePools})-\\\\d+"},
       "nodeId",
       "$1",
       "persistentvolumeclaim",
@@ -119,7 +120,7 @@ or
 sum by (__console_metric_name__, nodeId) (
   label_replace(
     label_replace(
-      kubelet_volume_stats_used_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-kafka-\\\\d+"},
+      kubelet_volume_stats_used_bytes{namespace="${namespace}",persistentvolumeclaim=~"data(?:-\\\\d+)?-${cluster}-(kafka|${nodePools})-\\\\d+"},
       "nodeId",
       "$1",
       "persistentvolumeclaim",

--- a/ui/api/kafka/schema.ts
+++ b/ui/api/kafka/schema.ts
@@ -51,6 +51,7 @@ const ClusterDetailSchema = z.object({
         lastTransitionTime: z.string().optional(),
       }),
     ),
+    nodePools: z.array(z.string()).optional().nullable(),
   }),
 });
 export const ClusterResponse = z.object({

--- a/ui/components/ClusterOverview/components/ChartDiskUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartDiskUsage.tsx
@@ -44,7 +44,7 @@ export function ChartDiskUsage({ usages, available }: ChartDiskUsageProps) {
       childName: `node ${idx}`,
     })),
     ...usages.map((_, idx) => ({
-      name: `Available storage threshold (node ${idx + 1})`,
+      name: `Available storage threshold (node ${idx})`,
       childName: `threshold ${idx}`,
       symbol: { type: "threshold" },
     })),


### PR DESCRIPTION
With Strimzi KafkaNodePools [1] (required to run the cluster in KRaft mode), storage metrics have a slightly different format for the PVC label. This PR adds support for storage allocated via a node pool, and also changes the example Kafka cluster to use KRaft mode.

[1] https://strimzi.io/blog/2023/08/28/kafka-node-pools-storage-and-scheduling/