### PR TITLE
[WIP] - [CI] Add minikube deployment for PR testing

### DIFF
--- a/.github/workflows/minikube-deployment.yaml
+++ b/.github/workflows/minikube-deployment.yaml
@@ -1,0 +1,155 @@
+name: Minikube Deployment
+
+on:
+  workflow_call:
+
+env:
+  TARGET_NAMESPACE: "console-namespace"
+  CI_CLUSTER: true
+  CONFIG_YAML: "./install/resources/console/console-config.yaml"
+  DEPLOYMENT_YAML: "./install/resources/console/console.deployment.yaml"
+  CLUSTER_DOMAIN: "192.168.49.2.nip.io"
+  CONSOLE_API_IMAGE: "quay.io/streamshub/console-api:latest"
+  CONSOLE_UI_IMAGE: "quay.io/streamshub/console-ui:latest"
+
+jobs:
+  setup_deployment:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Install yq
+        run: |
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 > yq && chmod +x yq
+          sudo cp -v yq /usr/bin/
+
+      - name: Start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@latest
+        with:
+          cpus: 2
+          memory: 4096m
+
+      - name: Enable ingress
+        run: |
+          minikube addons enable ingress
+          minikube addons enable ingress-dns
+          kubectl patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
+
+      - name: Download Docker API Image
+        uses: actions/download-artifact@v4
+        with:
+          name: streamshub-api
+
+      - name: Download Docker UI Image
+        uses: actions/download-artifact@v4
+        with:
+          name: streamshub-ui
+
+      - name: Load Docker Images
+        run: |
+          gunzip -c streamshub-api.tar.gz | docker load
+          gunzip -c streamshub-ui.tar.gz | docker load
+
+      - name: Push Images To Minikube
+        run: |
+          eval $(minikube docker-env)
+          minikube cache list
+          minikube cache add $CONSOLE_API_IMAGE
+          minikube cache add $CONSOLE_API_IMAGE
+          minikube cache reload
+          minikube cache list
+
+      - name: Create namespace
+        run: kubectl create namespace $TARGET_NAMESPACE
+
+      - name: Install Strimzi
+        run: kubectl create -f "https://strimzi.io/install/latest?namespace=$TARGET_NAMESPACE" -n $TARGET_NAMESPACE
+
+      - name: Prometheus Operator Deployment
+        shell: bash
+        run: |
+          curl -s "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/bundle.yaml" | sed "s#namespace: default#namespace: ${TARGET_NAMESPACE}#g" | kubectl create -n $TARGET_NAMESPACE -f -
+
+      - name: Prometheus Instance Deployment
+        run: ./install/001-deploy-prometheus.sh $TARGET_NAMESPACE $CLUSTER_DOMAIN
+
+      - name: Get pods
+        run: kubectl get pods -n $TARGET_NAMESPACE
+
+      - name: Wait For Strimzi
+        run: kubectl wait deployment/strimzi-cluster-operator --for=condition=available --timeout=180s -n $TARGET_NAMESPACE
+
+      - name: Kafka Cluster Deployment
+        run: ./install/002-deploy-console-kafka.sh $TARGET_NAMESPACE $CLUSTER_DOMAIN zk
+
+      - name: Get pods
+        run: kubectl get pods -n $TARGET_NAMESPACE
+
+      - name: Wait For Kafka
+        run: kubectl wait kafka/console-kafka --for=condition=Ready --timeout=300s -n $TARGET_NAMESPACE
+
+      - name: Wait For Kafka User Secret
+        run: while ! kubectl get secret console-kafka-user1 -n $TARGET_NAMESPACE; do echo "Waiting for user secret"; sleep 5; done
+
+      - name: Prepare config
+        shell: bash
+        run: |
+          USERPS=$(kubectl get secret console-kafka-user1 -n $TARGET_NAMESPACE -o yaml | yq '.data.password' - | base64 --decode)
+          sed -i -e "s#\$USER_PASSWORD#${USERPS}#g" -e "s#\$CLUSTER_DOMAIN#${CLUSTER_DOMAIN}#g" -e "s#\$NAMESPACE#${TARGET_NAMESPACE}#g" $CONFIG_YAML
+
+      - name: Switch image from remote to local only
+        shell: bash
+        run: |
+            sed -i -e "s#imagePullPolicy: Always#imagePullPolicy: Never#g" $DEPLOYMENT_YAML
+
+      - name: Deploy console
+        run: ./install/003-install-console.sh $TARGET_NAMESPACE $CLUSTER_DOMAIN $CONFIG_YAML
+
+      - name: Show pods
+        run: kubectl get pods -n $TARGET_NAMESPACE
+
+      - name: Wait For Console Deployment
+        run: kubectl wait deployment/console --for=condition=available --timeout=180s -n $TARGET_NAMESPACE
+
+      - name: Get pods
+        run: kubectl get pods -n $TARGET_NAMESPACE
+
+      - name: get services
+        run: kubectl get services -A
+
+      - name: get ingress
+        run: kubectl get ingress -A
+
+      - name: docker ps
+        run: docker ps
+
+      - name: curl
+        run: curl -L http://console-ui.192.168.49.2.nip.io
+
+      - name: curl
+        run: curl -L http://console-ui.192.168.49.2.nip.io/home
+
+      - name: curl
+        run: curl -L http://console-ui.$CLUSTER_DOMAIN/home
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./ui
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+        working-directory: ./ui
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        working-directory: ./ui

