### PR TITLE
Pass `allow-same-version` to npm-version

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -116,7 +116,7 @@
                                 </goals>
                                 <phase>process-resources</phase>
                                 <configuration>
-                                    <arguments>--no-git-tag-version version ${project.version}</arguments>
+                                    <arguments>--allow-same-version --no-git-tag-version version ${project.version}</arguments>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
NPM compares the old and new versions without suffixes, so 0.4.0-SNAPSHOT has the `-SNAPSHOT` trimmed before comparison. This change tells NPM to allow the same version, bypassing the comparison. Ultimately, the version changed in the package*.json files will not be the same.