### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Streaming Platform Console
 release:
-  current-version: 0.3.4
-  next-version: 0.4.0-SNAPSHOT
+  current-version: 0.4.0
+  next-version: 0.5.0-SNAPSHOT


### PR DESCRIPTION
The 0.4.0 milestone has over 100 issues accumulated, so this should be a good time to set a new tag. Several feature added in 0.4.0 allow for modifications - reset consumer groups, pause/resume Kafka reconciliation, and maintenance of KafkaRebalance CRs - that will not support authentication until 0.5.0.