### PR TITLE
fix: Improve slow consume records operation

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatDeserializer.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/MultiformatDeserializer.java
@@ -266,7 +266,7 @@ public class MultiformatDeserializer extends AbstractKafkaDeserializer<Object, R
     }
 
     private SchemaLookupResult<Object> resolve(ArtifactReference artifactReference) {
-        if (!artifactReference.hasValue()) {
+        if (artifactReference == null || !artifactReference.hasValue()) {
             return NO_SCHEMA_ID;
         }
 


### PR DESCRIPTION
- Skip consumer assignments for topic partitions with no data
- Skip consumer assignments that seek beyond the end of the assigned topic partition
- Limit consumer poll time to 100ms per request to poll the consumer
- Make total time polling via the endpoint configurable, default 5s
- Fix NPE in multi-format de-serializer