### PR TITLE
Use date/time format required by OperatorHub for createdAt

### DIFF
--- a/operator/bin/modify-bundle-metadata.sh
+++ b/operator/bin/modify-bundle-metadata.sh
@@ -38,7 +38,7 @@ echo "[DEBUG] Setting container image = ${image_with_digest}"
 ${YQ} eval -o yaml -i ".metadata.annotations.containerImage = \"${image_with_digest}\"" "${CSV_FILE_PATH}"
 
 # Add current createdAt time
-curr_time_date=$(date +'%Y-%m-%d %H:%M:%S')
+curr_time_date="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 echo "[DEBUG] Setting createdAt = ${curr_time_date}"
 ${YQ} eval -o yaml -i ".metadata.annotations.createdAt = \"${curr_time_date}\"" "${CSV_FILE_PATH}"
 


### PR DESCRIPTION
Explicitly use UTC time with `Z` zone indicator and `T` date/time delimiter.

https://k8s-operatorhub.github.io/community-operators/packaging-required-fields/