--- a/install/001-deploy-prometheus.sh
+++ b/install/001-deploy-prometheus.sh
@@ -19,7 +19,7 @@ fi
 echo -e "${INFO} Apply Prometheus security resources"
 ${KUBE} apply -n ${NAMESPACE} -f ${RESOURCE_PATH}/prometheus/console-prometheus-server.clusterrole.yaml
 ${KUBE} apply -n ${NAMESPACE} -f ${RESOURCE_PATH}/prometheus/console-prometheus-server.serviceaccount.yaml
-yq '.subjects[0].namespace = strenv(NAMESPACE)' ${RESOURCE_PATH}/prometheus/console-prometheus-server.clusterrolebinding.yaml | ${KUBE} apply -n ${NAMESPACE} -f -
+${YQ} '.subjects[0].namespace = strenv(NAMESPACE)' ${RESOURCE_PATH}/prometheus/console-prometheus-server.clusterrolebinding.yaml | ${KUBE} apply -n ${NAMESPACE} -f -
 
 echo -e "${INFO} Apply Prometheus PodMonitor and Kubernetes scrape configurations"
 ${KUBE} apply -n ${NAMESPACE} -f ${RESOURCE_PATH}/prometheus/kafka-resources.podmonitor.yaml

--- a/install/_common.sh
+++ b/install/_common.sh
@@ -34,7 +34,7 @@ fi
 
 OLM=$(kubectl get crd | grep operators.coreos.com) || :
 
-if [ "${OLM}" == "" ] ; then
+if [ "${OLM}" == "" ] && [ "${CI_CLUSTER}" == "" ] ; then
     echo -e "${ERROR} Operator Lifecycle Manager not found, please install it.
 
 $ operator-sdk olm install

--- a/install/resources/console/console-config.yaml
+++ b/install/resources/console/console-config.yaml
@@ -1,0 +1,13 @@
+kafka:
+  clusters:
+    - name: console-kafka
+      namespace: "$NAMESPACE"
+      listener: secure
+      properties:
+        security.protocol: SASL_SSL
+        sasl.mechanism: SCRAM-SHA-512
+        bootstrap.servers: "bootstrap.console-kafka.$CLUSTER_DOMAIN:443"
+        sasl.jaas.config: org.apache.kafka.common.security.scram.ScramLoginModule required username="console-kafka-user1" password="$USER_PASSWORD";
+      adminProperties: {}
+      consumerProperties: {}
+      producerProperties: {}

--- a/install/resources/console/console.deployment.yaml
+++ b/install/resources/console/console.deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       ### API
       - name: console-api
-        image: quay.io/streamshub/console-api:latest
+        image: quay.io/eyefloaters/console-api:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -36,7 +36,7 @@ spec:
           value: /deployments/console-config.yaml
       ### User Interface
       - name: console-ui
-        image: quay.io/streamshub/console-ui:latest
+        image: quay.io/eyefloaters/console-ui:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 3000


### PR DESCRIPTION
In this PR a new GitHub action workflow is created. This workflow is triggered on every pull-request which targets main branch (for each commit).

It utilizes installation of strimzi operator, prometheus operator from online example. 
Prometheus instance, kafka cluster and console deployment are installed using scripts from examples in this repository (located in `./install/ directory`). 

After an environment is prepared, console images are built and console is deployed. We should discuss what this step could be, if images can be built using make or can depend on existing build workflow. There is a demonstrative curl step at the end of the workflow which should be replaced with some testing steps.

In order to fully make this work a `console-config.yaml` was added based on the other provided examples style.
Also a few changes i the installation scripts needed to be done (Like removing unused variable `PROVIDED_APIS`) and switch that skips operatorhub installation on ci/minikube cluster.

Note: For demonstration purposes deployment images needed to be changed. After this PR is reviewed and approved these images will be replaced with streamshub ones (they do not exist at this point in the streamshub registry).