### PR TITLE
[Operator] Add Console Instance Description

### DIFF
--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/Console.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/Console.java
@@ -9,12 +9,17 @@ import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
+import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.sundr.builder.annotations.Buildable;
 
 @Version("v1alpha1")
 @Group("console.streamshub.github.com")
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@CSVMetadata(
+    displayName = "Console Instance",
+    description = "Represents a deployable Console UI for monitoring Kafka resources."
+    )
 public class Console extends CustomResource<ConsoleSpec, ConsoleStatus> implements Namespaced {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
This PR adds CSV metadata to Console Instance card displayed in openshift UI, which currently has "Not available" description.

Signed-off-by: jkalinic <jkalinic@redhat.com>