### PR TITLE
Decouple Strimzi Kafka CR from core functionality

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -180,11 +180,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>

--- a/api/src/main/java/com/github/streamshub/console/api/Annotations.java
+++ b/api/src/main/java/com/github/streamshub/console/api/Annotations.java
@@ -14,17 +14,7 @@ public enum Annotations {
      * Annotation to identify a listener in Strimzi Kafka resources to be used for
      * connections directly from the Console API.
      */
-    CONSOLE_LISTENER("console-listener"),
-
-    /**
-     * Annotation to identify a listener in Strimzi Kafka resources to be used for
-     * public connections. This may be used to differentiate a listener to be
-     * exposed via the KafkaCluster resource and published in the UI.
-     *
-     * @deprecated
-     */
-    @Deprecated(forRemoval = true)
-    EXPOSED_LISTENER("exposed-listener");
+    CONSOLE_LISTENER("console-listener");
 
     private static final String NAMESPACE = "streamshub.github.com";
     private final String value;

--- a/api/src/main/java/com/github/streamshub/console/api/BrokersResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/BrokersResource.java
@@ -1,7 +1,6 @@
 package com.github.streamshub.console.api;
 
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -11,7 +10,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.apache.kafka.clients.admin.Admin;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -23,9 +21,6 @@ import com.github.streamshub.console.api.service.BrokerService;
 @Path("/api/kafkas/{clusterId}/nodes")
 @Tag(name = "Kafka Cluster Resources")
 public class BrokersResource {
-
-    @Inject
-    Supplier<Admin> clientSupplier;
 
     @Inject
     BrokerService brokerService;

--- a/api/src/main/java/com/github/streamshub/console/api/errors/server/KafkaServerExceptionHandlers.java
+++ b/api/src/main/java/com/github/streamshub/console/api/errors/server/KafkaServerExceptionHandlers.java
@@ -1,0 +1,29 @@
+package com.github.streamshub.console.api.errors.server;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ext.Provider;
+
+import org.apache.kafka.common.errors.SslAuthenticationException;
+
+import com.github.streamshub.console.api.support.ErrorCategory;
+
+public class KafkaServerExceptionHandlers {
+
+    private KafkaServerExceptionHandlers() {
+    }
+
+    @Provider
+    @ApplicationScoped
+    public static class AuthenticationExceptionHandler
+        extends AbstractServerExceptionHandler<SslAuthenticationException> {
+
+        public AuthenticationExceptionHandler() {
+            super(ErrorCategory.ServerError.class);
+        }
+
+        @Override
+        public boolean handlesException(Throwable thrown) {
+            return thrown instanceof SslAuthenticationException;
+        }
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
@@ -55,13 +55,7 @@ public class KafkaCluster {
 
         public static final String LIST_DEFAULT =
                 NAME + ", "
-                + NAMESPACE + ", "
-                + CREATION_TIMESTAMP + ", "
-                + LISTENERS + ", "
-                + KAFKA_VERSION + ", "
-                + STATUS + ", "
-                + CONDITIONS + ", "
-                + NODE_POOLS;
+                + NAMESPACE;
 
         public static final String DESCRIBE_DEFAULT =
                 NAME + ", "
@@ -97,6 +91,7 @@ public class KafkaCluster {
                         var rsrc = new KafkaClusterResource(entry);
                         rsrc.addMeta("page", listSupport.buildPageMeta(entry::toCursor));
                         rsrc.addMeta("configured", entry.isConfigured());
+                        rsrc.addMeta("managed", entry.isManaged());
                         return rsrc;
                     })
                     .toList());
@@ -116,6 +111,8 @@ public class KafkaCluster {
     public static final class KafkaClusterResource extends Resource<KafkaCluster> {
         public KafkaClusterResource(KafkaCluster data) {
             super(data.id, "kafkas", data);
+            addMeta("configured", data.isConfigured());
+            addMeta("managed", data.isManaged());
         }
     }
 
@@ -123,7 +120,7 @@ public class KafkaCluster {
     String namespace; // Strimzi Kafka CR only
     String creationTimestamp; // Strimzi Kafka CR only
     @JsonIgnore
-    final String id;
+    String id; // non-final, may be overridden by configuration
     final List<Node> nodes;
     final Node controller;
     final List<String> authorizedOperations;
@@ -137,6 +134,8 @@ public class KafkaCluster {
     @JsonIgnore
     boolean configured;
     List<String> nodePools;
+    @JsonIgnore
+    boolean managed;
 
     public KafkaCluster(String id, List<Node> nodes, Node controller, List<String> authorizedOperations) {
         super();
@@ -211,6 +210,10 @@ public class KafkaCluster {
         return id;
     }
 
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public List<Node> getNodes() {
         return nodes;
     }
@@ -269,5 +272,13 @@ public class KafkaCluster {
 
     public void setNodePools(List<String> nodePools) {
         this.nodePools = nodePools;
+    }
+
+    public void setManaged(boolean managed) {
+        this.managed = managed;
+    }
+
+    public boolean isManaged() {
+        return managed;
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/service/ConsumerGroupService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/ConsumerGroupService.java
@@ -53,6 +53,7 @@ import com.github.streamshub.console.api.model.PartitionInfo;
 import com.github.streamshub.console.api.model.Topic;
 import com.github.streamshub.console.api.support.ConsumerGroupValidation;
 import com.github.streamshub.console.api.support.FetchFilterPredicate;
+import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.KafkaOffsetSpec;
 import com.github.streamshub.console.api.support.ListRequestContext;
 import com.github.streamshub.console.api.support.UnknownTopicIdPatch;
@@ -84,7 +85,7 @@ public class ConsumerGroupService {
     ThreadContext threadContext;
 
     @Inject
-    Supplier<Admin> clientSupplier;
+    KafkaContext kafkaContext;
 
     @Inject
     TopicService topicService;
@@ -99,7 +100,7 @@ public class ConsumerGroupService {
     public CompletionStage<List<ConsumerGroup>> listConsumerGroups(String topicId, List<String> includes,
             ListRequestContext<ConsumerGroup> listSupport) {
 
-        Admin adminClient = clientSupplier.get();
+        Admin adminClient = kafkaContext.admin();
         Uuid id = Uuid.fromString(topicId);
         Executor asyncExec = threadContext.currentContextExecutor();
 
@@ -120,7 +121,7 @@ public class ConsumerGroupService {
     }
 
     CompletionStage<List<ConsumerGroup>> listConsumerGroups(List<String> groupIds, List<String> includes, ListRequestContext<ConsumerGroup> listSupport) {
-        Admin adminClient = clientSupplier.get();
+        Admin adminClient = kafkaContext.admin();
 
         Set<ConsumerGroupState> states = listSupport.filters()
             .stream()
@@ -157,7 +158,7 @@ public class ConsumerGroupService {
     }
 
     public CompletionStage<ConsumerGroup> describeConsumerGroup(String requestGroupId, List<String> includes) {
-        Admin adminClient = clientSupplier.get();
+        Admin adminClient = kafkaContext.admin();
         String groupId = preprocessGroupId(requestGroupId);
 
         return assertConsumerGroupExists(adminClient, groupId)
@@ -167,7 +168,7 @@ public class ConsumerGroupService {
     }
 
     public CompletionStage<Map<String, List<String>>> listConsumerGroupMembership(Collection<String> topicIds) {
-        Admin adminClient = clientSupplier.get();
+        Admin adminClient = kafkaContext.admin();
 
         return adminClient.listConsumerGroups(new ListConsumerGroupsOptions()
                 .inStates(Set.of(
@@ -209,7 +210,7 @@ public class ConsumerGroupService {
     }
 
     public CompletionStage<Void> patchConsumerGroup(ConsumerGroup patch) {
-        Admin adminClient = clientSupplier.get();
+        Admin adminClient = kafkaContext.admin();
         String groupId = preprocessGroupId(patch.getGroupId());
 
         return assertConsumerGroupExists(adminClient, groupId)
@@ -389,7 +390,7 @@ public class ConsumerGroupService {
     }
 
     public CompletionStage<Void> deleteConsumerGroup(String requestGroupId) {
-        Admin adminClient = clientSupplier.get();
+        Admin adminClient = kafkaContext.admin();
         String groupId = preprocessGroupId(requestGroupId);
 
         return adminClient.deleteConsumerGroups(List.of(groupId))

--- a/api/src/main/java/com/github/streamshub/console/api/service/RecordService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/RecordService.java
@@ -31,7 +31,6 @@ import java.util.stream.StreamSupport;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -50,6 +49,7 @@ import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.KafkaRecord;
+import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.SizeLimitedSortedSet;
 
 import static java.util.Objects.requireNonNullElse;
@@ -64,7 +64,7 @@ public class RecordService {
     Logger logger;
 
     @Inject
-    Supplier<Admin> clientSupplier;
+    KafkaContext kafkaContext;
 
     @Inject
     Supplier<Consumer<byte[], byte[]>> consumerSupplier;
@@ -198,7 +198,7 @@ public class RecordService {
     CompletionStage<String> topicNameForId(String topicId) {
         Uuid kafkaTopicId = Uuid.fromString(topicId);
 
-        return clientSupplier.get()
+        return kafkaContext.admin()
             .listTopics(new ListTopicsOptions().listInternal(true))
             .listings()
             .toCompletionStage()

--- a/api/src/main/java/com/github/streamshub/console/api/support/Holder.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/Holder.java
@@ -1,0 +1,87 @@
+package com.github.streamshub.console.api.support;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Like {@linkplain java.util.Optional Optional}, but non-final so it may be
+ * used as a CDI type.
+ *
+ * @param <T> the type of value
+ * @see {@link java.util.Optional}
+ */
+public class Holder<T> implements Supplier<T> {
+
+    private static final Holder<?> EMPTY = new Holder<>(null);
+    private final T value;
+
+    private Holder(T value) {
+        this.value = value;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Holder<T> empty() {
+        return (Holder<T>) EMPTY;
+    }
+
+    public static <T> Holder<T> of(T value) {
+        return new Holder<>(value);
+    }
+
+    /**
+     * If a value is present, returns {@code true}, otherwise {@code false}.
+     *
+     * @return {@code true} if a value is present, otherwise {@code false}
+     */
+    public boolean isPresent() {
+        return value != null;
+    }
+
+    /**
+     * If a value is present, performs the given action with the value,
+     * otherwise does nothing.
+     *
+     * @param action the action to be performed, if a value is present
+     * @throws NullPointerException if value is present and the given action is
+     *         {@code null}
+     */
+    public void ifPresent(Consumer<? super T> action) {
+        if (value != null) {
+            action.accept(value);
+        }
+    }
+
+    /**
+     * If a value is present, returns the value, otherwise throws
+     * {@code NoSuchElementException}.
+     *
+     * @apiNote
+     * The preferred alternative to this method is {@link #orElseThrow()}.
+     *
+     * @return the non-{@code null} value described by this {@code Optional}
+     * @throws NoSuchElementException if no value is present
+     */
+    @Override
+    public T get() {
+        if (value == null) {
+            throw new NoSuchElementException("No value present");
+        }
+        return value;
+    }
+
+    /**
+     * @see {@link java.util.Optional#map(Function)}
+     */
+    public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(mapper.apply(value));
+        }
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/InformerFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/InformerFactory.java
@@ -5,8 +5,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.event.Startup;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
@@ -14,7 +12,10 @@ import jakarta.inject.Named;
 
 import org.jboss.logging.Logger;
 
+import com.github.streamshub.console.config.ConsoleConfig;
+
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -32,78 +33,112 @@ public class InformerFactory {
     @Inject
     KubernetesClient k8s;
 
-    @Produces
-    @ApplicationScoped
-    @Named("KafkaInformer")
-    SharedIndexInformer<Kafka> kafkaInformer;
+    @Inject
+    ConsoleConfig consoleConfig;
+
+    SharedIndexInformer<KafkaTopic> topicInformer;
 
     @Produces
     @ApplicationScoped
-    @Named("KafkaTopicInformer")
-    SharedIndexInformer<KafkaTopic> topicInformer;
+    @Named("KafkaInformer")
+    Holder<SharedIndexInformer<Kafka>> produceKafkaInformer() {
+        if (consoleConfig.getKubernetes().isEnabled()) {
+            var kafkaResources = k8s.resources(Kafka.class).inAnyNamespace();
+
+            try {
+                return Holder.of(kafkaResources.inform());
+            } catch (KubernetesClientException e) {
+                logger.warnf("Failed to create Strimzi Kafka informer: %s", e.getMessage());
+            }
+        } else {
+            logger.warn("Kubernetes client connection is disabled. Custom resource information will not be available.");
+        }
+
+        return Holder.empty();
+    }
+
+    void disposeKafkaInformer(@Disposes @Named("KafkaInformer") Holder<SharedIndexInformer<Kafka>> informer) {
+        informer.ifPresent(SharedIndexInformer::close);
+    }
 
     @Produces
     @ApplicationScoped
     @Named("KafkaTopics")
     // Keys: namespace -> cluster name -> topic name
-    Map<String, Map<String, Map<String, KafkaTopic>>> topics = new ConcurrentHashMap<>();
+    Map<String, Map<String, Map<String, KafkaTopic>>> produceKafkaTopics() {
+        Map<String, Map<String, Map<String, KafkaTopic>>> topics = new ConcurrentHashMap<>();
+
+        if (consoleConfig.getKubernetes().isEnabled()) {
+            try {
+                topicInformer = k8s.resources(KafkaTopic.class).inAnyNamespace().inform();
+                topicInformer.addEventHandler(new KafkaTopicEventHandler(topics));
+            } catch (KubernetesClientException e) {
+                logger.warnf("Failed to create Strimzi KafkaTopic informer: %s", e.getMessage());
+            }
+        } else {
+            logger.warn("Kubernetes client connection is disabled. Custom resource information will not be available.");
+        }
+
+        return topics;
+    }
 
     /**
-     * Initialize CDI beans produced by this factory. Executed on application startup.
+     * Close the KafkaTopic informer used to update the topics map being disposed.
      *
-     * @param event CDI startup event
+     * @param topics map of KafkaTopics being disposed.
      */
-    void onStartup(@Observes Startup event) {
-        kafkaInformer = k8s.resources(Kafka.class).inAnyNamespace().inform();
-        topicInformer = k8s.resources(KafkaTopic.class).inAnyNamespace().inform();
-        topicInformer.addEventHandler(new ResourceEventHandler<KafkaTopic>() {
-            @Override
-            public void onAdd(KafkaTopic topic) {
-                topicMap(topic).ifPresent(map -> map.put(topicName(topic), topic));
-            }
-
-            @Override
-            public void onUpdate(KafkaTopic oldTopic, KafkaTopic topic) {
-                onDelete(oldTopic, false);
-                onAdd(topic);
-            }
-
-            @Override
-            public void onDelete(KafkaTopic topic, boolean deletedFinalStateUnknown) {
-                topicMap(topic).ifPresent(map -> map.remove(topicName(topic)));
-            }
-
-            private static String topicName(KafkaTopic topic) {
-                return Optional.ofNullable(topic.getSpec())
-                        .map(KafkaTopicSpec::getTopicName)
-                        .orElseGet(() -> topic.getMetadata().getName());
-            }
-
-            Optional<Map<String, KafkaTopic>> topicMap(KafkaTopic topic) {
-                String namespace = topic.getMetadata().getNamespace();
-                String clusterName = topic.getMetadata().getLabels().get(STRIMZI_CLUSTER);
-
-                if (clusterName == null) {
-                    logger.warnf("KafkaTopic %s/%s is missing label %s and will be ignored",
-                            namespace,
-                            topic.getMetadata().getName(),
-                            STRIMZI_CLUSTER);
-                    return Optional.empty();
-                }
-
-                Map<String, KafkaTopic> map = topics.computeIfAbsent(namespace, k -> new ConcurrentHashMap<>())
-                        .computeIfAbsent(clusterName, k -> new ConcurrentHashMap<>());
-
-                return Optional.of(map);
-            }
-        });
+    void disposeKafkaTopics(@Disposes Map<String, Map<String, Map<String, KafkaTopic>>> topics) {
+        if (topicInformer != null) {
+            topicInformer.close();
+        }
     }
 
-    public void disposeKafkaInformer(@Disposes @Named("KafkaInformer") SharedIndexInformer<Kafka> informer) {
-        informer.close();
+    private class KafkaTopicEventHandler implements ResourceEventHandler<KafkaTopic> {
+        Map<String, Map<String, Map<String, KafkaTopic>>> topics;
+
+        public KafkaTopicEventHandler(Map<String, Map<String, Map<String, KafkaTopic>>> topics) {
+            this.topics = topics;
+        }
+
+        @Override
+        public void onAdd(KafkaTopic topic) {
+            topicMap(topic).ifPresent(map -> map.put(topicName(topic), topic));
+        }
+
+        @Override
+        public void onUpdate(KafkaTopic oldTopic, KafkaTopic topic) {
+            onDelete(oldTopic, false);
+            onAdd(topic);
+        }
+
+        @Override
+        public void onDelete(KafkaTopic topic, boolean deletedFinalStateUnknown) {
+            topicMap(topic).ifPresent(map -> map.remove(topicName(topic)));
+        }
+
+        private static String topicName(KafkaTopic topic) {
+            return Optional.ofNullable(topic.getSpec())
+                    .map(KafkaTopicSpec::getTopicName)
+                    .orElseGet(() -> topic.getMetadata().getName());
+        }
+
+        Optional<Map<String, KafkaTopic>> topicMap(KafkaTopic topic) {
+            String namespace = topic.getMetadata().getNamespace();
+            String clusterName = topic.getMetadata().getLabels().get(STRIMZI_CLUSTER);
+
+            if (clusterName == null) {
+                logger.warnf("KafkaTopic %s/%s is missing label %s and will be ignored",
+                        namespace,
+                        topic.getMetadata().getName(),
+                        STRIMZI_CLUSTER);
+                return Optional.empty();
+            }
+
+            Map<String, KafkaTopic> map = topics.computeIfAbsent(namespace, k -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(clusterName, k -> new ConcurrentHashMap<>());
+
+            return Optional.of(map);
+        }
     }
 
-    public void disposeTopicInformer(@Disposes @Named("KafkaTopicInformer") SharedIndexInformer<KafkaTopic> informer) {
-        informer.close();
-    }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -1,0 +1,78 @@
+package com.github.streamshub.console.api.support;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.admin.Admin;
+
+import com.github.streamshub.console.config.KafkaClusterConfig;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+
+public class KafkaContext implements Closeable {
+
+    public static final KafkaContext EMPTY = new KafkaContext(null, null, Collections.emptyMap(), null);
+
+    final KafkaClusterConfig clusterConfig;
+    final Kafka resource;
+    final Map<Class<?>, Map<String, Object>> configs;
+    final Admin admin;
+
+    public KafkaContext(KafkaClusterConfig clusterConfig, Kafka resource, Map<Class<?>, Map<String, Object>> configs, Admin admin) {
+        this.clusterConfig = clusterConfig;
+        this.resource = resource;
+        this.configs = Map.copyOf(configs);
+        this.admin = admin;
+    }
+
+    public KafkaContext(KafkaContext other, Admin admin) {
+        this(other.clusterConfig, other.resource, other.configs, admin);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof KafkaContext)) {
+            return false;
+        }
+
+        KafkaContext other = (KafkaContext) obj;
+        return Objects.equals(clusterConfig, other.clusterConfig)
+                && Objects.equals(resource, other.resource)
+                && Objects.equals(configs, other.configs)
+                && Objects.equals(admin, other.admin);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterConfig, resource, configs, admin);
+    }
+
+    @Override
+    public void close() {
+        if (admin != null) {
+            admin.close();
+        }
+    }
+
+    public KafkaClusterConfig clusterConfig() {
+        return clusterConfig;
+    }
+
+    public Kafka resource() {
+        return resource;
+    }
+
+    public Map<Class<?>, Map<String, Object>> configs() {
+        return configs;
+    }
+
+    public Map<String, Object> configs(Class<?> type) {
+        return configs.get(type);
+    }
+
+    public Admin admin() {
+        return admin;
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -39,7 +39,7 @@ quarkus.swagger-ui.enable=true
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.title=Console API
 
-quarkus.log.category."org.apache.kafka".level=WARN
+quarkus.log.category."org.apache.kafka".level=ERROR
 
 quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
 quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}
@@ -64,6 +64,11 @@ console.kafka.admin.default.api.timeout.ms=10000
 %dev.quarkus.log.category."com.github.streamshub.console".level=DEBUG
 
 ########
+%testplain.quarkus.devservices.enabled=true
+%testplain.quarkus.kubernetes-client.devservices.enabled=true
+%testplain.quarkus.kubernetes-client.devservices.override-kubeconfig=true
+%testplain.quarkus.log.category."io.fabric8.kubernetes".level=DEBUG
+
 #%testplain.quarkus.http.auth.proactive=false
 #%testplain.quarkus.http.auth.permission."oidc".policy=permit
 %testplain.quarkus.log.category."io.vertx.core.impl.BlockedThreadChecker".level=OFF

--- a/api/src/test/java/com/github/streamshub/console/api/BrokersResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/BrokersResourceIT.java
@@ -7,7 +7,6 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import com.github.streamshub.console.config.ConsoleConfig;
@@ -19,7 +18,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
@@ -38,7 +36,6 @@ import static org.hamcrest.Matchers.not;
 @QuarkusTest
 @TestHTTPEndpoint(BrokersResource.class)
 @TestProfile(TestPlainProfile.class)
-@Order(Integer.MAX_VALUE)
 class BrokersResourceIT {
 
     @Inject
@@ -61,7 +58,6 @@ class BrokersResourceIT {
 
     @BeforeEach
     void setup() {
-        client.resource(Crds.kafka()).serverSideApply();
         kafkaContainer = deployments.getKafkaContainer();
         bootstrapServers = URI.create(kafkaContainer.getBootstrapServers());
         utils = new TestHelper(bootstrapServers, config, null);

--- a/api/src/test/java/com/github/streamshub/console/api/BrokersResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/BrokersResourceIT.java
@@ -7,18 +7,19 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
+import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.deployment.DeploymentManager;
 import com.github.streamshub.console.test.TestHelper;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
@@ -35,9 +36,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
-@QuarkusTestResource(KubernetesServerTestResource.class)
 @TestHTTPEndpoint(BrokersResource.class)
 @TestProfile(TestPlainProfile.class)
+@Order(Integer.MAX_VALUE)
 class BrokersResourceIT {
 
     @Inject
@@ -45,6 +46,9 @@ class BrokersResourceIT {
 
     @Inject
     KubernetesClient client;
+
+    @Inject
+    ConsoleConfig consoleConfig;
 
     @DeploymentManager.InjectDeploymentManager
     DeploymentManager deployments;
@@ -57,13 +61,13 @@ class BrokersResourceIT {
 
     @BeforeEach
     void setup() {
+        client.resource(Crds.kafka()).serverSideApply();
         kafkaContainer = deployments.getKafkaContainer();
         bootstrapServers = URI.create(kafkaContainer.getBootstrapServers());
         utils = new TestHelper(bootstrapServers, config, null);
-        clusterId = utils.getClusterId();
 
         client.resources(Kafka.class).inAnyNamespace().delete();
-        client.resources(Kafka.class).resource(new KafkaBuilder()
+        utils.apply(client, new KafkaBuilder()
                 .withNewMetadata()
                     .withName("test-kafka1")
                     .withNamespace("default")
@@ -77,7 +81,7 @@ class BrokersResourceIT {
                     .endKafka()
                 .endSpec()
                 .withNewStatus()
-                    .withClusterId(clusterId)
+                    .withClusterId(utils.getClusterId())
                     .addNewListener()
                         .withName("listener0")
                         .addNewAddress()
@@ -86,8 +90,9 @@ class BrokersResourceIT {
                         .endAddress()
                     .endListener()
                 .endStatus()
-                .build())
-            .create();
+                .build());
+
+        clusterId = consoleConfig.getKafka().getCluster("default/test-kafka1").get().getId();
     }
 
     @Test

--- a/api/src/test/java/com/github/streamshub/console/api/ConsumerGroupsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/ConsumerGroupsResourceIT.java
@@ -63,7 +63,6 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 
 import static com.github.streamshub.console.test.TestHelper.whenRequesting;
@@ -114,7 +113,6 @@ class ConsumerGroupsResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
-        client.resource(Crds.kafka()).serverSideApply();
         URI bootstrapServers = URI.create(deployments.getExternalBootstrapServers());
 
         topicUtils = new TopicHelper(bootstrapServers, config, null);

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
@@ -53,7 +53,6 @@ import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustomBuilder;
@@ -118,7 +117,6 @@ class KafkaClustersResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
-        client.resource(Crds.kafka()).serverSideApply();
         kafkaContainer = deployments.getKafkaContainer();
         bootstrapServers = URI.create(kafkaContainer.getBootstrapServers());
         randomBootstrapServers = URI.create(consoleConfig.getKafka()

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
@@ -24,7 +24,6 @@ import jakarta.json.JsonString;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.eclipse.microprofile.config.Config;
@@ -39,6 +38,8 @@ import org.mockito.Mockito;
 import com.github.streamshub.console.api.model.ListFetchParams;
 import com.github.streamshub.console.api.service.KafkaClusterService;
 import com.github.streamshub.console.api.support.ErrorCategory;
+import com.github.streamshub.console.api.support.Holder;
+import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.deployment.DeploymentManager;
@@ -48,12 +49,11 @@ import com.github.streamshub.console.test.TestHelper;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustomBuilder;
@@ -81,7 +81,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-@QuarkusTestResource(KubernetesServerTestResource.class)
 @TestHTTPEndpoint(KafkaClustersResource.class)
 @TestProfile(TestPlainProfile.class)
 class KafkaClustersResourceIT {
@@ -95,10 +94,10 @@ class KafkaClustersResourceIT {
     KubernetesClient client;
 
     @Inject
-    SharedIndexInformer<Kafka> kafkaInformer;
+    Holder<SharedIndexInformer<Kafka>> kafkaInformer;
 
     @Inject
-    Map<String, Admin> configuredAdmins;
+    Map<String, KafkaContext> configuredContexts;
 
     @Inject
     KafkaClusterService kafkaClusterService;
@@ -119,6 +118,7 @@ class KafkaClustersResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
+        client.resource(Crds.kafka()).serverSideApply();
         kafkaContainer = deployments.getKafkaContainer();
         bootstrapServers = URI.create(kafkaContainer.getBootstrapServers());
         randomBootstrapServers = URI.create(consoleConfig.getKafka()
@@ -128,43 +128,40 @@ class KafkaClustersResourceIT {
 
         utils = new TestHelper(bootstrapServers, config, null);
 
-        clusterId1 = utils.getClusterId();
-        clusterId2 = UUID.randomUUID().toString();
-
         client.resources(Kafka.class).inAnyNamespace().delete();
-        client.resources(Kafka.class)
-            .resource(new KafkaBuilder(utils.buildKafkaResource("test-kafka1", clusterId1, bootstrapServers,
+
+        utils.apply(client, new KafkaBuilder(utils.buildKafkaResource("test-kafka1", utils.getClusterId(), bootstrapServers,
                         new KafkaListenerAuthenticationCustomBuilder()
-                            .withSasl()
-                            .addToListenerConfig("sasl.enabled.mechanisms", "oauthbearer")
-                            .build()))
-                .editOrNewStatus()
-                    .addNewCondition()
-                        .withType("Ready")
-                        .withStatus("True")
-                    .endCondition()
-                    .addNewKafkaNodePool()
-                        .withName("my-node-pool")
-                    .endKafkaNodePool()
-                .endStatus()
-                .build())
-            .create();
+                        .withSasl()
+                        .addToListenerConfig("sasl.enabled.mechanisms", "oauthbearer")
+                        .build()))
+            .editOrNewStatus()
+                .addNewCondition()
+                    .withType("Ready")
+                    .withStatus("True")
+                .endCondition()
+                .addNewKafkaNodePool()
+                    .withName("my-node-pool")
+                .endKafkaNodePool()
+            .endStatus()
+            .build());
+
         // Second cluster is offline/non-existent
-        client.resources(Kafka.class)
-            .resource(new KafkaBuilder(utils.buildKafkaResource("test-kafka2", clusterId2, randomBootstrapServers))
-                    .editOrNewStatus()
-                        .addNewCondition()
-                            .withType("NotReady")
-                            .withStatus("True")
-                        .endCondition()
-                    .endStatus()
-                    .build())
-            .create();
+        utils.apply(client, new KafkaBuilder(utils.buildKafkaResource("test-kafka2", UUID.randomUUID().toString(), randomBootstrapServers))
+            .editOrNewStatus()
+                .addNewCondition()
+                    .withType("NotReady")
+                    .withStatus("True")
+                .endCondition()
+            .endStatus()
+            .build());
 
         // Wait for the informer cache to be populated with all Kafka CRs
         await().atMost(10, TimeUnit.SECONDS)
-            .until(() -> Objects.equals(kafkaInformer.getStore().list().size(), 2));
+            .until(() -> Objects.equals(kafkaInformer.get().getStore().list().size(), 2));
 
+        clusterId1 = consoleConfig.getKafka().getCluster("default/test-kafka1").get().getId();
+        clusterId2 = consoleConfig.getKafka().getCluster("default/test-kafka2").get().getId();
         kafkaClusterService.setListUnconfigured(false);
     }
 
@@ -183,7 +180,7 @@ class KafkaClustersResourceIT {
         String k1Bootstrap = bootstrapServers.getHost() + ":" + bootstrapServers.getPort();
         String k2Bootstrap = randomBootstrapServers.getHost() + ":" + randomBootstrapServers.getPort();
 
-        whenRequesting(req -> req.get())
+        whenRequesting(req -> req.queryParam("fields[kafkas]", "name,status,nodePools,listeners").get())
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", equalTo(2))
@@ -204,7 +201,7 @@ class KafkaClustersResourceIT {
     void testListClustersWithInformerError() {
         SharedIndexInformer<Kafka> informer = Mockito.mock();
 
-        var informerType = new TypeLiteral<SharedIndexInformer<Kafka>>() {
+        var informerType = new TypeLiteral<Holder<SharedIndexInformer<Kafka>>>() {
             private static final long serialVersionUID = 1L;
         };
 
@@ -228,9 +225,9 @@ class KafkaClustersResourceIT {
             }
         });
 
-        QuarkusMock.installMockForType(informer, informerType, new NamedLiteral());
+        QuarkusMock.installMockForType(Holder.of(informer), informerType, new NamedLiteral());
 
-        whenRequesting(req -> req.get("{clusterId}", UUID.randomUUID().toString()))
+        whenRequesting(req -> req.get())
             .assertThat()
             .statusCode(is(Status.INTERNAL_SERVER_ERROR.getStatusCode()))
             .body("errors.size()", is(1))
@@ -270,13 +267,13 @@ class KafkaClustersResourceIT {
                 IntStream.range(3, 10)
                     .mapToObj(i -> "test-kafka" + i)
                     .map(name -> utils.buildKafkaResource(name, randomBootstrapServers))
-                    .map(kafka -> client.resources(Kafka.class).resource(kafka).create())
+                    .map(kafka -> utils.apply(client, kafka))
                     .map(kafka -> kafka.getMetadata().getName()))
             .toList();
 
         // Wait for the informer cache to be populated with all Kafka CRs
         await().atMost(10, TimeUnit.SECONDS)
-            .until(() -> Objects.equals(kafkaInformer.getStore().list().size(), allKafkaNames.size()));
+            .until(() -> Objects.equals(kafkaInformer.get().getStore().list().size(), allKafkaNames.size()));
 
         var fullResponse = whenRequesting(req -> req.queryParam("sort", "name").get())
             .assertThat()
@@ -327,13 +324,13 @@ class KafkaClustersResourceIT {
                 IntStream.range(3, 10)
                     .mapToObj(i -> "test-kafka" + i)
                     .map(name -> utils.buildKafkaResource(name, randomBootstrapServers))
-                    .map(kafka -> client.resources(Kafka.class).resource(kafka).create())
+                    .map(kafka -> utils.apply(client, kafka))
                     .map(kafka -> kafka.getMetadata().getName()))
             .toList();
 
         // Wait for the informer cache to be populated with all Kafka CRs
         await().atMost(10, TimeUnit.SECONDS)
-            .until(() -> Objects.equals(kafkaInformer.getStore().list().size(), allKafkaNames.size()));
+            .until(() -> Objects.equals(kafkaInformer.get().getStore().list().size(), allKafkaNames.size()));
 
         var fullResponse = whenRequesting(req -> req.queryParam("sort", "name").get())
             .assertThat()
@@ -510,7 +507,7 @@ class KafkaClustersResourceIT {
 
         // Wait for the informer cache to be populated with all Kafka CRs
         await().atMost(10, TimeUnit.SECONDS)
-            .until(() -> Objects.equals(kafkaInformer.getStore().list().size(), 3));
+            .until(() -> Objects.equals(kafkaInformer.get().getStore().list().size(), 3));
 
         whenRequesting(req -> req.get())
             .assertThat()
@@ -563,10 +560,10 @@ class KafkaClustersResourceIT {
 
         Map<String, Object> clientConfig = mockAdminClient();
 
-        client.resources(Kafka.class).resource(kafka).create();
+        utils.apply(client, kafka);
 
         await().atMost(Duration.ofSeconds(5))
-            .until(() -> configuredAdmins.containsKey(Cache.metaNamespaceKeyFunc(kafka)));
+            .until(() -> configuredContexts.containsKey(clusterId));
 
         whenRequesting(req -> req.get("{clusterId}", clusterId))
             .assertThat()
@@ -594,7 +591,7 @@ class KafkaClustersResourceIT {
         client.resources(Kafka.class).resource(kafka).create();
 
         await().atMost(Duration.ofSeconds(5))
-            .until(() -> kafkaInformer
+            .until(() -> kafkaInformer.get()
                     .getStore()
                     .list()
                     .stream()

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceNoK8sIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceNoK8sIT.java
@@ -1,0 +1,91 @@
+package com.github.streamshub.console.api;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.streamshub.console.api.service.KafkaClusterService;
+import com.github.streamshub.console.api.support.KafkaContext;
+import com.github.streamshub.console.config.ConsoleConfig;
+import com.github.streamshub.console.kafka.systemtest.TestPlainNoK8sProfile;
+import com.github.streamshub.console.kafka.systemtest.deployment.DeploymentManager;
+import com.github.streamshub.console.test.TestHelper;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.strimzi.test.container.StrimziKafkaContainer;
+
+import static com.github.streamshub.console.test.TestHelper.whenRequesting;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+@TestHTTPEndpoint(KafkaClustersResource.class)
+@TestProfile(TestPlainNoK8sProfile.class)
+class KafkaClustersResourceNoK8sIT {
+
+    @Inject
+    Config config;
+
+    @Inject
+    Map<String, KafkaContext> configuredContexts;
+
+    @Inject
+    KafkaClusterService kafkaClusterService;
+
+    @Inject
+    ConsoleConfig consoleConfig;
+
+    @DeploymentManager.InjectDeploymentManager
+    DeploymentManager deployments;
+
+    TestHelper utils;
+
+    StrimziKafkaContainer kafkaContainer;
+    String clusterId1;
+    String clusterId2;
+    URI bootstrapServers;
+    URI randomBootstrapServers;
+
+    @BeforeEach
+    void setup() throws IOException {
+        kafkaContainer = deployments.getKafkaContainer();
+        bootstrapServers = URI.create(kafkaContainer.getBootstrapServers());
+        randomBootstrapServers = URI.create(consoleConfig.getKafka()
+                .getCluster("default/test-kafka2")
+                .map(k -> k.getProperties().get("bootstrap.servers"))
+                .orElseThrow());
+
+        utils = new TestHelper(bootstrapServers, config, null);
+
+        clusterId1 = consoleConfig.getKafka().getCluster("default/test-kafka1").get().getId();
+        clusterId2 = consoleConfig.getKafka().getCluster("default/test-kafka2").get().getId();
+        kafkaClusterService.setListUnconfigured(false);
+    }
+
+    @Test
+    void testListClusters() {
+        whenRequesting(req -> req.queryParam("fields[kafkas]", "name,status,nodePools,listeners").get())
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("data.size()", equalTo(2))
+            .body("data.id", containsInAnyOrder(clusterId1, clusterId2))
+            .body("data.attributes.name", containsInAnyOrder("test-kafka1", "test-kafka2"))
+            .body("data.find { it.attributes.name == 'test-kafka1'}.attributes.status", is(nullValue()))
+            .body("data.find { it.attributes.name == 'test-kafka1'}.attributes.nodePools", is(nullValue()))
+            .body("data.find { it.attributes.name == 'test-kafka1'}.attributes.listeners", is(nullValue()))
+            .body("data.find { it.attributes.name == 'test-kafka2'}.attributes.status", is(nullValue()))
+            .body("data.find { it.attributes.name == 'test-kafka2'}.attributes.listeners", is(nullValue()));
+    }
+
+}

--- a/api/src/test/java/com/github/streamshub/console/api/RecordsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/RecordsResourceIT.java
@@ -43,11 +43,10 @@ import com.github.streamshub.console.test.TestHelper;
 import com.github.streamshub.console.test.TopicHelper;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 
 import static com.github.streamshub.console.test.TestHelper.whenRequesting;
@@ -63,7 +62,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@QuarkusTestResource(KubernetesServerTestResource.class)
 @TestHTTPEndpoint(RecordsResource.class)
 @TestProfile(TestPlainProfile.class)
 class RecordsResourceIT {
@@ -88,6 +86,7 @@ class RecordsResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
+        client.resource(Crds.kafka()).serverSideApply();
         URI bootstrapServers = URI.create(deployments.getExternalBootstrapServers());
         URI randomBootstrapServers = URI.create(consoleConfig.getKafka()
                 .getCluster("default/test-kafka2")
@@ -100,17 +99,14 @@ class RecordsResourceIT {
         utils = new TestHelper(bootstrapServers, config, null);
         recordUtils = new RecordHelper(bootstrapServers, config, null);
 
-        clusterId1 = utils.getClusterId();
-        clusterId2 = UUID.randomUUID().toString();
-
         client.resources(Kafka.class).inAnyNamespace().delete();
-        client.resources(Kafka.class)
-            .resource(utils.buildKafkaResource("test-kafka1", clusterId1, bootstrapServers))
-            .create();
+
+        utils.apply(client, utils.buildKafkaResource("test-kafka1", utils.getClusterId(), bootstrapServers));
         // Second cluster is offline/non-existent
-        client.resources(Kafka.class)
-            .resource(utils.buildKafkaResource("test-kafka2", clusterId2, randomBootstrapServers))
-            .create();
+        utils.apply(client, utils.buildKafkaResource("test-kafka2", UUID.randomUUID().toString(), randomBootstrapServers));
+
+        clusterId1 = consoleConfig.getKafka().getCluster("default/test-kafka1").get().getId();
+        clusterId2 = consoleConfig.getKafka().getCluster("default/test-kafka2").get().getId();
     }
 
     @Test

--- a/api/src/test/java/com/github/streamshub/console/api/RecordsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/RecordsResourceIT.java
@@ -46,7 +46,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 
 import static com.github.streamshub.console.test.TestHelper.whenRequesting;
@@ -86,7 +85,6 @@ class RecordsResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
-        client.resource(Crds.kafka()).serverSideApply();
         URI bootstrapServers = URI.create(deployments.getExternalBootstrapServers());
         URI randomBootstrapServers = URI.create(consoleConfig.getKafka()
                 .getCluster("default/test-kafka2")

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -79,7 +79,6 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.api.kafka.model.topic.KafkaTopicBuilder;
@@ -144,8 +143,6 @@ class TopicsResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
-        client.resource(Crds.kafka()).serverSideApply();
-        client.resource(Crds.kafkaTopic()).serverSideApply();
         bootstrapServers1 = URI.create(deployments.getExternalBootstrapServers());
         URI randomBootstrapServers = URI.create(consoleConfig.getKafka()
                 .getCluster("default/test-kafka2")

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -64,6 +64,7 @@ import org.mockito.stubbing.Answer;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.deployment.DeploymentManager;
@@ -75,11 +76,10 @@ import com.github.streamshub.console.test.TopicHelper;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.api.kafka.model.topic.KafkaTopicBuilder;
@@ -111,7 +111,6 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 
 @QuarkusTest
-@QuarkusTestResource(KubernetesServerTestResource.class)
 @TestHTTPEndpoint(TopicsResource.class)
 @TestProfile(TestPlainProfile.class)
 class TopicsResourceIT {
@@ -126,7 +125,7 @@ class TopicsResourceIT {
     KubernetesClient client;
 
     @Inject
-    SharedIndexInformer<Kafka> kafkaInformer;
+    Holder<SharedIndexInformer<Kafka>> kafkaInformer;
 
     @Inject
     @Named("KafkaTopics")
@@ -145,6 +144,8 @@ class TopicsResourceIT {
 
     @BeforeEach
     void setup() throws IOException {
+        client.resource(Crds.kafka()).serverSideApply();
+        client.resource(Crds.kafkaTopic()).serverSideApply();
         bootstrapServers1 = URI.create(deployments.getExternalBootstrapServers());
         URI randomBootstrapServers = URI.create(consoleConfig.getKafka()
                 .getCluster("default/test-kafka2")
@@ -158,23 +159,19 @@ class TopicsResourceIT {
 
         utils = new TestHelper(bootstrapServers1, config, null);
 
-        clusterId1 = utils.getClusterId();
-        clusterId2 = UUID.randomUUID().toString();
-
         client.resources(Kafka.class).inAnyNamespace().delete();
         client.resources(KafkaTopic.class).inAnyNamespace().delete();
 
-        client.resources(Kafka.class)
-            .resource(utils.buildKafkaResource(clusterName1, clusterId1, bootstrapServers1))
-            .create();
+        utils.apply(client, utils.buildKafkaResource(clusterName1, utils.getClusterId(), bootstrapServers1));
         // Second cluster is offline/non-existent
-        client.resources(Kafka.class)
-            .resource(utils.buildKafkaResource("test-kafka2", clusterId2, randomBootstrapServers))
-            .create();
+        utils.apply(client, utils.buildKafkaResource("test-kafka2", UUID.randomUUID().toString(), randomBootstrapServers));
 
         // Wait for the informer cache to be populated with all Kafka CRs
         await().atMost(10, TimeUnit.SECONDS)
-            .until(() -> Objects.equals(kafkaInformer.getStore().list().size(), 2));
+            .until(() -> Objects.equals(kafkaInformer.get().getStore().list().size(), 2));
+
+        clusterId1 = consoleConfig.getKafka().getCluster("default/test-kafka1").get().getId();
+        clusterId2 = consoleConfig.getKafka().getCluster("default/test-kafka2").get().getId();
     }
 
     @Test

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainNoK8sProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainNoK8sProfile.java
@@ -1,0 +1,46 @@
+package com.github.streamshub.console.kafka.systemtest;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.List;
+import java.util.Map;
+
+import com.github.streamshub.console.kafka.systemtest.deployment.KafkaUnsecuredResourceManager;
+
+/**
+ * Same as profile {@linkplain TestPlainProfile}, but disables Kubernetes use by setting
+ * properties {@code kuberentes.enabled=false} in the application's configuration YAML and
+ * {@code quarkus.kubernetes-client.devservices.enabled=false} to disable the testing/mock
+ * Kubernetes API server.
+ */
+public class TestPlainNoK8sProfile extends TestPlainProfile implements QuarkusTestProfile {
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return List.of(new TestResourceEntry(KafkaUnsecuredResourceManager.class, Map.of("profile", PROFILE)));
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        var configFile = writeConfiguration("""
+                kubernetes:
+                  enabled: false
+                kafka:
+                  clusters:
+                    - name: test-kafka1
+                      namespace: default
+                      id: k1-id
+                      properties:
+                        bootstrap.servers: ${console.test.external-bootstrap}
+                    - name: test-kafka2
+                      namespace: default
+                      id: k2-id
+                      properties:
+                        bootstrap.servers: ${console.test.random-bootstrap}
+                """);
+
+        return Map.of(
+                "quarkus.kubernetes-client.devservices.enabled", "false",
+                "console.config-path", configFile.getAbsolutePath());
+    }
+}

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.streamshub.console.kafka.systemtest.deployment.KafkaUnsecuredResourceManager;
+import com.github.streamshub.console.kafka.systemtest.deployment.StrimziCrdResourceManager;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
 
@@ -26,7 +27,7 @@ public class TestPlainProfile implements QuarkusTestProfile {
     @Override
     public List<TestResourceEntry> testResources() {
         return List.of(
-                //new TestResourceEntry(KubernetesServerTestResource.class),
+                new TestResourceEntry(StrimziCrdResourceManager.class),
                 new TestResourceEntry(KafkaUnsecuredResourceManager.class, Map.of("profile", PROFILE)));
     }
 

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
@@ -1,11 +1,16 @@
 package com.github.streamshub.console.kafka.systemtest;
 
-import io.quarkus.test.junit.QuarkusTestProfile;
-
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Map;
 
 import com.github.streamshub.console.kafka.systemtest.deployment.KafkaUnsecuredResourceManager;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
 
 public class TestPlainProfile implements QuarkusTestProfile {
 
@@ -20,7 +25,51 @@ public class TestPlainProfile implements QuarkusTestProfile {
 
     @Override
     public List<TestResourceEntry> testResources() {
-        return List.of(new TestResourceEntry(KafkaUnsecuredResourceManager.class, Map.of("profile", PROFILE)));
+        return List.of(
+                //new TestResourceEntry(KubernetesServerTestResource.class),
+                new TestResourceEntry(KafkaUnsecuredResourceManager.class, Map.of("profile", PROFILE)));
     }
 
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        var configFile = writeConfiguration("""
+                kubernetes:
+                  enabled: true
+                kafka:
+                  clusters:
+                    - name: test-kafka1
+                      namespace: default
+                      id: k1-id
+                      properties:
+                        bootstrap.servers: ${console.test.external-bootstrap}
+                    - name: test-kafka2
+                      namespace: default
+                      id: k2-id
+                      properties:
+                        bootstrap.servers: ${console.test.random-bootstrap}
+                    - name: test-kafka3
+                      namespace: default
+                      # listener is named and bootstrap.servers not set (will be retrieved from Kafka CR)
+                      listener: listener0
+                      properties:
+                        security.protocol: SSL
+                """);
+
+        return Map.of("console.config-path", configFile.getAbsolutePath());
+    }
+
+    protected File writeConfiguration(String configurationYaml) {
+        File configFile;
+
+        try {
+            configFile = File.createTempFile("console-test-config-", ".yaml");
+            configFile.deleteOnExit();
+
+            Files.writeString(configFile.toPath(), configurationYaml, StandardOpenOption.WRITE);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return configFile;
+    }
 }

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/KafkaUnsecuredResourceManager.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/KafkaUnsecuredResourceManager.java
@@ -1,12 +1,9 @@
 package com.github.streamshub.console.kafka.systemtest.deployment;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -16,7 +13,6 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 public class KafkaUnsecuredResourceManager extends KafkaResourceManager implements QuarkusTestResourceLifecycleManager {
 
     ServerSocket randomSocket;
-    File configFile;
 
     @Override
     public Map<String, String> start() {
@@ -33,36 +29,8 @@ public class KafkaUnsecuredResourceManager extends KafkaResourceManager implemen
 
         URI randomBootstrapServers = URI.create("dummy://localhost:" + randomSocket.getLocalPort());
 
-        try {
-            configFile = File.createTempFile("console-test-config-", ".yaml");
-            configFile.deleteOnExit();
-
-            Files.writeString(configFile.toPath(), """
-                    kafka:
-                      clusters:
-                        - name: test-kafka1
-                          namespace: default
-                          properties:
-                            bootstrap.servers: ${console.test.external-bootstrap}
-                        - name: test-kafka2
-                          namespace: default
-                          properties:
-                            bootstrap.servers: ${console.test.random-bootstrap}
-                        - name: test-kafka3
-                          namespace: default
-                          # listener is named and bootstrap.servers not set (will be retrieved from Kafka CR)
-                          listener: listener0
-                          properties:
-                            security.protocol: SSL
-                    """,
-                    StandardOpenOption.WRITE);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
         return Map.ofEntries(
                 Map.entry(profile + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, externalBootstrap),
-                Map.entry(profile + "console.config-path", configFile.getAbsolutePath()),
                 Map.entry(profile + "console.test.external-bootstrap", externalBootstrap),
                 Map.entry(profile + "console.test.random-bootstrap", randomBootstrapServers.toString()));
     }
@@ -78,7 +46,5 @@ public class KafkaUnsecuredResourceManager extends KafkaResourceManager implemen
                 throw new UncheckedIOException(e);
             }
         }
-
-        configFile.delete();
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/StrimziCrdResourceManager.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/StrimziCrdResourceManager.java
@@ -1,0 +1,86 @@
+package com.github.streamshub.console.kafka.systemtest.deployment;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.strimzi.api.kafka.Crds;
+
+/**
+ * This manager creates the Strimzi CRDs needed by the application prior to the test
+ * instance of the application being started. It is provided with the Kubernetes API
+ * connection properties for the Quarkus devservices instance of the K8s API.
+ */
+public class StrimziCrdResourceManager implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+    private static final String PREFIX = "quarkus.kubernetes-client.";
+
+    DevServicesContext context;
+    Map<String, String> devConfig;
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.context = context;
+        devConfig = context.devServicesProperties();
+    }
+
+    Optional<String> get(String key) {
+        return get(key, Function.identity());
+    }
+
+    <T> Optional<T> get(String key, Function<String, T> mapper) {
+        return Optional.ofNullable(devConfig.get(PREFIX + key))
+            .map(mapper);
+    }
+
+    @Override
+    public Map<String, String> start() {
+        Config base = Config.autoConfigure(null);
+
+        var k8s = new KubernetesClientBuilder()
+            .editOrNewConfig()
+                .withTrustCerts(get("trust-certs", Boolean::parseBoolean).orElseGet(base::isTrustCerts))
+                .withWatchReconnectLimit(get("watch-reconnect-limit", Integer::parseInt).orElseGet(base::getWatchReconnectLimit))
+                .withWatchReconnectInterval((int) get("watch-reconnect-interval", Duration::parse)
+                        .orElse(Duration.ofMillis(base.getWatchReconnectInterval())).toMillis())
+                .withConnectionTimeout((int) get("connection-timeout", Duration::parse)
+                        .orElse(Duration.ofMillis(base.getConnectionTimeout())).toMillis())
+                .withRequestTimeout((int) get("request-timeout", Duration::parse)
+                        .orElse(Duration.ofMillis(base.getRequestTimeout())).toMillis())
+                .withMasterUrl(get("api-server-url").or(() -> get("master-url")).orElse(base.getMasterUrl()))
+                .withNamespace(get("namespace").orElseGet(base::getNamespace))
+                .withUsername(get("username").orElse(base.getUsername()))
+                .withPassword(get("password").orElse(base.getPassword()))
+                .withCaCertFile(get("ca-cert-file").orElse(base.getCaCertFile()))
+                .withCaCertData(get("ca-cert-data").orElse(base.getCaCertData()))
+                .withClientCertFile(get("client-cert-file").orElse(base.getClientCertFile()))
+                .withClientCertData(get("client-cert-data").orElse(base.getClientCertData()))
+                .withClientKeyFile(get("client-key-file").orElse(base.getClientKeyFile()))
+                .withClientKeyData(get("client-key-data").orElse(base.getClientKeyData()))
+                .withClientKeyPassphrase(get("client-key-passphrase").orElse(base.getClientKeyPassphrase()))
+                .withClientKeyAlgo(get("client-key-algo").orElse(base.getClientKeyAlgo()))
+                .withHttpProxy(get("http-proxy").orElse(base.getHttpProxy()))
+                .withHttpsProxy(get("https-proxy").orElse(base.getHttpsProxy()))
+                .withProxyUsername(get("proxy-username").orElse(base.getProxyUsername()))
+                .withProxyPassword(get("proxy-password").orElse(base.getProxyPassword()))
+                .withNoProxy(get("no-proxy", s -> s.split(",")).orElse(base.getNoProxy()))
+            .endConfig()
+            .build();
+
+        k8s.resource(Crds.kafka()).serverSideApply();
+        k8s.resource(Crds.kafkaTopic()).serverSideApply();
+
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        // No-op
+    }
+}

--- a/api/src/test/java/com/github/streamshub/console/test/TestHelper.java
+++ b/api/src/test/java/com/github/streamshub/console/test/TestHelper.java
@@ -20,6 +20,8 @@ import org.jboss.logging.Logger;
 import com.github.streamshub.console.api.Annotations;
 import com.github.streamshub.console.kafka.systemtest.utils.ClientsConfig;
 
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
@@ -117,6 +119,11 @@ public class TestHelper {
                 .endListener()
             .endStatus()
             .build();
+    }
+
+    public <S, T, C extends CustomResource<S, T>> C apply(KubernetesClient client, C resource) {
+        client.resource(resource).serverSideApply();
+        return client.resource(resource).patchStatus();
     }
 
     public String getClusterId() {

--- a/api/src/test/resources/junit-platform.properties
+++ b/api/src/test/resources/junit-platform.properties
@@ -1,2 +1,0 @@
-# ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/api/src/test/resources/junit-platform.properties
+++ b/api/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -2,7 +2,16 @@ package com.github.streamshub.console.config;
 
 public class ConsoleConfig {
 
+    KubernetesConfig kubernetes = new KubernetesConfig();
     KafkaConfig kafka = new KafkaConfig();
+
+    public KubernetesConfig getKubernetes() {
+        return kubernetes;
+    }
+
+    public void setKubernetes(KubernetesConfig kubernetes) {
+        this.kubernetes = kubernetes;
+    }
 
     public KafkaConfig getKafka() {
         return kafka;

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class KafkaClusterConfig {
 
+    private String id;
     private String name;
     private String namespace;
     private String listener;
@@ -17,7 +18,18 @@ public class KafkaClusterConfig {
 
     @JsonIgnore
     public String clusterKey() {
+        if (namespace == null || namespace.isBlank()) {
+            return name;
+        }
         return "%s/%s".formatted(namespace, name);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     public String getName() {

--- a/common/src/main/java/com/github/streamshub/console/config/KubernetesConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KubernetesConfig.java
@@ -1,0 +1,14 @@
+package com.github.streamshub.console.config;
+
+public class KubernetesConfig {
+
+    boolean enabled = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/console-config-example.yaml
+++ b/console-config-example.yaml
@@ -1,7 +1,13 @@
 kafka:
+  kubernetes:
+    # enable/disable use of Kubernetes to obtain additional information from Strimzi
+    # Kafka and KafkaTopic custom resources. Enabled by default
+    enabled: true
+
   clusters:
     - name: my-kafka1 # name of the Strimzi Kafka CR
-      namespace: my-namespace1 # namespace of the Strimzi Kafka CR
+      namespace: my-namespace1 # namespace of the Strimzi Kafka CR (optional)
+      id: my-kafka1-id # value to be used as an identifier for the cluster. Must be specified when namespace is not.
       listener: "secure" # name of the listener to use for connections from the console
       # `properties` contains keys/values to use for any Kafka connection
       properties:

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVar.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVar.java
@@ -1,0 +1,34 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConfigVar {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("value")
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVarSource.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVarSource.java
@@ -1,0 +1,51 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.fabric8.generator.annotation.ValidationRule;
+import io.fabric8.kubernetes.api.model.ConfigMapEnvSource;
+import io.fabric8.kubernetes.api.model.SecretEnvSource;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ValidationRule(
+        value = "has(self.configMapRef) || has(self.secretRef)",
+        message = "One of `configMapRef` or `secretRef` is required")
+public class ConfigVarSource {
+
+    @JsonProperty("configMapRef")
+    private ConfigMapEnvSource configMapRef;
+
+    @JsonProperty("prefix")
+    private String prefix;
+
+    @JsonProperty("secretRef")
+    private SecretEnvSource secretRef;
+
+    public ConfigMapEnvSource getConfigMapRef() {
+        return configMapRef;
+    }
+
+    public void setConfigMapRef(ConfigMapEnvSource configMapRef) {
+        this.configMapRef = configMapRef;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public SecretEnvSource getSecretRef() {
+        return secretRef;
+    }
+
+    public void setSecretRef(SecretEnvSource secretRef) {
+        this.secretRef = secretRef;
+    }
+
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVars.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVars.java
@@ -1,0 +1,34 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConfigVars {
+
+    List<ConfigVar> values = new ArrayList<>();
+
+    List<ConfigVarSource> valuesFrom = new ArrayList<>();
+
+    public List<ConfigVar> getValues() {
+        return values;
+    }
+
+    public void setValues(List<ConfigVar> values) {
+        this.values = values;
+    }
+
+    public List<ConfigVarSource> getValuesFrom() {
+        return valuesFrom;
+    }
+
+    public void setValuesFrom(List<ConfigVarSource> valuesFrom) {
+        this.valuesFrom = valuesFrom;
+    }
+
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
@@ -1,23 +1,76 @@
 package com.github.streamshub.console.api.v1alpha1.spec;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.fabric8.generator.annotation.Required;
+import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
 @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@ValidationRule(
+        // The `namespace` property must be wrapped in double underscore to escape it
+        // due to it being a "reserved" word.
+        value = "has(self.id) || has(self.__namespace__)",
+        message = "One of `id` or `namespace` is required")
+@ValidationRule(
+        // The `namespace` property must be wrapped in double underscore to escape it
+        // due to it being a "reserved" word.
+        value = "!has(self.listener) || has(self.__namespace__)",
+        message = "Property `listener` may not be used when `namespace` is omitted")
 public class KafkaCluster {
 
-    @Required
-    String name;
+    @JsonPropertyDescription("""
+            Identifier to be used for this Kafka cluster in the console. When \
+            the console is connected to Kubernetes and a Strimzi Kafka custom \
+            resource may be discovered using the name and namespace properties, \
+            this property is optional. Otherwise, the Kafka cluster identifier \
+            published in the Kafka resource's status will be used. If namespace \
+            is not given or the console or Kubernetes is not in use, this property \
+            is required.
+
+            When provided, this property will override the Kafka cluster id available \
+            in the Kafka resource's status.""")
+    private String id;
 
     @Required
-    String namespace;
+    @JsonPropertyDescription("""
+            The name of the Kafka cluster. When the console is connected to \
+            Kubernetes, a Strimzi Kafka custom resource may be discovered using \
+            this property together with the namespace property. In any case, \
+            this property will be displayed in the console for the Kafka cluster's \
+            name.""")
+    private String name;
 
-    String listener;
+    @JsonPropertyDescription("""
+            The namespace of the Kafka cluster. When the console is connected to \
+            Kubernetes, a Strimzi Kafka custom resource may be discovered using \
+            this property together with the name property.""")
+    private String namespace;
 
-    Credentials credentials;
+    @JsonPropertyDescription("""
+            The name of the listener in the Strimzi Kafka Kubernetes resource that \
+            should be used by the console to establish connections.""")
+    private String listener;
+
+    private Credentials credentials;
+
+    private ConfigVars properties = new ConfigVars();
+
+    private ConfigVars adminProperties = new ConfigVars();
+
+    private ConfigVars consumerProperties = new ConfigVars();
+
+    private ConfigVars producerProperties = new ConfigVars();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;
@@ -51,4 +104,35 @@ public class KafkaCluster {
         this.credentials = credentials;
     }
 
+    public ConfigVars getProperties() {
+        return properties;
+    }
+
+    public void setProperties(ConfigVars properties) {
+        this.properties = properties;
+    }
+
+    public ConfigVars getAdminProperties() {
+        return adminProperties;
+    }
+
+    public void setAdminProperties(ConfigVars adminProperties) {
+        this.adminProperties = adminProperties;
+    }
+
+    public ConfigVars getConsumerProperties() {
+        return consumerProperties;
+    }
+
+    public void setConsumerProperties(ConfigVars consumerProperties) {
+        this.consumerProperties = consumerProperties;
+    }
+
+    public ConfigVars getProducerProperties() {
+        return producerProperties;
+    }
+
+    public void setProducerProperties(ConfigVars producerProperties) {
+        this.producerProperties = producerProperties;
+    }
 }

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/Condition.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/Condition.java
@@ -1,16 +1,9 @@
 package com.github.streamshub.console.api.v1alpha1.status;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
-
-import static java.util.Collections.emptyMap;
 
 @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -21,7 +14,6 @@ public class Condition {
     private String message;
     private String type;
     private String lastTransitionTime;
-    private Map<String, Object> additionalProperties;
 
     @JsonPropertyDescription("The status of the condition, either True, False or Unknown.")
     public String getStatus() {
@@ -68,18 +60,5 @@ public class Condition {
 
     public void setMessage(String message) {
         this.message = message;
-    }
-
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
-    }
-
-    @JsonAnySetter
-    public void setAdditionalProperty(String name, Object value) {
-        if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>(1);
-        }
-        this.additionalProperties.put(name, value);
     }
 }

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleResource.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleResource.java
@@ -26,7 +26,7 @@ public interface ConsoleResource {
     static final String INSTANCE_LABEL = "app.kubernetes.io/instance";
     static final String MANAGER = "streamshub-console-operator";
 
-    static final Map<String, String> MANAGEMENT_LABEL = Map.of(MANAGED_BY_LABEL, MANAGER);
+    public static final Map<String, String> MANAGEMENT_LABEL = Map.of(MANAGED_BY_LABEL, MANAGER);
     static final String MANAGEMENT_SELECTOR = MANAGED_BY_LABEL + '=' + MANAGER;
     static final HexFormat DIGEST_FORMAT = HexFormat.of();
     static final String DEFAULT_DIGEST = "0".repeat(40);

--- a/operator/src/test/example-console.yaml
+++ b/operator/src/test/example-console.yaml
@@ -2,11 +2,18 @@ apiVersion: console.streamshub.github.com/v1alpha1
 kind: Console
 metadata:
   name: example
-  namespace: streams-console
 spec:
   hostname: example-console.apps-crc.testing
   kafkaClusters:
-    - kafkaUserName: console-kafka-user1
+    - id: my-console
+      credentials:
+        kafkaUser:
+          name: console-kafka-user1
+          #namespace: same as kafkaCluster
       listener: secure
       name: console-kafka
       namespace: streams-console
+      properties:
+        values:
+          - name: x-some-test-property
+            value: the-value

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>streamshub</sonar.organization>
         <sonar.exclusions>api/src/main/java/com/github/streamshub/console/api/support/TrustAllCertificateManager.java</sonar.exclusions>
+        <!-- Ignore duplicates in configuration model classes -->
+        <sonar.cpd.exclusions>
+            common/src/main/java/com/github/streamshub/console/config/*.java,
+            operator/src/main/java/com/github/streamshub/console/api/v1alpha1/**/*.java
+        </sonar.cpd.exclusions>
         <sonar.issue.ignore.multicriteria>e1,e2</sonar.issue.ignore.multicriteria>
         <!-- Ignore rule java:S6813 about avoidance of field injection -->
         <sonar.issue.ignore.multicriteria.e1.ruleKey>java:S6813</sonar.issue.ignore.multicriteria.e1.ruleKey>

--- a/ui/api/kafka/actions.ts
+++ b/ui/api/kafka/actions.ts
@@ -76,7 +76,7 @@ export async function getKafkaClusterKpis(
 ): Promise<{ cluster: ClusterDetail; kpis: ClusterKpis | null } | null> {
   try {
     const cluster = await getKafkaCluster(clusterId);
-    if (!cluster) {
+    if (!cluster?.attributes?.namespace) {
       return null;
     }
 
@@ -238,7 +238,7 @@ export async function getKafkaClusterMetrics(
 
   try {
     const cluster = await getKafkaCluster(clusterId);
-    if (!cluster || !prom) {
+    if (!cluster?.attributes?.namespace || !prom) {
       return null;
     }
 
@@ -246,7 +246,7 @@ export async function getKafkaClusterMetrics(
       await Promise.all(
         metrics.map((m) =>
           getRangeByNodeId(
-            cluster.attributes.namespace,
+            cluster.attributes.namespace!,
             cluster.attributes.name,
             cluster.attributes.nodePools?.join("|") ?? "",
             m,
@@ -303,7 +303,7 @@ export async function getKafkaTopicMetrics(
 
   try {
     const cluster = await getKafkaCluster(clusterId);
-    if (!cluster || !prom) {
+    if (!cluster?.attributes?.namespace || !prom) {
       return null;
     }
 
@@ -311,7 +311,7 @@ export async function getKafkaTopicMetrics(
       await Promise.all(
         metrics.map((m) =>
           getRangeByNodeId(
-            cluster.attributes.namespace,
+            cluster.attributes.namespace!,
             cluster.attributes.name,
             cluster.attributes.nodePools?.join("|") ?? "",
             m,

--- a/ui/api/kafka/schema.ts
+++ b/ui/api/kafka/schema.ts
@@ -15,8 +15,8 @@ export const ClusterListSchema = z.object({
   }),
   attributes: z.object({
     name: z.string(),
-    namespace: z.string(),
-    kafkaVersion: z.string().optional(),
+    namespace: z.string().nullable().optional(),
+    kafkaVersion: z.string().nullable().optional(),
   }),
 });
 export const ClustersResponseSchema = z.object({
@@ -28,10 +28,10 @@ const ClusterDetailSchema = z.object({
   type: z.literal("kafkas"),
   attributes: z.object({
     name: z.string(),
-    namespace: z.string(),
-    creationTimestamp: z.string(),
-    status: z.string(),
-    kafkaVersion: z.string().optional(),
+    namespace: z.string().nullable().optional(),
+    creationTimestamp: z.string().nullable().optional(),
+    status: z.string().nullable().optional(),
+    kafkaVersion: z.string().nullable().optional(),
     nodes: z.array(NodeSchema),
     controller: NodeSchema,
     authorizedOperations: z.array(z.string()),
@@ -41,7 +41,7 @@ const ClusterDetailSchema = z.object({
         bootstrapServers: z.string().nullable(),
         authType: z.string().nullable(),
       }),
-    ),
+    ).nullable().optional(),
     conditions: z.array(
       z.object({
         type: z.string().optional(),
@@ -50,7 +50,7 @@ const ClusterDetailSchema = z.object({
         message: z.string().optional(),
         lastTransitionTime: z.string().optional(),
       }),
-    ),
+    ).nullable().optional(),
     nodePools: z.array(z.string()).optional().nullable(),
   }),
 });

--- a/ui/app/[locale]/home/ClustersTable.tsx
+++ b/ui/app/[locale]/home/ClustersTable.tsx
@@ -91,9 +91,9 @@ export function ClustersTable({
               <i>{t("ClustersTable.connection_not_configured")}</i>
             );
           case "version":
-            return <Td key={key}>{row.attributes.kafkaVersion ?? "n/a"}</Td>;
+            return <Td key={key}>{row.attributes.kafkaVersion ?? "Not Available"}</Td>;
           case "namespace":
-            return <Td key={key}>{row.attributes.namespace}</Td>;
+            return <Td key={key}>{row.attributes.namespace ?? "N/A"}</Td>;
         }
       }}
       renderActions={({ ActionsColumn, row }) => (


### PR DESCRIPTION
- Enable Kafka connections to be configured without a corresponding Kubernetes resource
- Allow console to run without Kubernetes connectivity
- Update operator's Console API to support arbitrary Kafka connection properties and a cluster ID to use instead of the Kafka cluster ID provided in the Strimzi Kafka CR (originates from Kafka itself).
- Update integration tests to use the Quarkus devservices extension for Kubernetes.