### PR TITLE
fix: resolve container-image label and Strimzi API index warnings

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -378,6 +378,7 @@
         <profile>
             <id>container-image</id>
             <properties>
+                <quarkus.profile>build</quarkus.profile>
                 <quarkus.docker.dockerfile-jvm-path>src/main/docker/Dockerfile</quarkus.docker.dockerfile-jvm-path>
                 <quarkus.container-image.build>true</quarkus.container-image.build>
                 <quarkus.container-image.registry>${docker.registry}</quarkus.container-image.registry>

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -41,8 +41,8 @@ quarkus.swagger-ui.title=Console API
 
 quarkus.log.category."org.apache.kafka".level=ERROR
 
-quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
-quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}
+%build.quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
+%build.quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}
 
 #
 # A Quarkus optimization may remove a CDI bean that is not directly used.
@@ -53,6 +53,9 @@ quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revisio
 # this configuration will prevent the removal of those classes and make them
 # eligible for access from a CDI `Instance`.
 quarkus.arc.unremovable-types=com.github.streamshub.console.api.**
+
+quarkus.index-dependency.strimzi-api.group-id=io.strimzi
+quarkus.index-dependency.strimzi-api.artifact-id=api
 
 console.kafka.admin.request.timeout.ms=10000
 console.kafka.admin.default.api.timeout.ms=10000

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -196,6 +196,7 @@
         <profile>
             <id>container-image</id>
             <properties>
+                <quarkus.profile>build</quarkus.profile>
                 <quarkus.docker.dockerfile-jvm-path>src/main/docker/Dockerfile</quarkus.docker.dockerfile-jvm-path>
                 <quarkus.container-image.build>true</quarkus.container-image.build>
                 <quarkus.container-image.registry>${container-image.registry}</quarkus.container-image.registry>

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -7,6 +7,9 @@ quarkus.container-image.name=console-operator
 quarkus.operator-sdk.activate-leader-election-for-profiles=prod
 quarkus.operator-sdk.controllers."consolereconciler".selector=${console.selector}
 
+%build.quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
+%build.quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}
+
 # set to true to automatically apply CRDs to the cluster when they get regenerated
 %dev.quarkus.operator-sdk.crd.apply=true
 %test.quarkus.operator-sdk.crd.apply=true


### PR DESCRIPTION
Resolve errors in the API logs about unknown `quarkus.container-image.labels.*` properties. These properties apply at build time only, so this PR uses a `build` profile to apply them only at that time. Additionally, this resolves a warning about the Strimzi API classes not being present in the Jandex index.

Warning for unknown runtime properties:
```
2024-07-18 14:53:42,089 WARN  [io.qua.config] (Quarkus Main Thread) Unrecognized configuration key "quarkus.container-image.labels."org.opencontainers.image.revision"" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2024-07-18 14:53:42,089 WARN  [io.qua.config] (Quarkus Main Thread) Unrecognized configuration key "quarkus.container-image.labels."org.opencontainers.image.version"" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```

Warning for unindexed classes:
```
2024-07-18 15:05:09,473 WARN  [io.qua.kub.cli.dep.KubernetesClientProcessor] (build-30) Unable to lookup class: io.strimzi.api.kafka.model.topic.KafkaTopic
2024-07-18 15:05:09,473 WARN  [io.qua.kub.cli.dep.KubernetesClientProcessor] (build-30) Unable to lookup class: io.strimzi.api.kafka.model.kafka.Kafka
```