### PR TITLE
Apicurio Registry integration with Avro/Protobuf ser/des support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ kubectl patch deployment -n ingress-nginx ingress-nginx-controller \
 ```
 
 ### Prerequisites
-#### Apache Kafka<sup>®</sup>
+#### Apache Kafka®
 The instructions below assume an existing Apache Kafka<sup>®</sup> cluster is available to use from the console. We recommend using [Strimzi](https://strimzi.io) to create and manage your Apache Kafka<sup>®</sup> clusters - plus the console provides additional features and insights for Strimzi Apache Kafka<sup>®</sup> clusters.
 
 If you already have Strimzi installed but would like to create an Apache Kafka<sup>®</sup> cluster for use with the console, example deployment resources are available to get started.  The resources create an Apache Kafka<sup>®</sup> cluster in KRaft mode with SCRAM-SHA-512 authentication, a Strimzi `KafkaNodePool` resource to manage the cluster nodes, and a Strimzi `KafkaUser` resource that may be used to connect to the cluster.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -134,7 +134,6 @@
         <dependency>
             <groupId>io.xlate</groupId>
             <artifactId>validators</artifactId>
-            <version>1.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -58,15 +58,15 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -83,6 +83,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apicurio-registry-avro</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.common</groupId>
@@ -107,6 +111,20 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serdes-protobuf-serde</artifactId>
+            <version>${apicurio-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
         </dependency>
 
         <dependency>
@@ -358,6 +376,7 @@
                             <systemProperties>
                                 <keycloak.image>${keycloak.image}</keycloak.image>
                                 <strimzi.test-container.kafka.custom.image>${strimzi-kafka.tag}</strimzi.test-container.kafka.custom.image>
+                                <apicurio-registry.version>${apicurio-registry.version}</apicurio-registry.version>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <maven.home>${maven.home}</maven.home>
                                 <quarkus.jacoco.reuse-data-file>true</quarkus.jacoco.reuse-data-file>

--- a/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
@@ -575,7 +575,7 @@ public class ClientFactory {
                 context.schemaRegistryContext().valueDeserializer());
     }
 
-    public void disposeConsumerSupplier(@Disposes Consumer<RecordData, RecordData> consumer) {
+    public void disposeConsumer(@Disposes Consumer<RecordData, RecordData> consumer) {
         consumer.close();
     }
 
@@ -589,7 +589,7 @@ public class ClientFactory {
                 context.schemaRegistryContext().valueSerializer());
     }
 
-    public void disposeProducerSupplier(@Disposes Producer<RecordData, RecordData> producer) {
+    public void disposeProducer(@Disposes Producer<RecordData, RecordData> producer) {
         producer.close();
     }
 

--- a/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
@@ -424,8 +424,10 @@ public class ClientFactory {
         }
 
         if (createContext) {
-            clientsMessage.insert(0, "Some configuration may be missing for connection to cluster %s, connection attempts may fail".formatted(clusterConfig.clusterKey()));
-            log.warn(clientsMessage.toString().trim());
+            if (clientsMessage.length() > 0) {
+                clientsMessage.insert(0, "Some configuration may be missing for connection to cluster %s, connection attempts may fail".formatted(clusterConfig.clusterKey()));
+                log.warn(clientsMessage.toString().trim());
+            }
         } else {
             clientsMessage.insert(0, "Missing configuration detected for connection to cluster %s, no connection will be setup".formatted(clusterConfig.clusterKey()));
             log.error(clientsMessage.toString().trim());

--- a/api/src/main/java/com/github/streamshub/console/api/SchemasResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/SchemasResource.java
@@ -1,0 +1,93 @@
+package com.github.streamshub.console.api;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.streamshub.console.api.support.KafkaContext;
+import com.github.streamshub.console.api.support.serdes.ArtifactReferences;
+import com.github.streamshub.console.api.support.serdes.MultiformatSchemaParser;
+
+import io.apicurio.registry.resolver.DefaultSchemaResolver;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.rest.client.RegistryClient;
+
+@Path("/api/schemas/{schemaId}")
+@Tag(name = "Schema Registry Resources")
+public class SchemasResource {
+
+    @Inject
+    Logger logger;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Inject
+    Map<String, KafkaContext> kafkaContexts;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @APIResponse(responseCode = "200", ref = "Configurations", content = @Content())
+    @APIResponse(responseCode = "404", ref = "NotFound")
+    @APIResponse(responseCode = "500", ref = "ServerError")
+    @APIResponse(responseCode = "504", ref = "ServerTimeout")
+    public Response describeConfigs(
+            @Parameter(description = "Schema identifier")
+            @PathParam("schemaId")
+            String schemaId) {
+
+        int clusterTerm = schemaId.indexOf('.');
+
+        if (clusterTerm < 0) {
+            throw new NotFoundException("No such schema");
+        }
+
+        String clusterId = new String(Base64.getUrlDecoder().decode(schemaId.substring(0, clusterTerm)));
+
+        if (!kafkaContexts.containsKey(clusterId)) {
+            throw new NotFoundException("No such schema");
+        }
+
+        RegistryClient registryClient = kafkaContexts.get(clusterId).schemaRegistryContext().registryClient();
+
+        if (registryClient == null) {
+            throw new NotFoundException("Schema not found, no registry is configured");
+        }
+
+        @SuppressWarnings("resource")
+        SchemaResolver<Object, ?> schemaResolver = new DefaultSchemaResolver<>();
+        schemaResolver.setClient(registryClient);
+        schemaResolver.configure(Collections.emptyMap(), new MultiformatSchemaParser<>(Collections.emptySet()));
+
+        schemaId = schemaId.substring(clusterTerm + 1);
+
+        var reference = ArtifactReferences.fromSchemaId(schemaId, objectMapper);
+        var schema = schemaResolver.resolveSchemaByArtifactReference(reference);
+
+        var response = Optional.ofNullable(schema)
+                .map(s -> s.getParsedSchema())
+                .map(s -> s.getRawSchema())
+                .map(Response::ok)
+                .orElseThrow(() -> new NotFoundException("No such schema"));
+
+        return response.build();
+    }
+
+}

--- a/api/src/main/java/com/github/streamshub/console/api/SchemasResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/SchemasResource.java
@@ -48,7 +48,7 @@ public class SchemasResource {
     @APIResponse(responseCode = "404", ref = "NotFound")
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "504", ref = "ServerTimeout")
-    public Response describeConfigs(
+    public Response getSchemaContent(
             @Parameter(description = "Schema identifier")
             @PathParam("schemaId")
             String schemaId) {

--- a/api/src/main/java/com/github/streamshub/console/api/model/HasLinks.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/HasLinks.java
@@ -1,0 +1,26 @@
+package com.github.streamshub.console.api.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+interface HasLinks<T> {
+
+    Map<String, String> links();
+
+    void links(Map<String, String> links);
+
+    default T addLink(String key, String value) {
+        links(addEntry(links(), key, value));
+        @SuppressWarnings("unchecked")
+        T t = (T) this;
+        return t;
+    }
+
+    private static <K, V> Map<K, V> addEntry(Map<K, V> map, K key, V value) {
+        if (map == null) {
+            map = new LinkedHashMap<>();
+        }
+        map.put(key, value);
+        return map;
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/model/HasMeta.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/HasMeta.java
@@ -1,0 +1,39 @@
+package com.github.streamshub.console.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+interface HasMeta<T> {
+
+    JsonApiMeta meta();
+
+    void meta(JsonApiMeta meta);
+
+    default JsonApiMeta metaFactory() {
+        return new JsonApiMeta();
+    }
+
+    @JsonIgnore
+    default JsonApiMeta getOrCreateMeta() {
+        JsonApiMeta meta = meta();
+
+        if (meta == null) {
+            meta = metaFactory();
+            meta(meta);
+        }
+
+        return meta;
+    }
+
+    default Object meta(String key) {
+        JsonApiMeta meta = meta();
+        return meta != null ? meta.get(key) : null;
+    }
+
+    default T addMeta(String key, Object value) {
+        JsonApiMeta meta = getOrCreateMeta();
+        meta.put(key, value);
+        @SuppressWarnings("unchecked")
+        T t = (T) this;
+        return t;
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/model/JsonApiMeta.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/JsonApiMeta.java
@@ -9,6 +9,11 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/**
+ * Base class for JSON API meta data attached to the document root, resources, or relationships.
+ *
+ * @see <a href="https://jsonapi.org/format/#document-meta">JSON API Document Structure, 7.5 Meta Information</a>
+ */
 @Schema(additionalProperties = Object.class)
 public class JsonApiMeta {
 

--- a/api/src/main/java/com/github/streamshub/console/api/model/JsonApiRelationship.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/JsonApiRelationship.java
@@ -6,15 +6,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * Base class for all JSON API request and response bodies.
- *
- * @see <a href="https://jsonapi.org/format/#document-structure">JSON API Document Structure, 7.1 Top Level</a>
- */
 @JsonInclude(value = Include.NON_NULL)
-public abstract class JsonApiDocument implements HasLinks<JsonApiDocument>, HasMeta<JsonApiDocument> {
+public class JsonApiRelationship implements HasLinks<JsonApiRelationship>, HasMeta<JsonApiRelationship> {
 
     private JsonApiMeta meta;
+    private Identifier data;
     private Map<String, String> links;
 
     @JsonProperty
@@ -34,4 +30,14 @@ public abstract class JsonApiDocument implements HasLinks<JsonApiDocument>, HasM
     public void links(Map<String, String> links) {
         this.links = links;
     }
+
+    @JsonProperty
+    public Identifier data() {
+        return data;
+    }
+
+    public void data(Identifier data) {
+        this.data = data;
+    }
+
 }

--- a/api/src/main/java/com/github/streamshub/console/api/model/JsonApiRelationship.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/JsonApiRelationship.java
@@ -6,6 +6,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Representation of a JSON API resource relationship linking a resource to another or
+ * providing meta information about the relationship.
+ *
+ * @see <a href="https://jsonapi.org/format/#document-resource-object-relationships">JSON API Document Structure, 7.2.2.2 Relationships</a>
+ */
 @JsonInclude(value = Include.NON_NULL)
 public class JsonApiRelationship implements HasLinks<JsonApiRelationship>, HasMeta<JsonApiRelationship> {
 

--- a/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
@@ -213,6 +213,11 @@ public class KafkaCluster extends Resource<KafkaCluster.Attributes> implements P
         return PaginatedKubeResource.fromCursor(cursor, KafkaCluster::fromId);
     }
 
+    @Override
+    public JsonApiMeta metaFactory() {
+        return new Meta();
+    }
+
     public void reconciliationPaused(Boolean reconciliationPaused) {
         ((Meta) getOrCreateMeta()).reconciliationPaused = reconciliationPaused;
     }

--- a/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/KafkaCluster.java
@@ -193,7 +193,7 @@ public class KafkaCluster extends Resource<KafkaCluster.Attributes> implements P
     }
 
     public KafkaCluster(String id, List<Node> nodes, Node controller, List<String> authorizedOperations) {
-        super(id, API_TYPE, Meta::new, new Attributes(nodes, controller, authorizedOperations));
+        super(id, API_TYPE, new Attributes(nodes, controller, authorizedOperations));
     }
 
     @JsonCreator
@@ -218,7 +218,7 @@ public class KafkaCluster extends Resource<KafkaCluster.Attributes> implements P
     }
 
     public Boolean reconciliationPaused() {
-        return Optional.ofNullable(getMeta())
+        return Optional.ofNullable(meta())
                 .map(Meta.class::cast)
                 .map(meta -> meta.reconciliationPaused)
                 .orElse(null);
@@ -304,7 +304,7 @@ public class KafkaCluster extends Resource<KafkaCluster.Attributes> implements P
 
     @JsonIgnore
     public boolean isConfigured() {
-        return Boolean.TRUE.equals(getMeta("configured"));
+        return Boolean.TRUE.equals(meta("configured"));
     }
 
     @JsonIgnore

--- a/api/src/main/java/com/github/streamshub/console/api/model/KafkaRebalance.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/KafkaRebalance.java
@@ -254,7 +254,7 @@ public class KafkaRebalance extends Resource<KafkaRebalance.Attributes> implemen
     }
 
     public KafkaRebalance(String id) {
-        super(id, API_TYPE, Meta::new, new Attributes());
+        super(id, API_TYPE, new Attributes());
     }
 
     @JsonCreator
@@ -270,6 +270,11 @@ public class KafkaRebalance extends Resource<KafkaRebalance.Attributes> implemen
         return PaginatedKubeResource.fromCursor(cursor, KafkaRebalance::new);
     }
 
+    @Override
+    public JsonApiMeta metaFactory() {
+        return new Meta();
+    }
+
     public List<String> allowedActions() {
         return ((Meta) getOrCreateMeta()).allowedActions;
     }
@@ -279,7 +284,7 @@ public class KafkaRebalance extends Resource<KafkaRebalance.Attributes> implemen
     }
 
     public String action() {
-        return Optional.ofNullable(getMeta())
+        return Optional.ofNullable(meta())
                 .map(Meta.class::cast)
                 .map(meta -> meta.action)
                 .orElse(null);

--- a/api/src/main/java/com/github/streamshub/console/api/model/KafkaRecord.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/KafkaRecord.java
@@ -19,9 +19,17 @@ import com.github.streamshub.console.api.support.ErrorCategory;
 
 import io.xlate.validation.constraints.Expression;
 
-@Schema(name = "KafkaRecordAttributes")
-@JsonFilter("fieldFilter")
-public class KafkaRecord {
+@Schema(name = "KafkaRecord")
+@Expression(
+    when = "self.type != null",
+    value = "self.type == '" + KafkaRecord.API_TYPE + "'",
+    message = "resource type conflicts with operation",
+    node = "type",
+    payload = ErrorCategory.ResourceConflict.class)
+public class KafkaRecord extends RelatableResource<KafkaRecord.Attributes, KafkaRecord.Relationships> {
+
+    public static final String API_TYPE = "records";
+    public static final String FIELDS_PARAM = "fields[" + API_TYPE + "]";
 
     public static final class Fields {
         public static final String PARTITION = "partition";
@@ -32,6 +40,8 @@ public class KafkaRecord {
         public static final String KEY = "key";
         public static final String VALUE = "value";
         public static final String SIZE = "size";
+        public static final String KEY_SCHEMA = "keySchema";
+        public static final String VALUE_SCHEMA = "valueSchema";
 
         public static final String DEFAULT =
                     PARTITION +
@@ -41,7 +51,9 @@ public class KafkaRecord {
                     ", " + HEADERS +
                     ", " + KEY +
                     ", " + VALUE +
-                    ", " + SIZE;
+                    ", " + SIZE +
+                    ", " + KEY_SCHEMA +
+                    ", " + VALUE_SCHEMA;
 
         public static final List<String> ALL = List.of(
                 PARTITION,
@@ -51,180 +63,197 @@ public class KafkaRecord {
                 HEADERS,
                 KEY,
                 VALUE,
-                SIZE);
+                SIZE,
+                KEY_SCHEMA,
+                VALUE_SCHEMA);
 
         private Fields() {
             // Prevent instances
         }
     }
 
-    @Schema(name = "KafkaRecordListResponse")
-    public static final class ListResponse extends DataList<RecordResource> {
-        public ListResponse(List<KafkaRecord> data) {
-            super(data.stream().map(RecordResource::new).toList());
-        }
-    }
-
-    @Schema(name = "KafkaRecordDocument")
-    public static final class KafkaRecordDocument extends DataSingleton<RecordResource> {
-        @JsonCreator
-        public KafkaRecordDocument(@JsonProperty("data") RecordResource data) {
+    @Schema(name = "KafkaRecordDataList")
+    public static final class KafkaRecordDataList extends DataList<KafkaRecord> {
+        public KafkaRecordDataList(List<KafkaRecord> data) {
             super(data);
         }
-
-        public KafkaRecordDocument(KafkaRecord data) {
-            super(new RecordResource(data));
-        }
     }
 
-    @Schema(name = "KafkaRecord")
-    @Expression(
-        when = "self.type != null",
-        value = "self.type == 'records'",
-        message = "resource type conflicts with operation",
-        node = "type",
-        payload = ErrorCategory.ResourceConflict.class
-    )
-    public static final class RecordResource extends Resource<KafkaRecord> {
+    @Schema(name = "KafkaRecordData")
+    public static final class KafkaRecordData extends DataSingleton<KafkaRecord> {
         @JsonCreator
-        public RecordResource(String type, KafkaRecord attributes) {
-            super(null, type, attributes);
-        }
-
-        public RecordResource(KafkaRecord attributes) {
-            super(null, "records", attributes);
+        public KafkaRecordData(@JsonProperty("data") KafkaRecord data) {
+            super(data);
         }
     }
 
-    @JsonIgnore
-    String topic;
+    @JsonFilter("fieldFilter")
+    @Schema(name = "KafkaRecordAttributes")
+    static class Attributes {
+        @JsonIgnore
+        String topic;
 
-    @Schema(description = "The record's partition within the topic")
-    Integer partition;
+        @JsonProperty
+        @Schema(description = "The record's partition within the topic")
+        Integer partition;
 
-    @Schema(readOnly = true, description = "The record's offset within the topic partition")
-    Long offset;
+        @JsonProperty
+        @Schema(readOnly = true, description = "The record's offset within the topic partition")
+        Long offset;
 
-    @Schema(description = "Timestamp associated with the record. The type is indicated by `timestampType`. When producing a record, this value will be used as the record's `CREATE_TIME`.", format = "date-time")
-    Instant timestamp;
+        @JsonProperty
+        @Schema(description = "Timestamp associated with the record. The type is indicated by `timestampType`. When producing a record, this value will be used as the record's `CREATE_TIME`.", format = "date-time")
+        Instant timestamp;
 
-    @Schema(readOnly = true, description = "Type of timestamp associated with the record")
-    String timestampType;
+        @JsonProperty
+        @Schema(readOnly = true, description = "Type of timestamp associated with the record")
+        String timestampType;
 
-    @Schema(description = "Record headers, key/value pairs")
-    Map<String, String> headers;
+        @JsonProperty
+        @Schema(description = "Record headers, key/value pairs")
+        Map<String, String> headers;
 
-    @Schema(description = "Record key")
-    String key;
+        @JsonProperty
+        @Schema(description = "Record key")
+        String key;
 
-    @NotNull
-    @Schema(description = "Record value")
-    String value;
+        @JsonProperty
+        @NotNull
+        @Schema(description = "Record value")
+        String value;
 
-    @Schema(readOnly = true, description = "Size of the uncompressed record, not including the overhead of the record in the log segment.")
-    Long size;
+        @JsonProperty
+        @Schema(readOnly = true, description = "Size of the uncompressed record, not including the overhead of the record in the log segment.")
+        Long size;
+    }
 
+    @JsonFilter("fieldFilter")
+    static class Relationships {
+        @JsonProperty
+        JsonApiRelationship keySchema;
+
+        @JsonProperty
+        JsonApiRelationship valueSchema;
+    }
+
+    @JsonCreator
     public KafkaRecord() {
-        super();
+        super(null, API_TYPE, new Attributes(), new Relationships());
     }
 
     public KafkaRecord(String topic) {
-        this.topic = topic;
+        this();
+        attributes.topic = topic;
     }
 
     public KafkaRecord(String topic, Integer partition, Instant timestamp, Map<String, String> headers, String key, String value, Long size) {
         this(topic);
-        this.partition = partition;
-        this.timestamp = timestamp;
-        this.headers = headers;
-        this.key = key;
-        this.value = value;
-        this.size = size;
+        attributes.partition = partition;
+        attributes.timestamp = timestamp;
+        attributes.headers = headers;
+        attributes.key = key;
+        attributes.value = value;
+        attributes.size = size;
     }
 
     @JsonIgnore
     public URI buildUri(UriBuilder builder, String topicName) {
-        builder.queryParam(Fields.PARTITION, partition);
-        builder.queryParam(Fields.OFFSET, offset);
+        builder.queryParam(Fields.PARTITION, attributes.partition);
+        builder.queryParam(Fields.OFFSET, attributes.offset);
         return builder.build(topicName);
     }
 
     @AssertTrue(message = "invalid timestamp")
     @JsonIgnore
     public boolean isTimestampValid() {
-        if (timestamp == null) {
+        if (attributes.timestamp == null) {
             return true;
         }
 
         try {
-            return timestamp.isAfter(Instant.ofEpochMilli(-1));
+            return attributes.timestamp.isAfter(Instant.ofEpochMilli(-1));
         } catch (Exception e) {
             return false;
         }
     }
 
-    public Integer getPartition() {
-        return partition;
+    public Integer partition() {
+        return attributes.partition;
     }
 
-    public void setPartition(Integer partition) {
-        this.partition = partition;
+    public void partition(Integer partition) {
+        attributes.partition = partition;
     }
 
-    public Long getOffset() {
-        return offset;
+    public Long offset() {
+        return attributes.offset;
     }
 
-    public void setOffset(Long offset) {
-        this.offset = offset;
+    public void offset(Long offset) {
+        attributes.offset = offset;
     }
 
-    public Instant getTimestamp() {
-        return timestamp;
+    public Instant timestamp() {
+        return attributes.timestamp;
     }
 
-    public void setTimestamp(Instant timestamp) {
-        this.timestamp = timestamp;
+    public void timestamp(Instant timestamp) {
+        attributes.timestamp = timestamp;
     }
 
-    public String getTimestampType() {
-        return timestampType;
+    public String timestampType() {
+        return attributes.timestampType;
     }
 
-    public void setTimestampType(String timestampType) {
-        this.timestampType = timestampType;
+    public void timestampType(String timestampType) {
+        attributes.timestampType = timestampType;
     }
 
-    public Map<String, String> getHeaders() {
-        return headers;
+    public Map<String, String> headers() {
+        return attributes.headers;
     }
 
-    public void setHeaders(Map<String, String> headers) {
-        this.headers = headers;
+    public void headers(Map<String, String> headers) {
+        attributes.headers = headers;
     }
 
-    public String getKey() {
-        return key;
+    public String key() {
+        return attributes.key;
     }
 
-    public void setKey(String key) {
-        this.key = key;
+    public void key(String key) {
+        attributes.key = key;
     }
 
-    public String getValue() {
-        return value;
+    public String value() {
+        return attributes.value;
     }
 
-    public void setValue(String value) {
-        this.value = value;
+    public void value(String value) {
+        attributes.value = value;
     }
 
-    public Long getSize() {
-        return size;
+    public Long size() {
+        return attributes.size;
     }
 
-    public void setSize(Long size) {
-        this.size = size;
+    public void size(Long size) {
+        attributes.size = size;
     }
 
+    public JsonApiRelationship keySchema() {
+        return relationships.keySchema;
+    }
+
+    public void keySchema(JsonApiRelationship keySchema) {
+        relationships.keySchema = keySchema;
+    }
+
+    public JsonApiRelationship valueSchema() {
+        return relationships.valueSchema;
+    }
+
+    public void valueSchema(JsonApiRelationship valueSchema) {
+        relationships.valueSchema = valueSchema;
+    }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/model/RecordFilterParams.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/RecordFilterParams.java
@@ -19,12 +19,18 @@ import io.xlate.validation.constraints.Expression.ExceptionalValue;
 @Expression(
     when = "self.rawTimestamp != null",
     value = "self.rawOffset == null",
-    node = "filter[offset]",
+    node = RecordFilterParams.FILTER_OFFSET,
     message = "Parameter `filter[offset]` must not be used when `filter[timestamp]` is present.",
     payload = ErrorCategory.InvalidQueryParameter.class)
 public class RecordFilterParams {
 
-    @QueryParam("filter[partition]")
+    static final String FILTER_PARTITION = "filter[partition]";
+    static final String FILTER_OFFSET = "filter[offset]";
+    static final String FILTER_TIMESTAMP = "filter[timestamp]";
+    static final String PAGE_SIZE = "page[size]";
+    static final String MAX_VALUE_LENGTH = "maxValueLength";
+
+    @QueryParam(FILTER_PARTITION)
     @Parameter(
         description = """
                 Retrieve messages only from the partition identified by this parameter.
@@ -39,23 +45,23 @@ public class RecordFilterParams {
         value = "self.operator == 'eq'",
         message = "unsupported filter operator, supported values: [ 'eq' ]",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[partition]")
+        node = FILTER_PARTITION)
     @Expression(
         when = "self != null",
         value = "self.operands.size() == 1",
         message = "exactly 1 operand is required",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[partition]")
+        node = FILTER_PARTITION)
     @Expression(
         when = "self != null && self.operator == 'eq' && self.operands.size() == 1",
         value = "val = Integer.parseInt(self.firstOperand); val >= 0 && val <= Integer.MAX_VALUE",
         exceptionalValue = ExceptionalValue.FALSE,
         message = "operand must be an integer between 0 and " + Integer.MAX_VALUE + ", inclusive",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[partition]")
+        node = FILTER_PARTITION)
     FetchFilter partition;
 
-    @QueryParam("filter[offset]")
+    @QueryParam(FILTER_OFFSET)
     @Parameter(
         description = """
         Retrieve messages with an offset greater than or equal to the filter
@@ -80,23 +86,23 @@ public class RecordFilterParams {
         exceptionalValue = ExceptionalValue.FALSE,
         message = "unsupported filter operator, supported values: [ 'gte' ]",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[offset]")
+        node = FILTER_OFFSET)
     @Expression(
         when = "self != null",
         value = "self.operands.size() == 1",
         message = "exactly 1 operand is required",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[offset]")
+        node = FILTER_OFFSET)
     @Expression(
         when = "self != null && self.operator == 'gte'",
         value = "val = Long.parseLong(self.firstOperand); val >= 0 && val <= Long.MAX_VALUE",
         exceptionalValue = ExceptionalValue.FALSE,
         message = "operand must be an integer between 0 and " + Long.MAX_VALUE + ", inclusive",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[offset]")
+        node = FILTER_OFFSET)
     FetchFilter offset;
 
-    @QueryParam("filter[timestamp]")
+    @QueryParam(FILTER_TIMESTAMP)
     @Parameter(
         description = """
             Retrieve messages with a timestamp greater than or equal to the filter
@@ -120,13 +126,13 @@ public class RecordFilterParams {
         value = "self.operator == 'gte'",
         message = "unsupported filter operator, supported values: [ 'gte' ]",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[timestamp]")
+        node = FILTER_TIMESTAMP)
     @Expression(
         when = "self != null",
         value = "self.operands.size() == 1",
         message = "exactly 1 operand is required",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[timestamp]")
+        node = FILTER_TIMESTAMP)
     @Expression(
         when = "self != null && self.operator == 'gte'",
         classImports = "java.time.Instant",
@@ -134,10 +140,10 @@ public class RecordFilterParams {
         exceptionalValue = ExceptionalValue.FALSE,
         message = "operand must be a valid RFC 3339 date-time no earlier than `1970-01-01T00:00:00Z`",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "filter[timestamp]")
+        node = FILTER_TIMESTAMP)
     FetchFilter timestamp;
 
-    @QueryParam("page[size]")
+    @QueryParam(PAGE_SIZE)
     @DefaultValue(ListFetchParams.PAGE_SIZE_DEFAULT + "")
     @Parameter(
         description = "Limit the number of records fetched and returned",
@@ -152,10 +158,10 @@ public class RecordFilterParams {
         exceptionalValue = ExceptionalValue.FALSE,
         message = "must be an integer between 1 and " + ListFetchParams.PAGE_SIZE_MAX + ", inclusive",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "page[size]")
+        node = PAGE_SIZE)
     String pageSize;
 
-    @QueryParam("maxValueLength")
+    @QueryParam(MAX_VALUE_LENGTH)
     @Parameter(
         description = """
         Maximum length of string values returned in the response.
@@ -169,7 +175,7 @@ public class RecordFilterParams {
         exceptionalValue = ExceptionalValue.FALSE,
         message = "must be an integer between 1 and " + Integer.MAX_VALUE + ", inclusive",
         payload = ErrorCategory.InvalidQueryParameter.class,
-        node = "maxValueLength")
+        node = MAX_VALUE_LENGTH)
     String maxValueLength;
 
     public String getRawOffset() {

--- a/api/src/main/java/com/github/streamshub/console/api/model/Resource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/Resource.java
@@ -1,13 +1,11 @@
 package com.github.streamshub.console.api.model;
 
-import java.util.function.Supplier;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.streamshub.console.api.support.ErrorCategory;
 
 /**
@@ -18,7 +16,7 @@ import com.github.streamshub.console.api.support.ErrorCategory;
  * @param <T> the type of the attribute model
  */
 @JsonInclude(Include.NON_NULL)
-public abstract class Resource<T> {
+public abstract class Resource<T> implements HasMeta<T> {
 
     protected String id;
 
@@ -32,26 +30,17 @@ public abstract class Resource<T> {
     @NotNull(payload = ErrorCategory.InvalidResource.class)
     protected final T attributes;
 
-    @JsonIgnore
-    private final Supplier<JsonApiMeta> metaFactory;
-
     protected Resource(String id, String type, JsonApiMeta meta, T attributes) {
         this.id = id;
         this.type = type;
         this.meta = meta;
-        this.metaFactory = JsonApiMeta::new;
-        this.attributes = attributes;
-    }
-
-    protected Resource(String id, String type, Supplier<JsonApiMeta> metaFactory, T attributes) {
-        this.id = id;
-        this.type = type;
-        this.metaFactory = metaFactory;
         this.attributes = attributes;
     }
 
     protected Resource(String id, String type, T attributes) {
-        this(id, type, JsonApiMeta::new, attributes);
+        this.id = id;
+        this.type = type;
+        this.attributes = attributes;
     }
 
     public String getId() {
@@ -66,24 +55,12 @@ public abstract class Resource<T> {
         return attributes;
     }
 
-    public JsonApiMeta getMeta() {
+    @JsonProperty
+    public JsonApiMeta meta() {
         return meta;
     }
 
-    @JsonIgnore
-    public JsonApiMeta getOrCreateMeta() {
-        if (meta == null) {
-            meta = metaFactory.get();
-        }
-        return meta;
-    }
-
-    public Object getMeta(String key) {
-        return meta != null ? meta.get(key) : null;
-    }
-
-    public Resource<T> addMeta(String key, Object value) {
-        getOrCreateMeta().put(key, value);
-        return this;
+    public void meta(JsonApiMeta meta) {
+        this.meta = meta;
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/service/RecordService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/RecordService.java
@@ -1,13 +1,10 @@
 package com.github.streamshub.console.api.service;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -18,11 +15,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -38,6 +36,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -48,17 +47,17 @@ import org.apache.kafka.common.header.Headers;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
+import com.github.streamshub.console.api.model.Identifier;
+import com.github.streamshub.console.api.model.JsonApiRelationship;
 import com.github.streamshub.console.api.model.KafkaRecord;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.SizeLimitedSortedSet;
+import com.github.streamshub.console.api.support.serdes.RecordData;
 
 import static java.util.Objects.requireNonNullElse;
 
 @ApplicationScoped
 public class RecordService {
-
-    public static final String BINARY_DATA_MESSAGE = "Binary or non-UTF-8 encoded data cannot be displayed";
-    static final int REPLACEMENT_CHARACTER = '\uFFFD';
 
     @Inject
     Logger logger;
@@ -67,15 +66,15 @@ public class RecordService {
     KafkaContext kafkaContext;
 
     @Inject
-    Supplier<Consumer<byte[], byte[]>> consumerSupplier;
+    Consumer<RecordData, RecordData> consumer;
 
     @Inject
-    Supplier<Producer<String, String>> producerSupplier;
+    Producer<RecordData, RecordData> producer;
 
     @Inject
     ThreadContext threadContext;
 
-    public List<KafkaRecord> consumeRecords(String topicId,
+    public CompletionStage<List<KafkaRecord>> consumeRecords(String topicId,
             Integer partition,
             Long offset,
             Instant timestamp,
@@ -83,72 +82,62 @@ public class RecordService {
             List<String> include,
             Integer maxValueLength) {
 
-        List<PartitionInfo> partitions = topicNameForId(topicId)
-            .thenApplyAsync(
-                    topicName -> consumerSupplier.get().partitionsFor(topicName),
-                    threadContext.currentContextExecutor())
-            .toCompletableFuture()
-            .join();
+        return topicNameForId(topicId).thenApplyAsync(topicName -> {
+            List<PartitionInfo> partitions = consumer.partitionsFor(topicName);
+            List<TopicPartition> assignments = partitions.stream()
+                    .filter(p -> partition == null || partition.equals(p.partition()))
+                    .map(p -> new TopicPartition(p.topic(), p.partition()))
+                    .toList();
 
-        List<TopicPartition> assignments = partitions.stream()
-            .filter(p -> partition == null || partition.equals(p.partition()))
-            .map(p -> new TopicPartition(p.topic(), p.partition()))
-            .toList();
+            if (assignments.isEmpty()) {
+                return Collections.emptyList();
+            }
 
-        if (assignments.isEmpty()) {
-            return Collections.emptyList();
-        }
+            consumer.assign(assignments);
+            var endOffsets = consumer.endOffsets(assignments);
 
-        Consumer<byte[], byte[]> consumer = consumerSupplier.get();
-        consumer.assign(assignments);
-        var endOffsets = consumer.endOffsets(assignments);
+            if (timestamp != null) {
+                seekToTimestamp(consumer, assignments, timestamp);
+            } else {
+                seekToOffset(consumer, assignments, endOffsets, offset, limit);
+            }
 
-        if (timestamp != null) {
-            seekToTimestamp(consumer, assignments, timestamp);
-        } else {
-            seekToOffset(consumer, assignments, endOffsets, offset, limit);
-        }
+            Iterable<ConsumerRecords<RecordData, RecordData>> poll = () -> new ConsumerRecordsIterator<>(consumer, endOffsets, limit);
+            var limitSet = new SizeLimitedSortedSet<ConsumerRecord<RecordData, RecordData>>(buildComparator(timestamp, offset), limit);
 
-        Iterable<ConsumerRecords<byte[], byte[]>> poll = () -> new ConsumerRecordsIterator<>(consumer, endOffsets, limit);
-        var limitSet = new SizeLimitedSortedSet<ConsumerRecord<byte[], byte[]>>(buildComparator(timestamp, offset), limit);
-
-        return StreamSupport.stream(poll.spliterator(), false)
-                .flatMap(records -> StreamSupport.stream(records.spliterator(), false))
-                .collect(Collectors.toCollection(() -> limitSet))
-                .stream()
-                .map(rec -> getItems(rec, topicId, include, maxValueLength))
-                .toList();
+            return StreamSupport.stream(poll.spliterator(), false)
+                    .flatMap(records -> StreamSupport.stream(records.spliterator(), false))
+                    .collect(Collectors.toCollection(() -> limitSet))
+                    .stream()
+                    .map(rec -> getItems(rec, topicId, include, maxValueLength))
+                    .toList();
+        }, threadContext.currentContextExecutor());
     }
 
     public CompletionStage<KafkaRecord> produceRecord(String topicId, KafkaRecord input) {
         CompletableFuture<KafkaRecord> promise = new CompletableFuture<>();
-        Executor asyncExec = threadContext.currentContextExecutor();
 
-        topicNameForId(topicId)
-            .thenApplyAsync(
-                    topicName -> producerSupplier.get().partitionsFor(topicName),
-                    asyncExec)
-            .thenAcceptAsync(
-                    partitions -> {
-                        Producer<String, String> producer = producerSupplier.get();
-                        String topicName = partitions.iterator().next().topic();
-                        Integer partition = input.getPartition();
+        topicNameForId(topicId).thenAcceptAsync(topicName -> {
+            List<PartitionInfo> partitions = producer.partitionsFor(topicName);
+            Integer partition = input.partition();
 
-                        if (partition != null && partitions.stream().noneMatch(p -> partition.equals(p.partition()))) {
-                            promise.completeExceptionally(invalidPartition(topicId, partition));
-                        } else {
-                            send(topicName, input, producer, promise);
-                        }
-                    },
-                    asyncExec);
+            if (partition != null && partitions.stream().noneMatch(p -> partition.equals(p.partition()))) {
+                promise.completeExceptionally(invalidPartition(topicId, partition));
+            } else {
+                send(topicName, input, producer, promise);
+            }
+
+            promise.whenComplete((kafkaRecord, error) -> producer.close());
+        }, threadContext.currentContextExecutor()).exceptionally(e -> {
+            promise.completeExceptionally(e);
+            return null;
+        });
 
         return promise;
     }
 
-    void send(String topicName, KafkaRecord input, Producer<String, String> producer, CompletableFuture<KafkaRecord> promise) {
-        String key = input.getKey();
-
-        List<Header> headers = Optional.ofNullable(input.getHeaders())
+    void send(String topicName, KafkaRecord input, Producer<RecordData, RecordData> producer, CompletableFuture<KafkaRecord> promise) {
+        List<Header> headers = Optional.ofNullable(input.headers())
             .orElseGet(Collections::emptyMap)
             .entrySet()
             .stream()
@@ -164,35 +153,78 @@ public class RecordService {
                 }
             })
             .map(Header.class::cast)
-            .toList();
+            .collect(Collectors.toCollection(ArrayList::new));
 
-        Long timestamp = Optional.ofNullable(input.getTimestamp()).map(Instant::toEpochMilli).orElse(null);
+        Long timestamp = Optional.ofNullable(input.timestamp()).map(Instant::toEpochMilli).orElse(null);
+        var key = new RecordData(input.key());
+        setSchemaMeta(input.keySchema(), key);
 
-        ProducerRecord<String, String> request = new ProducerRecord<>(topicName,
-                input.getPartition(),
+        var value = new RecordData(input.value());
+        setSchemaMeta(input.valueSchema(), value);
+
+        ProducerRecord<RecordData, RecordData> request = new ProducerRecord<>(topicName,
+                input.partition(),
                 timestamp,
                 key,
-                input.getValue(),
+                value,
                 headers);
 
-        producer.send(request, (meta, exception) -> {
-            if (exception != null) {
-                promise.completeExceptionally(exception);
-            } else {
+        CompletableFuture.completedFuture(null)
+            .thenApplyAsync(nothing -> {
+                try {
+                    return producer.send(request).get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new CompletionException("Error occurred while sending record to Kafka cluster", e);
+                } catch (Exception e) {
+                    throw new CompletionException("Error occurred while sending record to Kafka cluster", e);
+                }
+            }, threadContext.currentContextExecutor())
+            .thenApply(meta -> {
                 KafkaRecord result = new KafkaRecord();
-                result.setPartition(meta.partition());
+                result.partition(meta.partition());
+
                 if (meta.hasOffset()) {
-                    result.setOffset(meta.offset());
+                    result.offset(meta.offset());
                 }
+
                 if (meta.hasTimestamp()) {
-                    result.setTimestamp(Instant.ofEpochMilli(meta.timestamp()));
+                    result.timestamp(Instant.ofEpochMilli(meta.timestamp()));
                 }
-                result.setKey(input.getKey());
-                result.setValue(input.getValue());
-                result.setHeaders(input.getHeaders());
-                promise.complete(result);
-            }
-        });
+
+                result.key(key.dataString(null));
+                result.value(value.dataString(null));
+                result.headers(Arrays.stream(request.headers().toArray())
+                        .collect(
+                                // Duplicate headers will be overwritten
+                                LinkedHashMap::new,
+                                (map, hdr) -> map.put(hdr.key(), headerValue(hdr, null)),
+                                HashMap::putAll));
+                result.size(sizeOf(meta, request.headers()));
+                maybeRelate(key).ifPresent(result::keySchema);
+                maybeRelate(value).ifPresent(result::valueSchema);
+
+                return result;
+            })
+            .thenAccept(promise::complete)
+            .exceptionally(exception -> {
+                promise.completeExceptionally(exception);
+                return null;
+            });
+    }
+
+    void setSchemaMeta(JsonApiRelationship schemaRelationship, RecordData data) {
+        schemaMeta(schemaRelationship, "coordinates").ifPresent(gav -> data.meta.put("schema-gav", gav));
+        schemaMeta(schemaRelationship, "messageType").ifPresent(type -> data.meta.put("message-type", type));
+    }
+
+    Optional<String> schemaMeta(JsonApiRelationship schemaRelationship, String key) {
+        return Optional.ofNullable(schemaRelationship)
+                .map(JsonApiRelationship::meta)
+                .map(meta -> {
+                    Object value = meta.get(key);
+                    return (value instanceof String stringValue) ? stringValue : null;
+                });
     }
 
     CompletionStage<String> topicNameForId(String topicId) {
@@ -210,7 +242,7 @@ public class RecordService {
                     .orElseThrow(() -> noSuchTopic(topicId)));
     }
 
-    void seekToTimestamp(Consumer<byte[], byte[]> consumer, List<TopicPartition> assignments, Instant timestamp) {
+    void seekToTimestamp(Consumer<RecordData, RecordData> consumer, List<TopicPartition> assignments, Instant timestamp) {
         Long tsMillis = timestamp.toEpochMilli();
         Map<TopicPartition, Long> timestampsToSearch = assignments.stream()
                 .collect(Collectors.toMap(Function.identity(), p -> tsMillis));
@@ -237,7 +269,7 @@ public class RecordService {
             });
     }
 
-    void seekToOffset(Consumer<byte[], byte[]> consumer, List<TopicPartition> assignments, Map<TopicPartition, Long> endOffsets, Long offset, int limit) {
+    void seekToOffset(Consumer<RecordData, RecordData> consumer, List<TopicPartition> assignments, Map<TopicPartition, Long> endOffsets, Long offset, int limit) {
         var beginningOffsets = consumer.beginningOffsets(assignments);
 
         assignments.forEach(p -> {
@@ -263,9 +295,9 @@ public class RecordService {
         });
     }
 
-    Comparator<ConsumerRecord<byte[], byte[]>> buildComparator(Instant timestamp, Long offset) {
-        Comparator<ConsumerRecord<byte[], byte[]>> comparator = Comparator
-                .<ConsumerRecord<byte[], byte[]>>comparingLong(ConsumerRecord::timestamp)
+    Comparator<ConsumerRecord<RecordData, RecordData>> buildComparator(Instant timestamp, Long offset) {
+        Comparator<ConsumerRecord<RecordData, RecordData>> comparator = Comparator
+                .<ConsumerRecord<RecordData, RecordData>>comparingLong(ConsumerRecord::timestamp)
                 .thenComparingInt(ConsumerRecord::partition)
                 .thenComparingLong(ConsumerRecord::offset);
 
@@ -277,71 +309,89 @@ public class RecordService {
         return comparator;
     }
 
-    KafkaRecord getItems(ConsumerRecord<byte[], byte[]> rec, String topicId, List<String> include, Integer maxValueLength) {
+    KafkaRecord getItems(ConsumerRecord<RecordData, RecordData> rec, String topicId, List<String> include, Integer maxValueLength) {
         KafkaRecord item = new KafkaRecord(topicId);
 
-        setProperty(KafkaRecord.Fields.PARTITION, include, rec::partition, item::setPartition);
-        setProperty(KafkaRecord.Fields.OFFSET, include, rec::offset, item::setOffset);
-        setProperty(KafkaRecord.Fields.TIMESTAMP, include, () -> Instant.ofEpochMilli(rec.timestamp()), item::setTimestamp);
-        setProperty(KafkaRecord.Fields.TIMESTAMP_TYPE, include, rec.timestampType()::name, item::setTimestampType);
-        setProperty(KafkaRecord.Fields.KEY, include, rec::key, k -> item.setKey(bytesToString(k, maxValueLength)));
-        setProperty(KafkaRecord.Fields.VALUE, include, rec::value, v -> item.setValue(bytesToString(v, maxValueLength)));
-        setProperty(KafkaRecord.Fields.HEADERS, include, () -> headersToMap(rec.headers(), maxValueLength), item::setHeaders);
-        setProperty(KafkaRecord.Fields.SIZE, include, () -> sizeOf(rec), item::setSize);
+        setProperty(KafkaRecord.Fields.PARTITION, include, rec::partition, item::partition);
+        setProperty(KafkaRecord.Fields.OFFSET, include, rec::offset, item::offset);
+        setProperty(KafkaRecord.Fields.TIMESTAMP, include, () -> Instant.ofEpochMilli(rec.timestamp()), item::timestamp);
+        setProperty(KafkaRecord.Fields.TIMESTAMP_TYPE, include, rec.timestampType()::name, item::timestampType);
+        setProperty(KafkaRecord.Fields.KEY, include, rec::key, k -> item.key(k.dataString(maxValueLength)));
+        setProperty(KafkaRecord.Fields.VALUE, include, rec::value, v -> item.value(v.dataString(maxValueLength)));
+        setProperty(KafkaRecord.Fields.HEADERS, include, () -> headersToMap(rec.headers(), maxValueLength), item::headers);
+        setProperty(KafkaRecord.Fields.SIZE, include, () -> sizeOf(rec), item::size);
+
+        maybeRelate(rec.key()).ifPresent(item::keySchema);
+        maybeRelate(rec.value()).ifPresent(item::valueSchema);
 
         return item;
     }
 
-    <T> void setProperty(String fieldName, List<String> include, Supplier<T> source, java.util.function.Consumer<T> target) {
-        if (include.contains(fieldName)) {
-            target.accept(source.get());
-        }
+    Optional<JsonApiRelationship> maybeRelate(RecordData data) {
+        return Optional.ofNullable(data)
+                .map(d -> d.meta)
+                .filter(recordMeta -> recordMeta.containsKey("schema-id"))
+                .map(recordMeta -> {
+                    String artifactType = recordMeta.get("schema-type");
+                    String clusterIdEnc = Base64.getUrlEncoder().encodeToString(kafkaContext.clusterId().getBytes());
+                    String schemaId = clusterIdEnc + '.' + recordMeta.get("schema-id");
+                    String name = recordMeta.get("schema-name");
+
+                    var relationship = new JsonApiRelationship();
+                    relationship.addMeta("artifactType", artifactType);
+                    relationship.addMeta("name", name);
+                    relationship.data(new Identifier("schemas", schemaId));
+                    relationship.addLink("content", "/api/schemas/" + schemaId);
+
+                    return relationship;
+                })
+                .filter(Objects::nonNull);
     }
 
-    String bytesToString(byte[] bytes, Integer maxValueLength) {
-        if (bytes == null) {
-            return null;
-        }
-
-        if (bytes.length == 0) {
-            return "";
-        }
-
-        int bufferSize = maxValueLength != null ? Math.min(maxValueLength, bytes.length) : bytes.length;
-        StringBuilder buffer = new StringBuilder(bufferSize);
-
-        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8)) {
-            int input;
-
-            while ((input = reader.read()) > -1) {
-                if (input == REPLACEMENT_CHARACTER || !Character.isDefined(input)) {
-                    return BINARY_DATA_MESSAGE;
-                }
-
-                buffer.append((char) input);
-
-                if (maxValueLength != null && buffer.length() == maxValueLength) {
-                    break;
-                }
+    <T> void setProperty(String fieldName, List<String> include, Supplier<T> source, java.util.function.Consumer<T> target) {
+        if (include.contains(fieldName)) {
+            T value = source.get();
+            if (value != null) {
+                target.accept(value);
             }
-
-            return buffer.toString();
-        } catch (IOException e) {
-            return BINARY_DATA_MESSAGE;
         }
     }
 
     Map<String, String> headersToMap(Headers headers, Integer maxValueLength) {
         Map<String, String> headerMap = new LinkedHashMap<>();
-        headers.iterator().forEachRemaining(h -> headerMap.put(h.key(), bytesToString(h.value(), maxValueLength)));
+        headers.iterator().forEachRemaining(h -> headerMap.put(h.key(), headerValue(h, maxValueLength)));
         return headerMap;
     }
 
-    long sizeOf(ConsumerRecord<?, ?> rec) {
-        return rec.serializedKeySize() +
-            rec.serializedValueSize() +
-            Arrays.stream(rec.headers().toArray())
-                .mapToLong(h -> h.key().length() + h.value().length)
+    static String headerValue(Header header, Integer maxValueLength) {
+        byte[] value = header.value();
+
+        if (value != null) {
+            int length;
+
+            if (maxValueLength == null) {
+                length = value.length;
+            } else {
+                length = Integer.min(maxValueLength, value.length);
+            }
+
+            return new String(value, 0, length);
+        }
+
+        return null;
+    }
+
+    static long sizeOf(RecordMetadata meta, Headers headers) {
+        return sizeOf(meta.serializedKeySize(), meta.serializedValueSize(), headers);
+    }
+
+    static long sizeOf(ConsumerRecord<?, ?> rec) {
+        return sizeOf(rec.serializedKeySize(), rec.serializedValueSize(), rec.headers());
+    }
+
+    static long sizeOf(int keySize, int valueSize, Headers headers) {
+        return keySize + valueSize + Arrays.stream(headers.toArray())
+                .mapToLong(h -> h.key().length() + (h.value() != null ? h.value().length : 0))
                 .sum();
     }
 

--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -85,6 +85,11 @@ public class KafkaContext implements Closeable {
         if (admin != null) {
             admin.close();
         }
+        /*
+         * Do not close the registry context when the KafkaContext has client-provided
+         * credentials. I.e., only close when the context is global (with configured
+         * credentials).
+         */
         if (applicationScoped && schemaRegistryContext != null) {
             try {
                 schemaRegistryContext.close();
@@ -154,6 +159,13 @@ public class KafkaContext implements Closeable {
                     .map(KafkaListenerAuthenticationOAuth::getTokenEndpointUri));
     }
 
+    /**
+     * The SchemaRegistryContext contains a per-Kafka registry client
+     * and key/value SerDes classes to be used to handle message browsing.
+     *
+     * The client and SerDes instances will be kept open and reused until
+     * the parent KafkaContext is disposed of at application shutdown.
+     */
     public class SchemaRegistryContext implements Closeable {
         private final RegistryClient registryClient;
         private final MultiformatDeserializer keyDeserializer;

--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -1,6 +1,7 @@
 package com.github.streamshub.console.api.support;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -9,13 +10,22 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.jboss.logging.Logger;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.streamshub.console.api.support.serdes.ForceCloseable;
+import com.github.streamshub.console.api.support.serdes.MultiformatDeserializer;
+import com.github.streamshub.console.api.support.serdes.MultiformatSerializer;
 import com.github.streamshub.console.config.KafkaClusterConfig;
 
+import io.apicurio.registry.rest.client.RegistryClient;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaSpec;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.kafka.oauth.client.ClientConfig;
@@ -23,12 +33,14 @@ import io.strimzi.kafka.oauth.client.ClientConfig;
 public class KafkaContext implements Closeable {
 
     public static final KafkaContext EMPTY = new KafkaContext(null, null, Collections.emptyMap(), null);
+    private static final Logger LOGGER = Logger.getLogger(KafkaContext.class);
 
     final KafkaClusterConfig clusterConfig;
     final Kafka resource;
     final Map<Class<?>, Map<String, Object>> configs;
     final Admin admin;
     boolean applicationScoped;
+    SchemaRegistryContext schemaRegistryContext;
 
     public KafkaContext(KafkaClusterConfig clusterConfig, Kafka resource, Map<Class<?>, Map<String, Object>> configs, Admin admin) {
         this.clusterConfig = clusterConfig;
@@ -41,6 +53,13 @@ public class KafkaContext implements Closeable {
     public KafkaContext(KafkaContext other, Admin admin) {
         this(other.clusterConfig, other.resource, other.configs, admin);
         this.applicationScoped = false;
+        this.schemaRegistryContext = other.schemaRegistryContext;
+    }
+
+    public static String clusterId(KafkaClusterConfig clusterConfig, Optional<Kafka> kafkaResource) {
+        return Optional.ofNullable(clusterConfig.getId())
+                .or(() -> kafkaResource.map(Kafka::getStatus).map(KafkaStatus::getClusterId))
+                .orElseGet(clusterConfig::getName);
     }
 
     @Override
@@ -66,6 +85,17 @@ public class KafkaContext implements Closeable {
         if (admin != null) {
             admin.close();
         }
+        if (applicationScoped && schemaRegistryContext != null) {
+            try {
+                schemaRegistryContext.close();
+            } catch (IOException e) {
+                LOGGER.warnf("Exception closing schema registry context: %s", e.getMessage());
+            }
+        }
+    }
+
+    public String clusterId() {
+        return clusterId(clusterConfig, Optional.ofNullable(resource));
     }
 
     public KafkaClusterConfig clusterConfig() {
@@ -92,6 +122,14 @@ public class KafkaContext implements Closeable {
         return applicationScoped;
     }
 
+    public void schemaRegistryClient(RegistryClient schemaRegistryClient) {
+        schemaRegistryContext = new SchemaRegistryContext(schemaRegistryClient);
+    }
+
+    public SchemaRegistryContext schemaRegistryContext() {
+        return schemaRegistryContext;
+    }
+
     public String saslMechanism(Class<?> clientType) {
         return configs(clientType).get(SaslConfigs.SASL_MECHANISM) instanceof String auth ? auth : "";
     }
@@ -114,5 +152,72 @@ public class KafkaContext implements Closeable {
                     .filter(KafkaListenerAuthenticationOAuth.class::isInstance)
                     .map(KafkaListenerAuthenticationOAuth.class::cast)
                     .map(KafkaListenerAuthenticationOAuth::getTokenEndpointUri));
+    }
+
+    public class SchemaRegistryContext implements Closeable {
+        private final RegistryClient registryClient;
+        private final MultiformatDeserializer keyDeserializer;
+        private final MultiformatDeserializer valueDeserializer;
+        private final MultiformatSerializer keySerializer;
+        private final MultiformatSerializer valueSerializer;
+
+        SchemaRegistryContext(RegistryClient schemaRegistryClient) {
+            this.registryClient = schemaRegistryClient;
+
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            keyDeserializer = new MultiformatDeserializer(registryClient, objectMapper);
+            keyDeserializer.configure(configs(Consumer.class), true);
+
+            valueDeserializer = new MultiformatDeserializer(registryClient, objectMapper);
+            valueDeserializer.configure(configs(Consumer.class), false);
+
+            keySerializer = new MultiformatSerializer(registryClient, objectMapper);
+            keySerializer.configure(configs(Producer.class), true);
+
+            valueSerializer = new MultiformatSerializer(registryClient, objectMapper);
+            valueSerializer.configure(configs(Producer.class), false);
+        }
+
+        public RegistryClient registryClient() {
+            return registryClient;
+        }
+
+        public MultiformatDeserializer keyDeserializer() {
+            return keyDeserializer;
+        }
+
+        public MultiformatDeserializer valueDeserializer() {
+            return valueDeserializer;
+        }
+
+        public MultiformatSerializer keySerializer() {
+            return keySerializer;
+        }
+
+        public MultiformatSerializer valueSerializer() {
+            return valueSerializer;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (registryClient != null) {
+                // nothing to close otherwise
+                closeOptionally("key deserializer", keyDeserializer);
+                closeOptionally("value deserializer", valueDeserializer);
+                closeOptionally("key serializer", keySerializer);
+                closeOptionally("value serializer", valueSerializer);
+            }
+        }
+
+        private void closeOptionally(String name, ForceCloseable closeable) {
+            if (closeable != null) {
+                try {
+                    closeable.forceClose();
+                } catch (Exception e) {
+                    LOGGER.infof("Exception closing resource %s: %s", name, e.getMessage());
+                }
+            }
+        }
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -127,8 +127,8 @@ public class KafkaContext implements Closeable {
         return applicationScoped;
     }
 
-    public void schemaRegistryClient(RegistryClient schemaRegistryClient) {
-        schemaRegistryContext = new SchemaRegistryContext(schemaRegistryClient);
+    public void schemaRegistryClient(RegistryClient schemaRegistryClient, ObjectMapper objectMapper) {
+        schemaRegistryContext = new SchemaRegistryContext(schemaRegistryClient, objectMapper);
     }
 
     public SchemaRegistryContext schemaRegistryContext() {
@@ -173,10 +173,8 @@ public class KafkaContext implements Closeable {
         private final MultiformatSerializer keySerializer;
         private final MultiformatSerializer valueSerializer;
 
-        SchemaRegistryContext(RegistryClient schemaRegistryClient) {
+        SchemaRegistryContext(RegistryClient schemaRegistryClient, ObjectMapper objectMapper) {
             this.registryClient = schemaRegistryClient;
-
-            ObjectMapper objectMapper = new ObjectMapper();
 
             keyDeserializer = new MultiformatDeserializer(registryClient, objectMapper);
             keyDeserializer.configure(configs(Consumer.class), true);

--- a/api/src/main/java/com/github/streamshub/console/api/support/factories/ConsoleConfigFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/factories/ConsoleConfigFactory.java
@@ -1,0 +1,110 @@
+package com.github.streamshub.console.api.support.factories;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.github.streamshub.console.api.support.ValidationProxy;
+import com.github.streamshub.console.config.ConsoleConfig;
+
+@Singleton
+public class ConsoleConfigFactory {
+
+    @Inject
+    @ConfigProperty(name = "console.config-path")
+    Optional<String> configPath;
+
+    @Inject
+    Logger log;
+
+    @Inject
+    Config config;
+
+    @Inject
+    ObjectMapper mapper;
+
+    @Inject
+    ValidationProxy validationService;
+
+    @Produces
+    @ApplicationScoped
+    public ConsoleConfig produceConsoleConfig() {
+        return configPath.map(Path::of)
+            .map(Path::toUri)
+            .map(uri -> {
+                try {
+                    return uri.toURL();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            })
+            .filter(Objects::nonNull)
+            .map(url -> {
+                log.infof("Loading console configuration from %s", url);
+                ObjectMapper yamlMapper = mapper.copyWith(new YAMLFactory());
+
+                try (InputStream stream = url.openStream()) {
+                    return yamlMapper.readValue(stream, ConsoleConfig.class);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            })
+            .map(consoleConfig -> {
+                consoleConfig.getSchemaRegistries().forEach(registry -> {
+                    registry.setUrl(resolveValue(registry.getUrl()));
+                });
+
+                consoleConfig.getKafka().getClusters().forEach(cluster -> {
+                    resolveValues(cluster.getProperties());
+                    resolveValues(cluster.getAdminProperties());
+                    resolveValues(cluster.getProducerProperties());
+                    resolveValues(cluster.getConsumerProperties());
+                });
+
+                return consoleConfig;
+            })
+            .map(validationService::validate)
+            .orElseGet(() -> {
+                log.warn("Console configuration has not been specified using `console.config-path` property");
+                return new ConsoleConfig();
+            });
+    }
+
+    private void resolveValues(Map<String, String> properties) {
+        properties.entrySet().forEach(entry ->
+            entry.setValue(resolveValue(entry.getValue())));
+    }
+
+    /**
+     * If the given value is an expression referencing a configuration value,
+     * replace it with the target property value.
+     *
+     * @param value configuration value that may be a reference to another
+     *              configuration property
+     * @return replacement property or the same value if the given string is not a
+     *         reference.
+     */
+    private String resolveValue(String value) {
+        if (value.startsWith("${") && value.endsWith("}")) {
+            String replacement = value.substring(2, value.length() - 1);
+            return config.getOptionalValue(replacement, String.class).orElse(value);
+        }
+
+        return value;
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ArtifactReferences.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ArtifactReferences.java
@@ -17,6 +17,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
 
+/**
+ * Support methods to serialize and deserialize instances of {@link ArtifactReference}
+ * to a string suitable for use as a referencing in a URL.
+ */
 public class ArtifactReferences {
 
     private static final Logger LOGGER = Logger.getLogger(ArtifactReferences.class);

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ArtifactReferences.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ArtifactReferences.java
@@ -1,0 +1,91 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Base64;
+
+import jakarta.ws.rs.NotFoundException;
+
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+
+public class ArtifactReferences {
+
+    private static final Logger LOGGER = Logger.getLogger(ArtifactReferences.class);
+    private static final String GLOBAL_ID = "globalId";
+    private static final String CONTENT_ID = "contentId";
+    private static final String GROUP_ID = "groupId";
+    private static final String ARTIFACT_ID = "artifactId";
+    private static final String VERSION = "version";
+
+    private ArtifactReferences() {
+    }
+
+    public static String toSchemaId(ArtifactReference reference, ObjectMapper objectMapper) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        try (var generator = objectMapper.createGenerator(out)) {
+            generator.writeStartObject();
+            putEntry(generator, GLOBAL_ID, reference.getGlobalId());
+            putEntry(generator, CONTENT_ID, reference.getContentId());
+            putEntry(generator, GROUP_ID, reference.getGroupId());
+            putEntry(generator, ARTIFACT_ID, reference.getArtifactId());
+            putEntry(generator, VERSION, reference.getVersion());
+            generator.writeEndObject();
+            generator.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return Base64.getUrlEncoder().encodeToString(out.toByteArray());
+    }
+
+    public static ArtifactReference fromSchemaId(String schemaId, ObjectMapper objectMapper) {
+        JsonNode id;
+
+        try {
+            InputStream in = new ByteArrayInputStream(Base64.getUrlDecoder().decode(schemaId));
+            id = objectMapper.readTree(in);
+        } catch (IOException e) {
+            LOGGER.debugf("Failed to decode or parse schemaId '%s': %s", schemaId, e.getMessage());
+            throw new NotFoundException("No such schema");
+        }
+
+        var builder = ArtifactReference.builder();
+
+        if (id.has(GLOBAL_ID)) {
+            builder.globalId(id.get(GLOBAL_ID).asLong());
+        }
+        if (id.has(CONTENT_ID)) {
+            builder.contentId(id.get(CONTENT_ID).asLong());
+        }
+        if (id.has(GROUP_ID)) {
+            builder.groupId(id.get(GROUP_ID).asText());
+        }
+        if (id.has(ARTIFACT_ID)) {
+            builder.artifactId(id.get(ARTIFACT_ID).asText());
+        }
+        if (id.has(VERSION)) {
+            builder.version(id.get(VERSION).asText());
+        }
+
+        return builder.build();
+    }
+
+    static void putEntry(JsonGenerator generator, String key, Object value) throws IOException {
+        if (value instanceof String str) {
+            generator.writeStringField(key, str);
+        } else if (value instanceof Long nbr && nbr != 0) {
+            generator.writeNumberField(key, nbr);
+        }
+    }
+
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDatumProvider.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDatumProvider.java
@@ -1,0 +1,72 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+
+import io.apicurio.registry.serde.avro.DefaultAvroDatumProvider;
+
+public class AvroDatumProvider extends DefaultAvroDatumProvider<RecordData> {
+    @Override
+    public DatumWriter<RecordData> createDatumWriter(RecordData data, Schema schema) {
+        GenericDatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+
+        return new DatumWriter<RecordData>() {
+            @Override
+            public void write(RecordData data, org.apache.avro.io.Encoder out) throws IOException {
+                final DatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
+                final InputStream dataStream = new ByteArrayInputStream(data.data);
+                final Decoder jsonDecoder = DecoderFactory.get().jsonDecoder(schema, dataStream);
+                final Object datum = reader.read(null, jsonDecoder);
+                writer.write(datum, out);
+
+                final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                final Encoder jsonEncoder = EncoderFactory.get().jsonEncoder(schema, buffer);
+                writer.write(datum, jsonEncoder);
+                jsonEncoder.flush();
+                data.data = buffer.toByteArray();
+            }
+
+            @Override
+            public void setSchema(Schema schema) {
+                // No-op
+            }
+        };
+    }
+
+    @Override
+    public DatumReader<RecordData> createDatumReader(Schema schema) {
+        GenericDatumReader<Object> target = new GenericDatumReader<>(schema);
+
+        return new DatumReader<RecordData>() {
+            @Override
+            public RecordData read(RecordData reuse, Decoder in) throws IOException {
+                final Object datum = target.read(reuse, in);
+                final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                final DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+                final Encoder jsonEncoder = EncoderFactory.get().jsonEncoder(schema, buffer);
+                writer.write(datum, jsonEncoder);
+                jsonEncoder.flush();
+
+                return new RecordData(buffer.toByteArray(), null);
+            }
+
+            @Override
+            public void setSchema(Schema schema) {
+                // No-op
+            }
+        };
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDatumProvider.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDatumProvider.java
@@ -32,6 +32,11 @@ public class AvroDatumProvider extends DefaultAvroDatumProvider<RecordData> {
                 final Object datum = reader.read(null, jsonDecoder);
                 writer.write(datum, out);
 
+                /*
+                 * Replace input data with the re-seralized record so response contains
+                 * the data as it was sent to Kafka (but in JSON format). For example,
+                 * unknown fields will have been dropped.
+                 */
                 final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
                 final Encoder jsonEncoder = EncoderFactory.get().jsonEncoder(schema, buffer);
                 writer.write(datum, jsonEncoder);

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDatumProvider.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDatumProvider.java
@@ -18,6 +18,10 @@ import org.apache.avro.io.EncoderFactory;
 
 import io.apicurio.registry.serde.avro.DefaultAvroDatumProvider;
 
+/**
+ * Provides a reader and writer to convert JSON to and from Avro format using a provided
+ * Avro schema.
+ */
 public class AvroDatumProvider extends DefaultAvroDatumProvider<RecordData> {
     @Override
     public DatumWriter<RecordData> createDatumWriter(RecordData data, Schema schema) {
@@ -65,7 +69,7 @@ public class AvroDatumProvider extends DefaultAvroDatumProvider<RecordData> {
                 writer.write(datum, jsonEncoder);
                 jsonEncoder.flush();
 
-                return new RecordData(buffer.toByteArray(), null);
+                return new RecordData(buffer.toByteArray());
             }
 
             @Override

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDeserializer.java
@@ -9,6 +9,10 @@ import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
 
+/**
+ * Simple subclass of {@link AvroKafkaDeserializer} to make the {@code readData}
+ * methods public.
+ */
 class AvroDeserializer extends AvroKafkaDeserializer<RecordData> {
     AvroDeserializer(SchemaResolver<Schema, RecordData> schemaResolver) {
         super();

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/AvroDeserializer.java
@@ -1,0 +1,31 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.nio.ByteBuffer;
+
+import org.apache.avro.Schema;
+import org.apache.kafka.common.header.Headers;
+
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+
+class AvroDeserializer extends AvroKafkaDeserializer<RecordData> {
+    AvroDeserializer(SchemaResolver<Schema, RecordData> schemaResolver) {
+        super();
+        setSchemaResolver(schemaResolver);
+    }
+
+    @Override
+    public RecordData readData(ParsedSchema<Schema> schema, ByteBuffer buffer, int start, int length) {
+        return super.readData(schema, buffer, start, length);
+    }
+
+    @Override
+    public RecordData readData(Headers headers,
+            ParsedSchema<Schema> schema,
+            ByteBuffer buffer,
+            int start,
+            int length) {
+        return super.readData(headers, schema, buffer, start, length);
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ForceCloseable.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ForceCloseable.java
@@ -2,6 +2,12 @@ package com.github.streamshub.console.api.support.serdes;
 
 import java.io.IOException;
 
+/**
+ * The de-/serializers in this package are re-used between requests and have made
+ * their {@code close} methods no-ops. This interface is implemented by each to perform
+ * the actual close operations when a {@link com.github.streamshub.console.api.support.KafkaContext}
+ * is disposed.
+ */
 public interface ForceCloseable {
 
     void forceClose() throws IOException;

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ForceCloseable.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ForceCloseable.java
@@ -1,0 +1,9 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.IOException;
+
+public interface ForceCloseable {
+
+    void forceClose() throws IOException;
+
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatDeserializer.java
@@ -89,8 +89,8 @@ public class MultiformatDeserializer extends AbstractKafkaDeserializer<Object, R
         protobufDeserializer.configure(protobufConfigs, isKey);
 
         parser = new MultiformatSchemaParser<>(Set.of(
-            avroDeserializer.schemaParser(),
-            protobufDeserializer.schemaParser()
+            cast(avroDeserializer.schemaParser()),
+            cast(protobufDeserializer.schemaParser())
         ));
 
         super.configure(new BaseKafkaSerDeConfig(configs), isKey);

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatDeserializer.java
@@ -1,0 +1,239 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.avro.Schema;
+import org.apache.kafka.common.header.Headers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+
+import io.apicurio.registry.resolver.DefaultSchemaResolver;
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.SchemaLookupResult;
+import io.apicurio.registry.resolver.SchemaParser;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.serde.AbstractKafkaDeserializer;
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.avro.AvroKafkaSerdeConfig;
+import io.apicurio.registry.serde.config.BaseKafkaSerDeConfig;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
+
+public class MultiformatDeserializer extends AbstractKafkaDeserializer<Object, RecordData> implements ForceCloseable {
+
+    private static final SchemaLookupResult<Object> EMPTY_RESULT = SchemaLookupResult.builder().build();
+
+    private final ObjectMapper objectMapper;
+    AvroDeserializer avroDeserializer;
+    ProtobufDeserializer protobufDeserializer;
+    SchemaParser<Object, RecordData> parser;
+
+    public MultiformatDeserializer(RegistryClient client, ObjectMapper objectMapper) {
+        super();
+        this.objectMapper = objectMapper;
+
+        if (client != null) {
+            setSchemaResolver(newResolver(client));
+            avroDeserializer = new AvroDeserializer(newResolver(client));
+            protobufDeserializer = new ProtobufDeserializer(newResolver(client));
+        }
+    }
+
+    static <S, D> SchemaResolver<S, D> newResolver(RegistryClient client) {
+        var resolver = new DefaultSchemaResolver<S, D>();
+        resolver.setClient(client);
+        return resolver;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (getSchemaResolver() == null) {
+            // Do not attempt to configure anything if we will not be making remote calls to registry
+            return;
+        }
+
+        Map<String, Object> avroConfigs = new HashMap<>(configs);
+        avroConfigs.put(AvroKafkaSerdeConfig.AVRO_DATUM_PROVIDER, AvroDatumProvider.class.getName());
+        avroDeserializer.configure(avroConfigs, isKey);
+
+        Map<String, Object> protobufConfigs = new HashMap<>(configs);
+        protobufConfigs.put(SerdeConfig.DESERIALIZER_SPECIFIC_KEY_RETURN_CLASS, DynamicMessage.class);
+        protobufConfigs.put(SerdeConfig.DESERIALIZER_SPECIFIC_VALUE_RETURN_CLASS, DynamicMessage.class);
+        protobufDeserializer.configure(protobufConfigs, isKey);
+
+        parser = new MultiformatSchemaParser<>(Set.of(
+            avroDeserializer.schemaParser(),
+            protobufDeserializer.schemaParser()
+        ));
+
+        super.configure(new BaseKafkaSerDeConfig(configs), isKey);
+    }
+
+    @Override
+    public void close() {
+        // don't close - deserializer will be reused
+    }
+
+    public void forceClose() {
+        super.close();
+    }
+
+    @Override
+    public SchemaParser<Object, RecordData> schemaParser() {
+        return parser;
+    }
+
+    protected RecordData readData(Headers headers, SchemaLookupResult<Object> schemaResult, ByteBuffer buffer, int start, int length) {
+        ParsedSchema<Object> schema = Optional.ofNullable(schemaResult)
+                .map(s -> s.getParsedSchema())
+                .orElse(null);
+        Object parsedSchema = null;
+
+        if (schemaResult != null && schemaResult.getParsedSchema() != null) {
+            parsedSchema = schemaResult.getParsedSchema().getParsedSchema();
+        }
+
+        RecordData result;
+
+        if (parsedSchema instanceof Schema avroSchema) {
+            try {
+                if (headers != null) {
+                    result = avroDeserializer.readData(headers, cast(schema), buffer, start, length);
+                } else {
+                    result = avroDeserializer.readData(cast(schema), buffer, start, length);
+                }
+                result.schema = schema;
+                result.meta.put("schema-type", ArtifactType.AVRO);
+                result.meta.put("schema-id", ArtifactReferences.toSchemaId(schemaResult.toArtifactReference(), objectMapper));
+                result.meta.put("schema-name", avroSchema.getFullName());
+            } catch (Exception e) {
+                result = new RecordData(null, schema);
+                result.meta.put("error", e.getMessage());
+            }
+        } else if (parsedSchema instanceof ProtobufSchema) {
+            try {
+                Message msg;
+                if (headers != null) {
+                    msg = protobufDeserializer.readData(headers, cast(schema), buffer, start, length);
+                } else {
+                    msg = protobufDeserializer.readData(cast(schema), buffer, start, length);
+                }
+                byte[] data = com.google.protobuf.util.JsonFormat.printer()
+                        .omittingInsignificantWhitespace()
+                        .print(msg)
+                        .getBytes();
+                result = new RecordData(data, schema);
+                result.meta.put("schema-type", ArtifactType.PROTOBUF);
+                result.meta.put("schema-id", ArtifactReferences.toSchemaId(schemaResult.toArtifactReference(), objectMapper));
+                result.meta.put("schema-name", msg.getDescriptorForType().getFullName());
+            } catch (Exception e) {
+                result = new RecordData(null, schema);
+                result.meta.put("error", e.getMessage());
+            }
+        } else {
+            byte[] bytes = new byte[length];
+            System.arraycopy(buffer.array(), start, bytes, 0, length);
+            result = new RecordData(bytes, null);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T cast(Object object) {
+        return (T) object;
+    }
+
+    @Override
+    public RecordData deserialize(String topic, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        ByteBuffer buffer;
+        SchemaLookupResult<Object> schema;
+        int length;
+
+        if (data[0] == MAGIC_BYTE) {
+            buffer = getByteBuffer(data);
+            ArtifactReference artifactReference = getIdHandler().readId(buffer);
+            schema = resolve(artifactReference);
+            length = buffer.limit() - 1 - getIdHandler().idSize();
+        } else {
+            buffer = ByteBuffer.wrap(data);
+            // Empty schema
+            schema = EMPTY_RESULT;
+            length = buffer.limit() - 1;
+        }
+
+        int start = buffer.position() + buffer.arrayOffset();
+
+        return readData(null, schema, buffer, start, length);
+    }
+
+    @Override
+    public RecordData deserialize(String topic, Headers headers, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        ArtifactReference artifactReference = null;
+        if (headersHandler != null && headers != null) {
+            artifactReference = headersHandler.readHeaders(headers);
+
+            if (artifactReference.hasValue()) {
+                return readData(headers, data, artifactReference);
+            }
+        }
+
+        if (headers == null) {
+            return deserialize(topic, data);
+        } else {
+            //try to read data even if artifactReference has no value, maybe there is a fallbackArtifactProvider configured
+            return readData(headers, data, artifactReference);
+        }
+    }
+
+    private RecordData readData(Headers headers, byte[] data, ArtifactReference artifactReference) {
+        SchemaLookupResult<Object> schema = resolve(artifactReference);
+
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        int length = buffer.limit();
+        int start = buffer.position();
+
+        return readData(headers, schema, buffer, start, length);
+    }
+
+    private SchemaLookupResult<Object> resolve(ArtifactReference artifactReference) {
+        var schemaResolver = getSchemaResolver();
+
+        if (schemaResolver == null) {
+            // Empty result
+            return EMPTY_RESULT;
+        }
+
+        try {
+            return getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
+        } catch (RuntimeException e) {
+            // Empty result
+            return EMPTY_RESULT;
+        }
+    }
+
+    @Override
+    protected RecordData readData(ParsedSchema<Object> schema, ByteBuffer buffer, int start, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected RecordData readData(Headers headers, ParsedSchema<Object> schema, ByteBuffer buffer, int start, int length) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSchemaParser.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSchemaParser.java
@@ -1,11 +1,5 @@
 package com.github.streamshub.console.api.support.serdes;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -13,25 +7,15 @@ import java.util.stream.Collectors;
 import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaParser;
 import io.apicurio.registry.resolver.data.Record;
-import io.apicurio.registry.types.ArtifactType;
 
 /**
  * Schema parser that delegates to either the Avro or Protobuf schema parser.
- * This class attempts to sniff the schema's type using a primitive check for a
- * Protobuf message header.
- *
- * This class can likely be improved with more a advanced/accurate detection
- * process.
  */
 public class MultiformatSchemaParser<D> implements SchemaParser<Object, D> {
 
-    private static final int CACHE_LIMIT = 20;
-    private static final char[] PROTOBUF_INTRO = "message ".toCharArray();
+    private final Map<String, SchemaParser<Object, ?>> delegates;
 
-    private final Map<String, SchemaParser<?, ?>> delegates;
-    private final Map<byte[], Object> schemaCache = new LinkedHashMap<>(CACHE_LIMIT);
-
-    public MultiformatSchemaParser(Set<SchemaParser<?, ?>> delegates) {
+    public MultiformatSchemaParser(Set<SchemaParser<Object, ?>> delegates) {
         this.delegates = delegates.stream()
                 .map(p -> Map.entry(p.artifactType(), p))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -42,24 +26,25 @@ public class MultiformatSchemaParser<D> implements SchemaParser<Object, D> {
         throw new UnsupportedOperationException("MultiformatSchemaParser#artifactType()");
     }
 
+    /**
+     * Parse the raw schema bytes to a format-specific schema object using the
+     * {@link #delegates} known to this parser. If none of the delegates are able to
+     * parse the schema, this method will return null.
+     *
+     * @return a parsed schema model object or null if the raw schema cannot be
+     *         parsed by one of the delegates.
+     */
     @Override
     public Object parseSchema(byte[] rawSchema, Map<String, ParsedSchema<Object>> resolvedReferences) {
-        if (schemaCache.containsKey(rawSchema)) {
-            return schemaCache.get(rawSchema);
+        for (SchemaParser<Object, ?> delegate : delegates.values()) {
+            try {
+                return delegate.parseSchema(rawSchema, resolvedReferences);
+            } catch (Exception e) {
+                // Schema is not valid for the delegate parser
+            }
         }
 
-        Object parsedSchema = loadSchema(rawSchema, resolvedReferences);
-
-        if (schemaCache.size() == CACHE_LIMIT) {
-            // Remove the oldest entry
-            var iter = schemaCache.entrySet().iterator();
-            iter.next();
-            iter.remove();
-        }
-
-        schemaCache.put(rawSchema, parsedSchema);
-
-        return parsedSchema;
+        return null;
     }
 
     @Override
@@ -75,48 +60,5 @@ public class MultiformatSchemaParser<D> implements SchemaParser<Object, D> {
     @Override
     public ParsedSchema<Object> getSchemaFromData(Record<D> data, boolean dereference) {
         throw new UnsupportedOperationException("MultiformatSchemaParser#getSchemaFromData(Record,boolean)");
-    }
-
-    @SuppressWarnings("unchecked")
-    Object loadSchema(byte[] rawSchema, Map<String, ParsedSchema<Object>> resolvedReferences) {
-        Object parsedSchema = null;
-        SchemaParser<Object, RecordData> delegate = null;
-
-        if (delegates.containsKey(ArtifactType.PROTOBUF) && looksLikeProtobuf(rawSchema)) {
-            delegate = (SchemaParser<Object, RecordData>) delegates.get(ArtifactType.PROTOBUF);
-        } else if (delegates.containsKey(ArtifactType.AVRO)) {
-            delegate = (SchemaParser<Object, RecordData>) delegates.get(ArtifactType.AVRO);
-        }
-
-        if (delegate != null) {
-            try {
-                parsedSchema = delegate.parseSchema(rawSchema, resolvedReferences);
-            } catch (Exception e) {
-                // Schema is not valid, will be cached as null
-            }
-        }
-
-        return parsedSchema;
-    }
-
-    boolean looksLikeProtobuf(byte[] rawSchema) {
-        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(rawSchema))) {
-            int input;
-
-            while ((input = reader.read()) != -1) {
-                if (Character.isWhitespace(input)) {
-                    continue;
-                }
-                char[] buffer = new char[8];
-                buffer[0] = (char) input;
-
-                if (reader.read(buffer, 1, 7) == 7 && Arrays.equals(PROTOBUF_INTRO, buffer)) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            // Ignore
-        }
-        return false;
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSchemaParser.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSchemaParser.java
@@ -1,0 +1,114 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.SchemaParser;
+import io.apicurio.registry.resolver.data.Record;
+import io.apicurio.registry.types.ArtifactType;
+
+public class MultiformatSchemaParser<D> implements SchemaParser<Object, D> {
+
+    private static final int CACHE_LIMIT = 20;
+    private static final char[] PROTOBUF_INTRO = "message ".toCharArray();
+
+    private final Map<String, SchemaParser<?, ?>> delegates;
+    private final Map<byte[], Object> schemaCache = new LinkedHashMap<>(CACHE_LIMIT);
+
+    public MultiformatSchemaParser(Set<SchemaParser<?, ?>> delegates) {
+        this.delegates = delegates.stream()
+                .map(p -> Map.entry(p.artifactType(), p))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public String artifactType() {
+        throw new UnsupportedOperationException("MultiformatSchemaParser#artifactType()");
+    }
+
+    @Override
+    public Object parseSchema(byte[] rawSchema, Map<String, ParsedSchema<Object>> resolvedReferences) {
+        if (schemaCache.containsKey(rawSchema)) {
+            return schemaCache.get(rawSchema);
+        }
+
+        Object parsedSchema = loadSchema(rawSchema, resolvedReferences);
+
+        if (schemaCache.size() == CACHE_LIMIT) {
+            // Remove the oldest entry
+            var iter = schemaCache.entrySet().iterator();
+            iter.next();
+            iter.remove();
+        }
+
+        schemaCache.put(rawSchema, parsedSchema);
+
+        return parsedSchema;
+    }
+
+    @Override
+    public boolean supportsExtractSchemaFromData() {
+        return false;
+    }
+
+    @Override
+    public ParsedSchema<Object> getSchemaFromData(Record<D> data) {
+        throw new UnsupportedOperationException("MultiformatSchemaParser#getSchemaFromData(Record)");
+    }
+
+    @Override
+    public ParsedSchema<Object> getSchemaFromData(Record<D> data, boolean dereference) {
+        throw new UnsupportedOperationException("MultiformatSchemaParser#getSchemaFromData(Record,boolean)");
+    }
+
+    @SuppressWarnings("unchecked")
+    Object loadSchema(byte[] rawSchema, Map<String, ParsedSchema<Object>> resolvedReferences) {
+        Object parsedSchema = null;
+        SchemaParser<Object, RecordData> delegate = null;
+
+        if (delegates.containsKey(ArtifactType.PROTOBUF) && looksLikeProtobuf(rawSchema)) {
+            delegate = (SchemaParser<Object, RecordData>) delegates.get(ArtifactType.PROTOBUF);
+        } else if (delegates.containsKey(ArtifactType.AVRO)) {
+            delegate = (SchemaParser<Object, RecordData>) delegates.get(ArtifactType.AVRO);
+        }
+
+        if (delegate != null) {
+            try {
+                parsedSchema = delegate.parseSchema(rawSchema, resolvedReferences);
+            } catch (Exception e) {
+                // Schema is not valid, will be cached as null
+            }
+        }
+
+        return parsedSchema;
+    }
+
+    boolean looksLikeProtobuf(byte[] rawSchema) {
+        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(rawSchema))) {
+            int input;
+
+            while ((input = reader.read()) != -1) {
+                if (Character.isWhitespace(input)) {
+                    continue;
+                }
+                char[] buffer = new char[8];
+                buffer[0] = (char) input;
+
+                if (reader.read(buffer, 1, 7) == 7 && Arrays.equals(PROTOBUF_INTRO, buffer)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            // Ignore
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSchemaParser.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSchemaParser.java
@@ -15,6 +15,14 @@ import io.apicurio.registry.resolver.SchemaParser;
 import io.apicurio.registry.resolver.data.Record;
 import io.apicurio.registry.types.ArtifactType;
 
+/**
+ * Schema parser that delegates to either the Avro or Protobuf schema parser.
+ * This class attempts to sniff the schema's type using a primitive check for a
+ * Protobuf message header.
+ *
+ * This class can likely be improved with more a advanced/accurate detection
+ * process.
+ */
 public class MultiformatSchemaParser<D> implements SchemaParser<Object, D> {
 
     private static final int CACHE_LIMIT = 20;

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
@@ -37,6 +37,15 @@ import io.apicurio.registry.serde.data.KafkaSerdeRecord;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
 
+/**
+ * Serializer that supports writing Avro, Protobuf, and raw bytes.
+ *
+ * This serializer requires that the input data has provided a GAV
+ * (groupId/artifactId/version) for the target schema, otherwise it will pass
+ * through the input untouched. If the provided GAV can be found in the Apicurio
+ * Registry, the schema will be used to serialize to either Avro or Protobuf
+ * depending on the schema type.
+ */
 public class MultiformatSerializer extends AbstractKafkaSerializer<Object, RecordData> implements ArtifactReferenceResolverStrategy<Object, RecordData>, ForceCloseable {
 
     private static final SchemaLookupResult<Object> EMPTY_RESULT = SchemaLookupResult.builder().build();

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
@@ -67,7 +67,8 @@ public class MultiformatSerializer extends AbstractKafkaSerializer<Object, Recor
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         if (getSchemaResolver() == null) {
-            // Do not attempt to configure anything if we will not be making remote calls to registry
+            key = isKey;
+            // Do not attempt to configure anything more if we will not be making remote calls to registry
             return;
         }
 

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
@@ -95,8 +95,8 @@ public class MultiformatSerializer extends AbstractKafkaSerializer<Object, Recor
         protobufSerializer.configure(protobufConfigs, isKey);
 
         parser = new MultiformatSchemaParser<>(Set.of(
-            avroSerializer.schemaParser(),
-            protobufSerializer.schemaParser()
+            cast(avroSerializer.schemaParser()),
+            cast(protobufSerializer.schemaParser())
         ));
 
         super.configure(new BaseKafkaSerDeConfig(serConfigs), isKey);

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatSerializer.java
@@ -1,0 +1,239 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.ws.rs.BadRequestException;
+
+import org.apache.avro.Schema;
+import org.apache.kafka.common.header.Headers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+
+import io.apicurio.registry.resolver.DefaultSchemaResolver;
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.SchemaLookupResult;
+import io.apicurio.registry.resolver.SchemaParser;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.resolver.SchemaResolverConfig;
+import io.apicurio.registry.resolver.data.Record;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.serde.AbstractKafkaSerializer;
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.avro.AvroKafkaSerdeConfig;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.config.BaseKafkaSerDeConfig;
+import io.apicurio.registry.serde.data.KafkaSerdeMetadata;
+import io.apicurio.registry.serde.data.KafkaSerdeRecord;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
+
+public class MultiformatSerializer extends AbstractKafkaSerializer<Object, RecordData> implements ArtifactReferenceResolverStrategy<Object, RecordData>, ForceCloseable {
+
+    private static final SchemaLookupResult<Object> EMPTY_RESULT = SchemaLookupResult.builder().build();
+
+    final ObjectMapper objectMapper;
+    AvroKafkaSerializer<RecordData> avroSerializer;
+    ProtobufSerializer protobufSerializer;
+    SchemaParser<Object, RecordData> parser;
+
+    public MultiformatSerializer(RegistryClient client, ObjectMapper objectMapper) {
+        super();
+        this.objectMapper = objectMapper;
+
+        if (client != null) {
+            setSchemaResolver(newResolver(client));
+            avroSerializer = new AvroKafkaSerializer<>();
+            avroSerializer.setSchemaResolver(newResolver(client));
+            protobufSerializer = new ProtobufSerializer(newResolver(client));
+        }
+    }
+
+    static <S, D> SchemaResolver<S, D> newResolver(RegistryClient client) {
+        var resolver = new DefaultSchemaResolver<S, D>();
+        resolver.setClient(client);
+        return resolver;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (getSchemaResolver() == null) {
+            // Do not attempt to configure anything if we will not be making remote calls to registry
+            return;
+        }
+
+        Map<String, Object> serConfigs = new HashMap<>(configs);
+        serConfigs.put(SchemaResolverConfig.ARTIFACT_RESOLVER_STRATEGY, this);
+
+        Map<String, Object> avroConfigs = new HashMap<>(serConfigs);
+        avroConfigs.put(AvroKafkaSerdeConfig.AVRO_DATUM_PROVIDER, AvroDatumProvider.class.getName());
+        avroConfigs.put(SchemaResolverConfig.FIND_LATEST_ARTIFACT, Boolean.TRUE);
+        avroSerializer.configure(avroConfigs, isKey);
+
+        Map<String, Object> protobufConfigs = new HashMap<>(serConfigs);
+        protobufConfigs.put(SchemaResolverConfig.FIND_LATEST_ARTIFACT, Boolean.TRUE);
+        protobufConfigs.put(SerdeConfig.VALIDATION_ENABLED, Boolean.TRUE);
+        protobufSerializer.configure(protobufConfigs, isKey);
+
+        parser = new MultiformatSchemaParser<>(Set.of(
+            avroSerializer.schemaParser(),
+            protobufSerializer.schemaParser()
+        ));
+
+        super.configure(new BaseKafkaSerDeConfig(serConfigs), isKey);
+    }
+
+    @Override
+    public void close() {
+        // don't close - serializer will be reused
+    }
+
+    public void forceClose() {
+        super.close();
+    }
+
+    @Override
+    public SchemaParser<Object, RecordData> schemaParser() {
+        return parser;
+    }
+
+    @Override
+    public byte[] serialize(String topic, Headers headers, RecordData data) {
+        // just return null
+        if (data == null) {
+            return null; // NOSONAR - we want to return null and not an empty array
+        }
+
+        SchemaLookupResult<Object> schema = resolveSchema(topic, headers, data);
+        Object parsedSchema = null;
+
+        if (schema != null && schema.getParsedSchema() != null) {
+            parsedSchema = schema.getParsedSchema().getParsedSchema();
+        }
+
+        byte[] serialized;
+
+        if (parsedSchema instanceof Schema avroSchema) {
+            try {
+                serialized = avroSerializer.serialize(topic, headers, data);
+                setSchemaMeta(data, schema, ArtifactType.AVRO, avroSchema.getFullName());
+            } catch (Exception e) {
+                throw new BadRequestException(e.getMessage(), e);
+            }
+        } else if (parsedSchema instanceof ProtobufSchema protobufSchema) {
+            Message msg;
+            String schemaRef = schemaMeta(data, "schema-gav").orElseThrow(); // we know it's non-null because we have a schema
+            String messageType = schemaMeta(data, "message-type").orElse(null);
+            Descriptor descriptor;
+
+            if (messageType != null) {
+                descriptor = protobufSchema.getFileDescriptor().findMessageTypeByName(messageType);
+                if (descriptor == null) {
+                    throw new BadRequestException("No such message type %s for schema %s"
+                            .formatted(messageType, schemaRef));
+                }
+            } else if (protobufSchema.getFileDescriptor().getMessageTypes().size() == 1) {
+                descriptor = protobufSchema.getFileDescriptor().getMessageTypes().get(0);
+            } else {
+                throw new BadRequestException("Unable to determine message type to use from schema %s"
+                        .formatted(schemaRef));
+            }
+
+            try {
+                var builder = DynamicMessage.newBuilder(descriptor);
+                com.google.protobuf.util.JsonFormat.parser()
+                    .ignoringUnknownFields()
+                    .merge(data.dataString(null), builder);
+                msg = builder.build();
+            } catch (InvalidProtocolBufferException e) {
+                throw new BadRequestException(e.getMessage(), e);
+            }
+
+            serialized = protobufSerializer.serialize(headers, msg, cast(schema));
+            setSchemaMeta(data, schema, ArtifactType.PROTOBUF, descriptor.getFullName());
+        } else {
+            data.meta.remove("schema"); // Remove schema meta so it is not returned with 201 response
+            serialized = data.data;
+        }
+
+        return serialized;
+    }
+
+    SchemaLookupResult<Object> resolveSchema(String topic, Headers headers, RecordData data) {
+        if (getSchemaResolver() == null) {
+            return EMPTY_RESULT;
+        }
+
+        KafkaSerdeMetadata resolverMetadata = new KafkaSerdeMetadata(topic, isKey(), headers);
+        var reference = artifactReference(new KafkaSerdeRecord<>(resolverMetadata, data), null);
+        SchemaLookupResult<Object> schema = null;
+
+        if (reference != null) {
+            try {
+                schema = getSchemaResolver().resolveSchemaByArtifactReference(reference);
+            } catch (Exception e) {
+                schema = EMPTY_RESULT;
+            }
+        }
+
+        return schema;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T cast(Object object) {
+        return (T) object;
+    }
+
+    private void setSchemaMeta(RecordData data, SchemaLookupResult<Object> schema, String type, String name) {
+        String id = ArtifactReferences.toSchemaId(schema.toArtifactReference(), objectMapper);
+
+        data.meta.put("schema-type", type);
+        data.meta.put("schema-id", id);
+        data.meta.put("schema-name", name);
+    }
+
+    @Override
+    public ArtifactReference artifactReference(Record<RecordData> data, ParsedSchema<Object> parsedSchema) {
+        KafkaSerdeRecord<RecordData> kdata = (KafkaSerdeRecord<RecordData>) data;
+        RecordData rData = kdata.payload();
+
+        return schemaMeta(rData, "schema-gav")
+            .map(schemaRef -> {
+                String[] gav = schemaRef.split(":");
+                return ArtifactReference.builder()
+                        .groupId(gav[0])
+                        .artifactId(gav[1])
+                        .version(gav.length > 2 ? gav[2] : null)
+                        .build();
+            })
+            .orElse(null);
+    }
+
+    private Optional<String> schemaMeta(RecordData data, String metaProperty) {
+        return Optional.ofNullable(data.meta.get(metaProperty));
+    }
+
+    @Override
+    public boolean loadSchema() {
+        return false;
+    }
+
+    @Override
+    protected void serializeData(ParsedSchema<Object> schema, RecordData data, OutputStream out) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void serializeData(Headers headers, ParsedSchema<Object> schema, RecordData data, OutputStream out) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufDeserializer.java
@@ -11,6 +11,10 @@ import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.serde.protobuf.ProtobufKafkaDeserializer;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
 
+/**
+ * Simple subclass of {@link ProtobufKafkaDeserializer} to make the
+ * {@code readData} methods public.
+ */
 class ProtobufDeserializer extends ProtobufKafkaDeserializer<Message> {
     ProtobufDeserializer(SchemaResolver<ProtobufSchema, Message> schemaResolver) {
         super();

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufDeserializer.java
@@ -1,0 +1,33 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.header.Headers;
+
+import com.google.protobuf.Message;
+
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.serde.protobuf.ProtobufKafkaDeserializer;
+import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
+
+class ProtobufDeserializer extends ProtobufKafkaDeserializer<Message> {
+    ProtobufDeserializer(SchemaResolver<ProtobufSchema, Message> schemaResolver) {
+        super();
+        setSchemaResolver(schemaResolver);
+    }
+
+    @Override
+    public Message readData(ParsedSchema<ProtobufSchema> schema, ByteBuffer buffer, int start, int length) {
+        return super.readData(schema, buffer, start, length);
+    }
+
+    @Override
+    public Message readData(Headers headers,
+            ParsedSchema<ProtobufSchema> schema,
+            ByteBuffer buffer,
+            int start,
+            int length) {
+        return super.readData(headers, schema, buffer, start, length);
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufSerializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufSerializer.java
@@ -10,9 +10,17 @@ import com.google.protobuf.Message;
 
 import io.apicurio.registry.resolver.SchemaLookupResult;
 import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.serde.AbstractKafkaSerializer;
 import io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
 
+/**
+ * This serializer is required to provide a {@code serialize} method to be used
+ * instead of {@link AbstractKafkaSerializer#serialize(String, Headers, Object)}
+ * where the schema is provided, rather than resolved. We have already resolved
+ * the schema when this serializer is invoked in order to determine that the
+ * message type should be Protobuf.
+ */
 class ProtobufSerializer extends ProtobufKafkaSerializer<Message> {
     ProtobufSerializer(SchemaResolver<ProtobufSchema, Message> schemaResolver) {
         super();

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufSerializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ProtobufSerializer.java
@@ -1,0 +1,44 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.apache.kafka.common.header.Headers;
+
+import com.google.protobuf.Message;
+
+import io.apicurio.registry.resolver.SchemaLookupResult;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer;
+import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
+
+class ProtobufSerializer extends ProtobufKafkaSerializer<Message> {
+    ProtobufSerializer(SchemaResolver<ProtobufSchema, Message> schemaResolver) {
+        super();
+        setSchemaResolver(schemaResolver);
+    }
+
+    public byte[] serialize(Headers headers, Message data, SchemaLookupResult<ProtobufSchema> schema) {
+        // just return null
+        if (data == null) {
+            return null; // NOSONAR
+        }
+
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            if (headersHandler != null && headers != null) {
+                headersHandler.writeHeaders(headers, schema.toArtifactReference());
+                serializeData(headers, schema.getParsedSchema(), data, out);
+            } else {
+                out.write(MAGIC_BYTE);
+                getIdHandler().writeId(schema.toArtifactReference(), out);
+                serializeData(schema.getParsedSchema(), data, out);
+            }
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
@@ -38,10 +38,28 @@ public class RecordData {
         return error;
     }
 
+    /**
+     * Convert this instance's {@link RecordData#data data} bytes to a string
+     * Optionally, the length of the string will be limited to maxValueLength. When
+     * invalid characters are detected, the result is replaced with the value of
+     * {@link #BINARY_DATA_MESSAGE}.
+     *
+     * @param maxValueLength maximum length of the result string
+     * @return the record's data bytes as a string
+     */
     public String dataString(Integer maxValueLength) {
         return bytesToString(data, maxValueLength);
     }
 
+    /**
+     * Convert the given bytes to a string Optionally, the length of the string will
+     * be limited to maxValueLength. When invalid characters are detected, the
+     * result is replaced with the value of {@link #BINARY_DATA_MESSAGE}.
+     *
+     * @param bytes          byte array to be converted to a string
+     * @param maxValueLength maximum length of the result string
+     * @return the record's data bytes as a string
+     */
     public static String bytesToString(byte[] bytes, Integer maxValueLength) {
         if (bytes == null) {
             return null;

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
@@ -8,8 +8,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import io.apicurio.registry.resolver.ParsedSchema;
-
+/**
+ * The multi-format de-/serializer uses this type as both the key and value in
+ * order to provide a bi-directional flow of information. Meta information about
+ * the associated schema is passed between clients of Producer/Consumer and the
+ * serializer/de-serializer, and error information may also be conveyed back to
+ * the client without throwing an exception and disrupting the processing of the
+ * topic.
+ */
 public class RecordData {
 
     public static final String BINARY_DATA_MESSAGE = "Binary or non-UTF-8 encoded data cannot be displayed";
@@ -17,27 +23,15 @@ public class RecordData {
 
     public final Map<String, String> meta = new LinkedHashMap<>(1);
     byte[] data;
-    ParsedSchema<?> schema;
     com.github.streamshub.console.api.model.Error error;
-
-    public RecordData(byte[] data, ParsedSchema<?> schema) {
-        super();
-        this.data = data;
-        this.schema = schema;
-    }
 
     public RecordData(byte[] data) {
         super();
         this.data = data;
-        this.schema = null;
     }
 
     public RecordData(String data) {
         this(data != null ? data.getBytes(StandardCharsets.UTF_8) : null);
-    }
-
-    public ParsedSchema<?> schema() {
-        return schema;
     }
 
     public com.github.streamshub.console.api.model.Error error() {

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
@@ -18,6 +18,7 @@ public class RecordData {
     public final Map<String, String> meta = new LinkedHashMap<>(1);
     byte[] data;
     ParsedSchema<?> schema;
+    com.github.streamshub.console.api.model.Error error;
 
     public RecordData(byte[] data, ParsedSchema<?> schema) {
         super();
@@ -37,6 +38,10 @@ public class RecordData {
 
     public ParsedSchema<?> schema() {
         return schema;
+    }
+
+    public com.github.streamshub.console.api.model.Error error() {
+        return error;
     }
 
     public String dataString(Integer maxValueLength) {

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/RecordData.java
@@ -1,0 +1,79 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.apicurio.registry.resolver.ParsedSchema;
+
+public class RecordData {
+
+    public static final String BINARY_DATA_MESSAGE = "Binary or non-UTF-8 encoded data cannot be displayed";
+    static final int REPLACEMENT_CHARACTER = '\uFFFD';
+
+    public final Map<String, String> meta = new LinkedHashMap<>(1);
+    byte[] data;
+    ParsedSchema<?> schema;
+
+    public RecordData(byte[] data, ParsedSchema<?> schema) {
+        super();
+        this.data = data;
+        this.schema = schema;
+    }
+
+    public RecordData(byte[] data) {
+        super();
+        this.data = data;
+        this.schema = null;
+    }
+
+    public RecordData(String data) {
+        this(data != null ? data.getBytes(StandardCharsets.UTF_8) : null);
+    }
+
+    public ParsedSchema<?> schema() {
+        return schema;
+    }
+
+    public String dataString(Integer maxValueLength) {
+        return bytesToString(data, maxValueLength);
+    }
+
+    public static String bytesToString(byte[] bytes, Integer maxValueLength) {
+        if (bytes == null) {
+            return null;
+        }
+
+        if (bytes.length == 0) {
+            return "";
+        }
+
+        int bufferSize = maxValueLength != null ? Math.min(maxValueLength, bytes.length) : bytes.length;
+        StringBuilder buffer = new StringBuilder(bufferSize);
+
+        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8)) {
+            int input;
+
+            while ((input = reader.read()) > -1) {
+                if (input == REPLACEMENT_CHARACTER || !Character.isDefined(input)) {
+                    return BINARY_DATA_MESSAGE;
+                }
+
+                buffer.append((char) input);
+
+                if (maxValueLength != null && buffer.length() == maxValueLength) {
+                    break;
+                }
+            }
+
+            return buffer.toString();
+        } catch (IOException e) {
+            return BINARY_DATA_MESSAGE;
+        }
+    }
+
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -25,6 +25,7 @@ quarkus.kafka.devservices.enabled=false
 quarkus.kubernetes-client.devservices.enabled=false
 quarkus.devservices.enabled=false
 
+quarkus.vertx.event-loops-pool-size=5
 quarkus.vertx.max-event-loop-execute-time=4000
 
 mp.openapi.scan.disable=false
@@ -67,10 +68,16 @@ console.kafka.admin.default.api.timeout.ms=10000
 %dev.quarkus.log.category."io.vertx.core.impl.BlockedThreadChecker".level=OFF
 %dev.quarkus.log.category."com.github.streamshub.console".level=DEBUG
 
+# %dev.quarkus.apicurio-registry.devservices.enabled=true
+# %dev.apicurio.rest.client.disable-auto-basepath-append=true
+# %dev.quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.6.x-release
+
 ########
 %testplain.quarkus.devservices.enabled=true
 %testplain.quarkus.kubernetes-client.devservices.enabled=true
 %testplain.quarkus.kubernetes-client.devservices.override-kubeconfig=true
+%testplain.quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.6.x-release
+%testplain.apicurio.rest.client.disable-auto-basepath-append=true
 
 #%testplain.quarkus.http.auth.proactive=false
 #%testplain.quarkus.http.auth.permission."oidc".policy=permit

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -41,6 +41,9 @@ quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.title=Console API
 
 quarkus.log.category."org.apache.kafka".level=ERROR
+# Apicurio cache logger is noisy for "not found" scenarios. We log the error
+# in our own handler instead.
+quarkus.log.category."io.apicurio.registry.resolver.ERCache".level=OFF
 
 %build.quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
 %build.quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}
@@ -54,6 +57,8 @@ quarkus.log.category."org.apache.kafka".level=ERROR
 # this configuration will prevent the removal of those classes and make them
 # eligible for access from a CDI `Instance`.
 quarkus.arc.unremovable-types=com.github.streamshub.console.api.**
+# Apicurio's Jackson customizer is distributed in a common jar by mistake
+quarkus.arc.exclude-types=io.apicurio.registry.rest.JacksonDateTimeCustomizer
 
 quarkus.index-dependency.strimzi-api.group-id=io.strimzi
 quarkus.index-dependency.strimzi-api.artifact-id=api

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
@@ -41,6 +41,12 @@ public class TestPlainProfile implements QuarkusTestProfile {
                     - name: test-kafka1
                       namespace: default
                       id: k1-id
+                      schemaRegistry:
+                        ###
+                        # This is the property used by Dev Services for Apicurio Registry
+                        # https://quarkus.io/guides/apicurio-registry-dev-services
+                        ###
+                        url: ${mp.messaging.connector.smallrye-kafka.apicurio.registry.url}
                       properties:
                         bootstrap.servers: ${console.test.external-bootstrap}
 

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
@@ -36,17 +36,21 @@ public class TestPlainProfile implements QuarkusTestProfile {
         var configFile = writeConfiguration("""
                 kubernetes:
                   enabled: true
+
+                schemaRegistries:
+                  - name: test-registry
+                    ###
+                    # This is the property used by Dev Services for Apicurio Registry
+                    # https://quarkus.io/guides/apicurio-registry-dev-services
+                    ###
+                    url: ${mp.messaging.connector.smallrye-kafka.apicurio.registry.url}
+
                 kafka:
                   clusters:
                     - name: test-kafka1
                       namespace: default
                       id: k1-id
-                      schemaRegistry:
-                        ###
-                        # This is the property used by Dev Services for Apicurio Registry
-                        # https://quarkus.io/guides/apicurio-registry-dev-services
-                        ###
-                        url: ${mp.messaging.connector.smallrye-kafka.apicurio.registry.url}
+                      schemaRegistry: test-registry
                       properties:
                         bootstrap.servers: ${console.test.external-bootstrap}
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,5 +33,56 @@
             <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.xlate</groupId>
+            <artifactId>validators</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
+            <scope>test</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -3,14 +3,32 @@ package com.github.streamshub.console.config;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.xlate.validation.constraints.Expression;
+
+@Expression(
+    message = "Kafka cluster references an unknown schema registry",
+    value = """
+        registryNames = self.schemaRegistries.stream()
+            .map(registry -> registry.getName())
+            .toList();
+        self.kafka.clusters.stream()
+            .map(cluster -> cluster.getSchemaRegistry())
+            .filter(registry -> registry != null)
+            .allMatch(registry -> registryNames.contains(registry))
+        """)
 public class ConsoleConfig {
 
     KubernetesConfig kubernetes = new KubernetesConfig();
+
+    @Valid
     List<SchemaRegistryConfig> schemaRegistries = new ArrayList<>();
+
+    @Valid
     KafkaConfig kafka = new KafkaConfig();
 
     @JsonIgnore

--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -1,9 +1,23 @@
 package com.github.streamshub.console.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.validation.constraints.AssertTrue;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class ConsoleConfig {
 
     KubernetesConfig kubernetes = new KubernetesConfig();
+    List<SchemaRegistryConfig> schemaRegistries = new ArrayList<>();
     KafkaConfig kafka = new KafkaConfig();
+
+    @JsonIgnore
+    @AssertTrue(message = "Schema registry names must be unique")
+    public boolean hasUniqueRegistryNames() {
+        return schemaRegistries.stream().map(SchemaRegistryConfig::getName).distinct().count() == schemaRegistries.size();
+    }
 
     public KubernetesConfig getKubernetes() {
         return kubernetes;
@@ -11,6 +25,14 @@ public class ConsoleConfig {
 
     public void setKubernetes(KubernetesConfig kubernetes) {
         this.kubernetes = kubernetes;
+    }
+
+    public List<SchemaRegistryConfig> getSchemaRegistries() {
+        return schemaRegistries;
+    }
+
+    public void setSchemaRegistries(List<SchemaRegistryConfig> schemaRegistries) {
+        this.schemaRegistries = schemaRegistries;
     }
 
     public KafkaConfig getKafka() {

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -14,7 +14,11 @@ public class KafkaClusterConfig {
     private String name;
     private String namespace;
     private String listener;
-    private SchemaRegistryConfig schemaRegistry;
+    /**
+     * Name of a configured schema registry that will be used to ser/des configurations
+     * with this Kafka cluster.
+     */
+    private String schemaRegistry;
     private Map<String, String> properties = new LinkedHashMap<>();
     private Map<String, String> adminProperties = new LinkedHashMap<>();
     private Map<String, String> consumerProperties = new LinkedHashMap<>();
@@ -62,11 +66,11 @@ public class KafkaClusterConfig {
         this.listener = listener;
     }
 
-    public SchemaRegistryConfig getSchemaRegistry() {
+    public String getSchemaRegistry() {
         return schemaRegistry;
     }
 
-    public void setSchemaRegistry(SchemaRegistryConfig schemaRegistry) {
+    public void setSchemaRegistry(String schemaRegistry) {
         this.schemaRegistry = schemaRegistry;
     }
 

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -14,6 +14,7 @@ public class KafkaClusterConfig {
     private String name;
     private String namespace;
     private String listener;
+    private SchemaRegistryConfig schemaRegistry;
     private Map<String, String> properties = new LinkedHashMap<>();
     private Map<String, String> adminProperties = new LinkedHashMap<>();
     private Map<String, String> consumerProperties = new LinkedHashMap<>();
@@ -59,6 +60,14 @@ public class KafkaClusterConfig {
 
     public void setListener(String listener) {
         this.listener = listener;
+    }
+
+    public SchemaRegistryConfig getSchemaRegistry() {
+        return schemaRegistry;
+    }
+
+    public void setSchemaRegistry(SchemaRegistryConfig schemaRegistry) {
+        this.schemaRegistry = schemaRegistry;
     }
 
     public Map<String, String> getProperties() {

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class KafkaClusterConfig {
 
     private String id;
-    @NotBlank
+    @NotBlank(message = "Kafka cluster `name` is required")
     private String name;
     private String namespace;
     private String listener;

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaConfig.java
@@ -4,12 +4,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class KafkaConfig {
 
+    @Valid
     List<KafkaClusterConfig> clusters = new ArrayList<>();
 
     @JsonIgnore

--- a/common/src/main/java/com/github/streamshub/console/config/SchemaRegistryConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/SchemaRegistryConfig.java
@@ -1,0 +1,17 @@
+package com.github.streamshub.console.config;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SchemaRegistryConfig {
+
+    @NotBlank(message = "Schema registry `url` is required")
+    String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/common/src/main/java/com/github/streamshub/console/config/SchemaRegistryConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/SchemaRegistryConfig.java
@@ -4,8 +4,19 @@ import jakarta.validation.constraints.NotBlank;
 
 public class SchemaRegistryConfig {
 
+    @NotBlank(message = "Schema registry `name` is required")
+    String name;
+
     @NotBlank(message = "Schema registry `url` is required")
     String url;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public String getUrl() {
         return url;

--- a/common/src/test/java/com/github/streamshub/console/config/ConsoleConfigTest.java
+++ b/common/src/test/java/com/github/streamshub/console/config/ConsoleConfigTest.java
@@ -1,0 +1,124 @@
+package com.github.streamshub.console.config;
+
+import java.util.Comparator;
+import java.util.List;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConsoleConfigTest {
+
+    ConsoleConfig config;
+    Validator validator;
+
+    @BeforeEach
+    void setup() {
+        config = new ConsoleConfig();
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void testRegistryNamesNotUniqueFailsValidation() {
+        for (String name : List.of("name1", "name2", "name1")) {
+            SchemaRegistryConfig registry = new SchemaRegistryConfig();
+            registry.setName(name);
+            registry.setUrl("http://example.com");
+            config.getSchemaRegistries().add(registry);
+        }
+
+        var violations = validator.validate(config);
+
+        assertEquals(1, violations.size());
+        assertEquals("Schema registry names must be unique", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    void testRegistryNamesUniquePassesValidation() {
+        for (String name : List.of("name1", "name2", "name3")) {
+            SchemaRegistryConfig registry = new SchemaRegistryConfig();
+            registry.setName(name);
+            registry.setUrl("http://example.com");
+            config.getSchemaRegistries().add(registry);
+        }
+
+        var violations = validator.validate(config);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    void testRegistryMissingPropertiesFailsValidation() {
+        SchemaRegistryConfig registry = new SchemaRegistryConfig();
+        // name and url are null
+        config.getSchemaRegistries().add(registry);
+
+        var violations = validator.validate(config).stream()
+                .sorted(Comparator.comparing(ConstraintViolation::getMessage))
+                .toList();
+
+        assertEquals(2, violations.size());
+        assertEquals("Schema registry `name` is required", violations.get(0).getMessage());
+        assertEquals("Schema registry `url` is required", violations.get(1).getMessage());
+    }
+
+    @Test
+    void testKafkaNamesNotUniqueFailsValidation() {
+        for (String name : List.of("name1", "name2", "name1")) {
+            KafkaClusterConfig cluster = new KafkaClusterConfig();
+            cluster.setName(name);
+            config.getKafka().getClusters().add(cluster);
+        }
+
+        var violations = validator.validate(config);
+
+        assertEquals(1, violations.size());
+        assertEquals("Kafka cluster names must be unique", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    void testKafkaNameMissingFailsValidation() {
+        config.getKafka().getClusters().add(new KafkaClusterConfig());
+
+        var violations = validator.validate(config);
+
+        assertEquals(1, violations.size());
+        assertEquals("Kafka cluster `name` is required", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    void testRegistryNamePassesValidation() {
+        SchemaRegistryConfig registry = new SchemaRegistryConfig();
+        registry.setName("known-registry");
+        registry.setUrl("http://example.com");
+        config.getSchemaRegistries().add(registry);
+
+        KafkaClusterConfig cluster = new KafkaClusterConfig();
+        cluster.setName("name1");
+        cluster.setSchemaRegistry("known-registry");
+        config.getKafka().getClusters().add(cluster);
+
+        var violations = validator.validate(config);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    void testUnknownRegistryNameFailsValidation() {
+        KafkaClusterConfig cluster = new KafkaClusterConfig();
+        cluster.setName("name1");
+        cluster.setSchemaRegistry("unknown-registry");
+        config.getKafka().getClusters().add(cluster);
+
+        var violations = validator.validate(config);
+
+        assertEquals(1, violations.size());
+        assertEquals("Kafka cluster references an unknown schema registry", violations.iterator().next().getMessage());
+    }
+}

--- a/console-config-example.yaml
+++ b/console-config-example.yaml
@@ -9,6 +9,9 @@ kafka:
       namespace: my-namespace1 # namespace of the Strimzi Kafka CR (optional)
       id: my-kafka1-id # value to be used as an identifier for the cluster. Must be specified when namespace is not.
       listener: "secure" # name of the listener to use for connections from the console
+      # This object may contain a `url` string property with the Apicurio Registry API path to be used to resolve
+      # Avro or Protobuf schemas for topic message browsing
+      schemaRegistry: { }
       # `properties` contains keys/values to use for any Kafka connection
       properties:
         security.protocol: SASL_SSL

--- a/console-config-example.yaml
+++ b/console-config-example.yaml
@@ -3,15 +3,19 @@ kubernetes:
   # Kafka and KafkaTopic custom resources. Enabled by default
   enabled: true
 
+schemaRegistries:
+  # Array of Apicurio Registries that my be referenced by Kafka cluster configurations
+  # to resolve Avro or Protobuf schemas for topic message browsing
+  - name: "my-apicurio-registry"
+    url: "http://registry.exampl.com/apis/registry/v2/"
+
 kafka:
   clusters:
     - name: my-kafka1 # name of the Strimzi Kafka CR
       namespace: my-namespace1 # namespace of the Strimzi Kafka CR (optional)
       id: my-kafka1-id # value to be used as an identifier for the cluster. Must be specified when namespace is not.
       listener: "secure" # name of the listener to use for connections from the console
-      # This object may contain a `url` string property with the Apicurio Registry API path to be used to resolve
-      # Avro or Protobuf schemas for topic message browsing
-      schemaRegistry: { }
+      schemaRegistry: "my-apicurio-registry" # name of the schema registry to use with this Kafka (optional)
       # `properties` contains keys/values to use for any Kafka connection
       properties:
         security.protocol: SASL_SSL

--- a/examples/console/010-Console-example.yaml
+++ b/examples/console/010-Console-example.yaml
@@ -13,6 +13,8 @@ spec:
     - name: console-kafka             # Name of the `Kafka` CR representing the cluster
       namespace: ${KAFKA_NAMESPACE}   # Namespace of the `Kafka` CR representing the cluster
       listener: secure                # Listener on the `Kafka` CR to connect from the console
+      schemaRegistry: null            # Configuration for a connection to an Apicurio Registry instance
+                                      # E.g. : { "url": "http://example.com/apis/registry/v2" }
       properties:
         values: []                    # Array of name/value for properties to be used for connections
                                       # made to this cluster

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
@@ -18,6 +18,8 @@ public class ConsoleSpec {
 
     Images images = new Images();
 
+    List<SchemaRegistry> schemaRegistries;
+
     List<KafkaCluster> kafkaClusters = new ArrayList<>();
 
     // TODO: copy EnvVar into console's API to avoid unexpected changes
@@ -37,6 +39,14 @@ public class ConsoleSpec {
 
     public void setImages(Images images) {
         this.images = images;
+    }
+
+    public List<SchemaRegistry> getSchemaRegistries() {
+        return schemaRegistries;
+    }
+
+    public void setSchemaRegistries(List<SchemaRegistry> schemaRegistries) {
+        this.schemaRegistries = schemaRegistries;
     }
 
     public List<KafkaCluster> getKafkaClusters() {

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
@@ -52,11 +52,10 @@ public class KafkaCluster {
     private Credentials credentials;
 
     @JsonPropertyDescription("""
-            Configuration for a connection to an Apicurio Registry instance \
-            to use for serializing and de-serializing records written to or read \
-            from this Kafka cluster.
+            Name of a configured Apicurio Registry instance to use for serializing \
+            and de-serializing records written to or read from this Kafka cluster.
             """)
-    private SchemaRegistry schemaRegistry;
+    private String schemaRegistry;
 
     private ConfigVars properties = new ConfigVars();
 
@@ -106,11 +105,11 @@ public class KafkaCluster {
         this.credentials = credentials;
     }
 
-    public SchemaRegistry getSchemaRegistry() {
+    public String getSchemaRegistry() {
         return schemaRegistry;
     }
 
-    public void setSchemaRegistry(SchemaRegistry schemaRegistry) {
+    public void setSchemaRegistry(String schemaRegistry) {
         this.schemaRegistry = schemaRegistry;
     }
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
@@ -51,6 +51,13 @@ public class KafkaCluster {
 
     private Credentials credentials;
 
+    @JsonPropertyDescription("""
+            Configuration for a connection to an Apicurio Registry instance \
+            to use for serializing and de-serializing records written to or read \
+            from this Kafka cluster.
+            """)
+    private SchemaRegistry schemaRegistry;
+
     private ConfigVars properties = new ConfigVars();
 
     private ConfigVars adminProperties = new ConfigVars();
@@ -97,6 +104,14 @@ public class KafkaCluster {
 
     public void setCredentials(Credentials credentials) {
         this.credentials = credentials;
+    }
+
+    public SchemaRegistry getSchemaRegistry() {
+        return schemaRegistry;
+    }
+
+    public void setSchemaRegistry(SchemaRegistry schemaRegistry) {
+        this.schemaRegistry = schemaRegistry;
     }
 
     public ConfigVars getProperties() {

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
@@ -1,0 +1,24 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.fabric8.generator.annotation.Required;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SchemaRegistry {
+
+    @Required
+    @JsonPropertyDescription("URL of the Apicurio Registry server API.")
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
@@ -11,8 +11,24 @@ import io.sundr.builder.annotations.Buildable;
 public class SchemaRegistry {
 
     @Required
+    @JsonPropertyDescription("""
+            Name of the Apicurio Registry. The name may be referenced by Kafka clusters \
+            configured in the console to indicate that a particular registry is to be \
+            used for message deserialization when browsing topics within that cluster.
+            """)
+    private String name;
+
+    @Required
     @JsonPropertyDescription("URL of the Apicurio Registry server API.")
     private String url;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public String getUrl() {
         return url;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleSecret.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleSecret.java
@@ -32,6 +32,7 @@ import com.github.streamshub.console.api.v1alpha1.spec.Credentials;
 import com.github.streamshub.console.api.v1alpha1.spec.KafkaCluster;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.config.KafkaClusterConfig;
+import com.github.streamshub.console.config.SchemaRegistryConfig;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -131,6 +132,12 @@ public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Conso
         kcConfig.setNamespace(namespace);
         kcConfig.setName(name);
         kcConfig.setListener(listenerName);
+
+        if (kafkaRef.getSchemaRegistry() != null) {
+            SchemaRegistryConfig registry = new SchemaRegistryConfig();
+            registry.setUrl(kafkaRef.getSchemaRegistry().getUrl());
+            kcConfig.setSchemaRegistry(registry);
+        }
 
         config.getKubernetes().setEnabled(Objects.nonNull(namespace));
         config.getKafka().getClusters().add(kcConfig);

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleSecret.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleSecret.java
@@ -9,12 +9,14 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -30,6 +32,7 @@ import com.github.streamshub.console.api.v1alpha1.Console;
 import com.github.streamshub.console.api.v1alpha1.spec.ConfigVars;
 import com.github.streamshub.console.api.v1alpha1.spec.Credentials;
 import com.github.streamshub.console.api.v1alpha1.spec.KafkaCluster;
+import com.github.streamshub.console.api.v1alpha1.spec.SchemaRegistry;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.config.KafkaClusterConfig;
 import com.github.streamshub.console.config.SchemaRegistryConfig;
@@ -112,8 +115,19 @@ public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Conso
         return new String(buffer.toByteArray()).substring(0, length);
     }
 
+    private static <T> List<T> coalesce(List<T> value, Supplier<List<T>> defaultValue) {
+        return value != null ? value : defaultValue.get();
+    }
+
     private ConsoleConfig buildConfig(Console primary, Context<Console> context) {
         ConsoleConfig config = new ConsoleConfig();
+
+        for (SchemaRegistry registry : coalesce(primary.getSpec().getSchemaRegistries(), Collections::emptyList)) {
+            var registryConfig = new SchemaRegistryConfig();
+            registryConfig.setName(registry.getName());
+            registryConfig.setUrl(registry.getUrl());
+            config.getSchemaRegistries().add(registryConfig);
+        }
 
         for (var kafkaRef : primary.getSpec().getKafkaClusters()) {
             addConfig(primary, context, config, kafkaRef);
@@ -132,12 +146,7 @@ public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Conso
         kcConfig.setNamespace(namespace);
         kcConfig.setName(name);
         kcConfig.setListener(listenerName);
-
-        if (kafkaRef.getSchemaRegistry() != null) {
-            SchemaRegistryConfig registry = new SchemaRegistryConfig();
-            registry.setUrl(kafkaRef.getSchemaRegistry().getUrl());
-            kcConfig.setSchemaRegistry(registry);
-        }
+        kcConfig.setSchemaRegistry(kafkaRef.getSchemaRegistry());
 
         config.getKubernetes().setEnabled(Objects.nonNull(namespace));
         config.getKafka().getClusters().add(kcConfig);

--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTest.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTest.java
@@ -78,12 +78,14 @@ class ConsoleReconcilerTest {
         var allConsoles = client.resources(Console.class).inAnyNamespace();
         var allKafkas = client.resources(Kafka.class).inAnyNamespace();
         var allKafkaUsers = client.resources(KafkaUser.class).inAnyNamespace();
+        var allDeployments = client.resources(Deployment.class).inAnyNamespace().withLabels(ConsoleResource.MANAGEMENT_LABEL);
         var allConfigMaps = client.resources(ConfigMap.class).inAnyNamespace().withLabels(ConsoleResource.MANAGEMENT_LABEL);
         var allSecrets = client.resources(Secret.class).inAnyNamespace().withLabels(ConsoleResource.MANAGEMENT_LABEL);
 
         allConsoles.delete();
         allKafkas.delete();
         allKafkaUsers.delete();
+        allDeployments.delete();
         allConfigMaps.delete();
         allSecrets.delete();
 
@@ -91,6 +93,7 @@ class ConsoleReconcilerTest {
             assertTrue(allConsoles.list().getItems().isEmpty());
             assertTrue(allKafkas.list().getItems().isEmpty());
             assertTrue(allKafkaUsers.list().getItems().isEmpty());
+            assertTrue(allDeployments.list().getItems().isEmpty());
             assertTrue(allConfigMaps.list().getItems().isEmpty());
             assertTrue(allSecrets.list().getItems().isEmpty());
         });
@@ -516,7 +519,6 @@ class ConsoleReconcilerTest {
         });
     }
 
-
     @Test
     void testConsoleReconciliationWithKafkaProperties() {
         client.resource(new ConfigMapBuilder()
@@ -593,6 +595,50 @@ class ConsoleReconcilerTest {
             assertEquals("x-admin-prop-value", kafkaConfig.getAdminProperties().get("x-admin-prop-name"));
             assertEquals("x-consumer-prop-value", kafkaConfig.getConsumerProperties().get("extra-x-consumer-prop-name"));
             assertEquals("x-producer-prop-value", kafkaConfig.getProducerProperties().get("x-producer-prop-name"));
+        });
+    }
+
+    @Test
+    void testConsoleReconciliationWithSchemaRegistryUrl() {
+        Console consoleCR = new ConsoleBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName("console-1")
+                        .withNamespace("ns2")
+                        .build())
+                .withNewSpec()
+                    .withHostname("example.com")
+                    .addNewKafkaCluster()
+                        .withName(kafkaCR.getMetadata().getName())
+                        .withNamespace(kafkaCR.getMetadata().getNamespace())
+                        .withListener(kafkaCR.getSpec().getKafka().getListeners().get(0).getName())
+                        .withNewSchemaRegistry()
+                            .withUrl("http://example.com/apis/registry/v2")
+                        .endSchemaRegistry()
+                    .endKafkaCluster()
+                .endSpec()
+                .build();
+
+        client.resource(consoleCR).create();
+
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var console = client.resources(Console.class)
+                    .inNamespace(consoleCR.getMetadata().getNamespace())
+                    .withName(consoleCR.getMetadata().getName())
+                    .get();
+            assertEquals(1, console.getStatus().getConditions().size());
+            var ready = console.getStatus().getConditions().get(0);
+            assertEquals("Ready", ready.getType());
+            assertEquals("False", ready.getStatus());
+            assertEquals("DependentsNotReady", ready.getReason());
+
+            var consoleSecret = client.secrets().inNamespace("ns2").withName("console-1-" + ConsoleSecret.NAME).get();
+            assertNotNull(consoleSecret);
+            String configEncoded = consoleSecret.getData().get("console-config.yaml");
+            byte[] configDecoded = Base64.getDecoder().decode(configEncoded);
+            ConsoleConfig consoleConfig = new ObjectMapper().readValue(configDecoded, ConsoleConfig.class);
+            String registryUrl = consoleConfig.getKafka().getClusters().get(0).getSchemaRegistry().getUrl();
+            Logger.getLogger(getClass()).infof("config YAML: %s", new String(configDecoded));
+            assertEquals("http://example.com/apis/registry/v2", registryUrl);
         });
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.xlate</groupId>
+                <artifactId>validators</artifactId>
+                <version>1.4.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <quarkus.platform.version>3.15.1</quarkus.platform.version>
         <strimzi-api.version>0.43.0</strimzi-api.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+        <apicurio-registry.version>2.6.2.Final</apicurio-registry.version>
 
         <!-- Test Dependencies -->
         <hamcrest.version>3.0</hamcrest.version>

--- a/ui/api/api.ts
+++ b/ui/api/api.ts
@@ -14,7 +14,7 @@ export async function getHeaders(): Promise<Record<string, string>> {
 }
 
 export const ApiError = z.object({
-  meta: z.object({ type: z.string() }), // z.map(z.string(), z.string()),
+  meta: z.object({ type: z.string() }).optional(), // z.map(z.string(), z.string()),
   id: z.string().optional(),
   status: z.string().optional(),
   code: z.string().optional(),

--- a/ui/api/messages/actions.ts
+++ b/ui/api/messages/actions.ts
@@ -99,9 +99,9 @@ export async function getTopicMessages(
     } else {
       return { messages: messages, ts: new Date() };
     }
-  } catch {
+  } catch (e) {
     log.error(
-      { status: res.status, message: rawData, url },
+      { error: e, status: res.status, message: rawData, url },
       "Error fetching message",
     );
     if (res.status === 404) {

--- a/ui/api/messages/actions.ts
+++ b/ui/api/messages/actions.ts
@@ -56,7 +56,7 @@ export async function getTopicMessages(
   const sp = new URLSearchParams(
     filterUndefinedFromObj({
       "fields[records]":
-        "partition,offset,timestamp,timestampType,headers,key,value,size",
+        "partition,offset,timestamp,timestampType,headers,key,keySchema,value,valueSchema,size",
       "filter[partition]": params.partition,
       "filter[offset]":
         params.filter?.type === "offset"

--- a/ui/api/messages/schema.ts
+++ b/ui/api/messages/schema.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
+import { ApiError } from "@/api/api";
 
 const RelatedSchema = z.object({
   meta: z.object({
     artifactType: z.string().optional(),
     name: z.string().optional(),
+    errors: z.array(ApiError).optional(),
   }).nullable().optional(),
   links: z.object({
     content: z.string(),
@@ -11,7 +13,7 @@ const RelatedSchema = z.object({
   data: z.object({
     type: z.literal("schemas"),
     id: z.string(),
-  }),
+  }).optional(),
 });
 
 export const MessageSchema = z.object({

--- a/ui/api/messages/schema.ts
+++ b/ui/api/messages/schema.ts
@@ -1,5 +1,19 @@
 import { z } from "zod";
 
+const RelatedSchema = z.object({
+  meta: z.object({
+    artifactType: z.string().optional(),
+    name: z.string().optional(),
+  }).nullable().optional(),
+  links: z.object({
+    content: z.string(),
+  }).nullable().optional(),
+  data: z.object({
+    type: z.literal("schemas"),
+    id: z.string(),
+  }),
+});
+
 export const MessageSchema = z.object({
   type: z.literal("records"),
   attributes: z.object({
@@ -12,9 +26,15 @@ export const MessageSchema = z.object({
     value: z.string().nullable(),
     size: z.number().optional(),
   }),
+  relationships: z.object({
+    keySchema: RelatedSchema.optional().nullable(),
+    valueSchema: RelatedSchema.optional().nullable(),
+  }),
 });
+
 export const MessageApiResponse = z.object({
   meta: z.object({}).nullable().optional(),
   data: z.array(MessageSchema),
 });
+
 export type Message = z.infer<typeof MessageSchema>;

--- a/ui/components/MessagesTable/MessagesTable.stories.tsx
+++ b/ui/components/MessagesTable/MessagesTable.stories.tsx
@@ -119,6 +119,13 @@ function sampleData({
           '{"order":{"address":{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},"contact":{"firstName":"james","lastName":"smith","phone":"512-123-1234"},"orderId":"123","customerName":""},"primitives":{"stringPrimitive":"some value","booleanPrimitive":true,"numberPrimitive":24},"addressList":[{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"}]}',
         size: 1234,
       },
+      relationships: {
+        valueSchema: {
+          meta: {
+            artifactType: "AVRO"
+          }
+        }
+      },
     },
     {
       attributes: {
@@ -139,6 +146,13 @@ function sampleData({
           '{"order":{"address":{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},"contact":{"firstName":"james","lastName":"smith","phone":"512-123-1234"},"orderId":"123"},"primitives":{"stringPrimitive":"some value","booleanPrimitive":true,"numberPrimitive":24},"addressList":[{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"},{"street":"123 any st","city":"Austin","state":"TX","zip":"78626"}]}',
         size: 1234,
       },
+      relationships: {
+        keySchema: {
+          meta: {
+            artifactType: "PROTOBUF"
+          }
+        }
+      },
     },
     {
       attributes: {
@@ -151,6 +165,7 @@ function sampleData({
         value: '{"foo": "bar", "baz": "???"}',
         size: 432,
       },
+      relationships: {},
     },
     {
       attributes: {
@@ -161,6 +176,7 @@ function sampleData({
         value: "random string",
         size: 532,
       },
+      relationships: {},
     },
     {
       attributes: {
@@ -171,6 +187,7 @@ function sampleData({
         value: "",
         size: 0,
       },
+      relationships: {},
     },
   ];
   const numberOfMessages =
@@ -186,6 +203,9 @@ function sampleData({
             offset:
               (filterOffset ?? 0) + numberOfMessages - messages.length * i - j,
             partition: filterPartition || m.attributes.partition,
+          },
+          relationships: {
+            ...m.relationships,
           },
         }))
         .filter((m) => {

--- a/ui/components/MessagesTable/MessagesTable.tsx
+++ b/ui/components/MessagesTable/MessagesTable.tsx
@@ -12,7 +12,7 @@ import {
   TextContent,
   Tooltip,
 } from "@/libs/patternfly/react-core";
-import { HelpIcon } from "@/libs/patternfly/react-icons";
+import { ExclamationTriangleIcon, HelpIcon } from "@/libs/patternfly/react-icons";
 import {
   BaseCellProps,
   InnerScrollContainer,
@@ -272,10 +272,19 @@ export function MessagesTable({
                                   onSelectMessage(row);
                                 }}
                               />
-                              {row.relationships.keySchema?.meta?.artifactType && (
+                              {row.relationships.keySchema && (
                                 <TextContent>
                                   <Text component={"small"}>
-                                    {row.relationships.keySchema?.meta?.artifactType}
+                                    {row.relationships.keySchema?.meta?.artifactType && (
+                                        <>
+                                        {row.relationships.keySchema?.meta?.artifactType}
+                                        </>
+                                    )}
+                                    {row.relationships.keySchema?.meta?.errors && (
+                                        <>
+                                        <ExclamationTriangleIcon /> { row.relationships.keySchema?.meta?.errors[0].detail }
+                                        </>
+                                    )}
                                   </Text>
                                 </TextContent>
                               )}
@@ -317,10 +326,19 @@ export function MessagesTable({
                                   onSelectMessage(row);
                                 }}
                               />
-                              {row.relationships.valueSchema?.meta?.artifactType && (
+                              {row.relationships.valueSchema && (
                                 <TextContent>
                                   <Text component={"small"}>
-                                    {row.relationships.valueSchema?.meta?.artifactType}
+                                    {row.relationships.valueSchema?.meta?.artifactType && (
+                                      <>
+                                      {row.relationships.valueSchema?.meta?.artifactType}
+                                      </>
+                                    )}
+                                    {row.relationships.valueSchema?.meta?.errors && (
+                                      <>
+                                      <ExclamationTriangleIcon /> { row.relationships.valueSchema?.meta?.errors[0].detail }
+                                      </>
+                                    )}
                                   </Text>
                                 </TextContent>
                               )}

--- a/ui/components/MessagesTable/MessagesTable.tsx
+++ b/ui/components/MessagesTable/MessagesTable.tsx
@@ -263,6 +263,7 @@ export function MessagesTable({
                         return (
                           <Cell>
                             {row.attributes.key ? (
+                              <>
                               <UnknownValuePreview
                                 value={row.attributes.key}
                                 highlight={filterQuery}
@@ -271,6 +272,14 @@ export function MessagesTable({
                                   onSelectMessage(row);
                                 }}
                               />
+                              {row.relationships.keySchema?.meta?.artifactType && (
+                                <TextContent>
+                                  <Text component={"small"}>
+                                    {row.relationships.keySchema?.meta?.artifactType}
+                                  </Text>
+                                </TextContent>
+                              )}
+                              </>
                             ) : (
                               empty
                             )}
@@ -299,6 +308,7 @@ export function MessagesTable({
                         return (
                           <Cell>
                             {row.attributes.value ? (
+                              <>
                               <UnknownValuePreview
                                 value={row.attributes.value}
                                 highlight={filterQuery}
@@ -307,6 +317,14 @@ export function MessagesTable({
                                   onSelectMessage(row);
                                 }}
                               />
+                              {row.relationships.valueSchema?.meta?.artifactType && (
+                                <TextContent>
+                                  <Text component={"small"}>
+                                    {row.relationships.valueSchema?.meta?.artifactType}
+                                  </Text>
+                                </TextContent>
+                              )}
+                              </>
                             ) : (
                               empty
                             )}


### PR DESCRIPTION
This PR adds a multiformat message deserializer and serializer (not exposed in UI) and support to integrate with Apicurio Registry for retrieval of message schemas. The deserializer works generally by locating a schema identifier in a message's headers or directly in the key/value being deserialized. The identifier is used to fetch a schema from Apicurio Registry and either Avro or Protobuf deserialization is performed based on the type of schema returned.

Failure to locate a schema for a discovered identifier is communicated to the client (UI). When successful, the schema's name and link (to retrieve the content) will be returned to the client so that a user may view the schema if wanted. Retrieval of the schema content is proxied to Apicurio Registry via a new `SchemasResource` added in this PR as well.

Inline information for key/value formats:
![image](https://github.com/user-attachments/assets/056ea94b-068f-4e7c-b63b-3e3624b30d22)

Inline schema resolution warnings:
![image](https://github.com/user-attachments/assets/70c9ccd0-db2a-40da-aab1-25fa78d03618)
