### PR TITLE
[CI] Increase playwright retries, remove waits for `networkidle` state

### DIFF
--- a/ui/tests/playwright/BrokerPropertyPage.test.tsx
+++ b/ui/tests/playwright/BrokerPropertyPage.test.tsx
@@ -10,7 +10,6 @@ test("Brokers property page", async ({page}) => {
     await page.waitForSelector('text="Clear all filters"',{ timeout: 500000 });
   })
   await test.step("Brokers page should display properties", async () => {
-    await page.waitForLoadState("networkidle");
     const dataRows = await page.locator('table[aria-label="Node configuration"] tbody tr').count();
     expect(dataRows).toBeGreaterThan(0);
     const dataCells = await page.locator('table[aria-label="Node configuration"] tbody tr td').evaluateAll((tds) =>

--- a/ui/tests/playwright/BrokersPage.test.tsx
+++ b/ui/tests/playwright/BrokersPage.test.tsx
@@ -8,7 +8,6 @@ test("Brokers page", async ({page}) => {
     await page.waitForSelector('text="Rack"', { timeout: 500000 });
   })
   await test.step("Brokers page should display table", async () => {
-    await page.waitForLoadState("networkidle");
     expect(await page.innerText("body")).toContain("Brokers");
     expect(await page.innerText("body")).toContain(
       "Partitions distribution (% of total)",

--- a/ui/tests/playwright/ConsumerGroupsPage.test.tsx
+++ b/ui/tests/playwright/ConsumerGroupsPage.test.tsx
@@ -10,7 +10,9 @@ test("Consumer groups page", async ({ page }) => {
     });
   });
   await test.step("Consumer groups page should display table", async () => {
-    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(() => {
+        return document.querySelectorAll('table[aria-label="Consumer groups"] tbody tr').length > 0;
+    });
     expect(await page.innerText("body")).toContain("Consumer group name");
     expect(await page.innerText("body")).toContain("State");
     expect(await page.innerText("body")).toContain("Overall lag");

--- a/ui/tests/playwright/ConsumerPage.test.tsx
+++ b/ui/tests/playwright/ConsumerPage.test.tsx
@@ -9,7 +9,6 @@ test("Consumer  page", async ({page}) => {
     await page.waitForSelector('text="Member ID"', { timeout: 500000 });
   })
   await test.step("Consumer  page should display table", async () => {
-    await page.waitForLoadState("networkidle");
     expect(await page.innerText("body")).toContain("Member ID");
     expect(await page.innerText("body")).toContain("Overall lag");
     expect(await page.innerText("body")).toContain("Assigned partitions");

--- a/ui/tests/playwright/MessagesPage.test.tsx
+++ b/ui/tests/playwright/MessagesPage.test.tsx
@@ -10,7 +10,6 @@ test("Messages page", async ({page}) => {
     await expect(page.getByText("Last updated").or(page.getByText("No messages data"))).toBeVisible();
   })
   await test.step("Messages page should display table", async () => {
-    await page.waitForLoadState("networkidle");
     if (await page.getByText("No messages data").isVisible()) {
       expect(await page.innerText("body")).toContain("Data will appear shortly after we receive produced messages.");
       return;

--- a/ui/tests/playwright/PartitionsPage.test.tsx
+++ b/ui/tests/playwright/PartitionsPage.test.tsx
@@ -13,7 +13,6 @@ test("Partitions page", async ({page}) => {
 
   })
   await test.step("Partitions page should display table", async () => {
-    await page.waitForLoadState("networkidle");
     expect(await page.innerText("body")).toContain("Partition ID");
     expect(await page.innerText("body")).toContain("Status");
     expect(await page.innerText("body")).toContain("Replicas");

--- a/ui/tests/playwright/TopicConsumers.test.tsx
+++ b/ui/tests/playwright/TopicConsumers.test.tsx
@@ -12,7 +12,6 @@ test("Topics consumers", async ({page}) => {
     await expect(page.getByText("Consumer group name").or(page.getByText("No consumer groups"))).toBeVisible();
   })
   await test.step("Topics consumers page should display table", async () => {
-    await page.waitForLoadState("networkidle");
     expect(await page.innerText("body")).toContain("Consumer group name");
     expect(await page.innerText("body")).toContain("Overall lag");
     expect(await page.innerText("body")).toContain("State");

--- a/ui/tests/playwright/playwright.config.ts
+++ b/ui/tests/playwright/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "playwright/test";
 
 export default defineConfig({
   // Retry on CI only.
-  retries: process.env.CI_CLUSTER ? 2 : 0,
+  retries: process.env.CI_CLUSTER ? 5 : 0,
 
   // Opt out of parallel tests on CI.
   workers: process.env.CI_CLUSTER ? 1 : undefined,


### PR DESCRIPTION
This increases the number of retries to deal with flaky tests. All tests pass for me locally, but started failing in GH actions recently. It also removes the waiting for state `networkidle`, which is discouraged [1] and seems to break the tests anyway.

[1] https://playwright.dev/docs/api/class-page#page-wait-for-load-state