### PR TITLE
Use a common, fixed value for storybook date values

### DIFF
--- a/ui/components/Format/DateTime.stories.tsx
+++ b/ui/components/Format/DateTime.stories.tsx
@@ -5,7 +5,7 @@ import { DateTime } from "./DateTime";
 const meta: Meta<typeof DateTime> = {
   component: DateTime,
   args: {
-    value: new Date(1709561281).toISOString(),
+    value: new Date(Date.UTC(2024, 11, 31, 23, 59, 59, 999)).toISOString(),
     tz: "local",
     empty: "-",
   },

--- a/ui/components/MessagesTable/MessagesTable.stories.tsx
+++ b/ui/components/MessagesTable/MessagesTable.stories.tsx
@@ -7,7 +7,7 @@ import { MessagesTable, MessagesTableProps } from "./MessagesTable";
 export default {
   component: MessagesTable,
   args: {
-    lastUpdated: new Date(),
+    lastUpdated: new Date(Date.UTC(2024, 11, 31, 23, 59, 59, 999)),
     partitions: 5,
     messages: [],
     topicName: "Example",

--- a/ui/components/MessagesTable/components/MessageDetails.stories.tsx
+++ b/ui/components/MessagesTable/components/MessageDetails.stories.tsx
@@ -16,7 +16,7 @@ export default {
         partition: 4,
         offset: 16,
         size: 1234,
-        timestamp: new Date("2022-03-15T14:11:57.103Z").toISOString(),
+        timestamp: new Date(Date.UTC(2024, 11, 31, 23, 59, 59, 999)).toISOString(),
         headers: {
           "post-office-box": "string",
           "extended-address": "string",


### PR DESCRIPTION
Use a consistent, fixed date in stories. Avoid unnecessary changes in Chromatic to review