### PR TITLE
[OLM] Operator name change

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -92,7 +92,7 @@ jobs:
             ./install/operator-olm/010-CatalogSource-console-operator-catalog.yaml \
             | kubectl apply -n olm -f -
 
-          kubectl wait catalogsource/console-operator-catalog -n olm \
+          kubectl wait catalogsource/streamshub-console-catalog -n olm \
             --for=jsonpath='{.status.connectionState.lastObservedState}'=READY \
             --timeout=180s
 

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -135,7 +135,7 @@ jobs:
 
           export -f wait_operator
           timeout 300s bash -c 'wait_operator "strimzi-kafka-operator"'
-          timeout 300s bash -c 'wait_operator "console-operator"'
+          timeout 300s bash -c 'wait_operator "streamshub-console-operator"'
 
       # replace with resources in docs PR
       - name: Deploy Kafka Cluster & Console
@@ -248,7 +248,7 @@ jobs:
           mkdir ./resources
           kubectl get all,catalogsources,operatorgroups -n olm -o yaml > ./resources/olm.yaml
           kubectl get all,subscriptions,csv,operatorgroups,installplans -n operators -o yaml > ./resources/operators.yaml
-          kubectl logs -n operators -l app.kubernetes.io/name=console-operator --all-containers=true --tail -1 > ./resources/console-operator-logs.txt
+          kubectl logs -n operators -l app.kubernetes.io/name=streamshub-console-operator --all-containers=true --tail -1 > ./resources/streamshub-console-operator-logs.txt
           kubectl get all -n $TARGET_NAMESPACE -o yaml > ./resources/$TARGET_NAMESPACE.yaml
           kubectl logs -n ${TARGET_NAMESPACE} -l app.kubernetes.io/instance=example-console-deployment --all-containers=true --tail -1 > ./resources/$TARGET_NAMESPACE-console-logs.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
 
           cat ${RELEASE_K8S_PATH}/consoles.console.streamshub.github.com-v1.yml \
               ${RELEASE_K8S_PATH}/kubernetes.yml \
-            > target/console-operator-${{ steps.metadata.outputs.current-version }}.yaml
+            > target/streamshub-console-operator.yaml
 
       - name: Push Release Tag
         run: |
@@ -151,4 +151,4 @@ jobs:
           tag: ${{ steps.metadata.outputs.current-version }}
           allow_override: true
           gzip: false
-          files: target/console-operator-${{ steps.metadata.outputs.current-version }}.yaml
+          files: target/streamshub-console-operator.yaml

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ container-image-api-push: container-image-api
 container-image-operator:
 	mvn package -am -pl operator -Pcontainer-image -DskipTests -Dquarkus.container-image.image=$(CONSOLE_OPERATOR_IMAGE)
 	operator/bin/modify-bundle-metadata.sh
-	operator/bin/generate-catalog.sh $(VERSION)``
+	operator/bin/generate-catalog.sh $(VERSION)
 	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_OPERATOR_BUNDLE_IMAGE) -f operator/target/bundle/console-operator/bundle.Dockerfile
 	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_OPERATOR_CATALOG_IMAGE) -f operator/target/catalog.Dockerfile
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ SKIP_RANGE ?= ">=1.0.0 <1.0.3"
 
 CONSOLE_UI_NEXTAUTH_SECRET ?= $(shell openssl rand -base64 32)
 
+# This helps to build CSV using Quarkus with correct image tags in lowercase "-snapshot" instead of "-SNAPSHOT" (default project pom value)
+# Without this export, UI and API images could not be pulled from registry during the deployment of Console instance
+export QUARKUS_CONTAINER_IMAGE_TAG=${VERSION}
+export QUARKUS_KUBERNETES_VERSION=${VERSION}
+
 container-image-api:
 	mvn package -am -pl api -Pcontainer-image -DskipTests -Dquarkus.container-image.image=$(CONSOLE_API_IMAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ container-image-api-push: container-image-api
 container-image-operator:
 	mvn package -am -pl operator -Pcontainer-image -DskipTests -Dquarkus.container-image.image=$(CONSOLE_OPERATOR_IMAGE)
 	operator/bin/modify-bundle-metadata.sh
-	operator/bin/generate-catalog.sh $(VERSION)
+	operator/bin/generate-catalog.sh $(VERSION)``
 	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_OPERATOR_BUNDLE_IMAGE) -f operator/target/bundle/console-operator/bundle.Dockerfile
 	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_OPERATOR_CATALOG_IMAGE) -f operator/target/catalog.Dockerfile
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ spec:
 ```
 
 ### Deploy the operator directly
-Deploying the operator without the use of OLM requires applying the component Kubernetes resources for the operator directly. These resources are bundled and attached to each StreamsHub Console release. The latest release can be found [here](https://github.com/streamshub/console/releases/latest). The resource file is named `console-operator-x.y.z.yaml` where `x.y.z` is the released version.
+Deploying the operator without the use of OLM requires applying the component Kubernetes resources for the operator directly. These resources are bundled and attached to each StreamsHub Console release. The latest release can be found [here](https://github.com/streamshub/console/releases/latest). The resource file is named `streamshub-console-operator-x.y.z.yaml` where `x.y.z` is the released version.
 
 This example will create the operator's resources in the `default` namespace. Modify the `NAMESPACE` variable according to your needs and set `VERSION` to the [latest release](https://github.com/streamshub/console/releases/latest).
 ```

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ spec:
 ```
 
 ### Deploy the operator directly
-Deploying the operator without the use of OLM requires applying the component Kubernetes resources for the operator directly. These resources are bundled and attached to each StreamsHub Console release. The latest release can be found [here](https://github.com/streamshub/console/releases/latest). The resource file is named `streamshub-console-operator-x.y.z.yaml` where `x.y.z` is the released version.
+Deploying the operator without the use of OLM requires applying the component Kubernetes resources for the operator directly. These resources are bundled and attached to each StreamsHub Console release. The latest release can be found [here](https://github.com/streamshub/console/releases/latest). The resource file is named `streamshub-console-operator.yaml`.
 
 This example will create the operator's resources in the `default` namespace. Modify the `NAMESPACE` variable according to your needs and set `VERSION` to the [latest release](https://github.com/streamshub/console/releases/latest).
 ```
 export NAMESPACE=default
 export VERSION=0.3.3
-curl -sL https://github.com/streamshub/console/releases/download/${VERSION}/console-operator-${VERSION}.yaml \
+curl -sL https://github.com/streamshub/console/releases/download/${VERSION}/streamshub-console-operator.yaml \
   | envsubst \
   | kubectl apply -n ${NAMESPACE} -f -
 ```

--- a/install/operator-olm/000-OperatorGroup-console-operator.yaml
+++ b/install/operator-olm/000-OperatorGroup-console-operator.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: console-operator
+  name: streamshub-operators
 spec:
   targetNamespaces: []
   upgradeStrategy: Default

--- a/install/operator-olm/010-CatalogSource-console-operator-catalog.yaml
+++ b/install/operator-olm/010-CatalogSource-console-operator-catalog.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: console-operator-catalog
+  name: streamshub-console-catalog
 spec:
   displayName: StreamsHub
   image: quay.io/streamshub/console-operator-catalog:latest

--- a/install/operator-olm/020-Subscription-console-operator.yaml
+++ b/install/operator-olm/020-Subscription-console-operator.yaml
@@ -2,9 +2,9 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: console-operator
+  name: streamshub-console-sub
 spec:
-  name: console-operator
+  name: streamshub-console-operator
   channel: alpha
-  source: console-operator-catalog
+  source: streamshub-console-catalog
   sourceNamespace: ${NAMESPACE}

--- a/operator/bin/common.sh
+++ b/operator/bin/common.sh
@@ -7,7 +7,7 @@ CSV_FILE_PATH=${BUNDLE_PATH}/manifests/console-operator.clusterserviceversion.ya
 CATALOG_PATH=${SCRIPT_PATH}/../target/catalog
 # Operator naming
 ORIGINAL_OPERATOR_NAME="console-operator"
-OPERATOR_NAME="streamshub-operator"
+OPERATOR_NAME="streamshub-console-operator"
 OPERATOR_INSTANCE_NAME="${OPERATOR_NAME}-v${VERSION}"
 OPERATOR_CSV_NAME="${OPERATOR_NAME}.v${VERSION}"
 

--- a/operator/bin/common.sh
+++ b/operator/bin/common.sh
@@ -5,7 +5,7 @@ SCRIPT_PATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 BUNDLE_PATH=${SCRIPT_PATH}/../target/bundle/console-operator/
 CSV_FILE_PATH=${BUNDLE_PATH}/manifests/console-operator.clusterserviceversion.yaml
 CATALOG_PATH=${SCRIPT_PATH}/../target/catalog
-# Naming
+# Operator naming
 ORIGINAL_OPERATOR_NAME="console-operator"
 OPERATOR_NAME="streamshub-operator"
 OPERATOR_INSTANCE_NAME="${OPERATOR_NAME}-v${VERSION}"

--- a/operator/bin/common.sh
+++ b/operator/bin/common.sh
@@ -5,6 +5,11 @@ SCRIPT_PATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 BUNDLE_PATH=${SCRIPT_PATH}/../target/bundle/console-operator/
 CSV_FILE_PATH=${BUNDLE_PATH}/manifests/console-operator.clusterserviceversion.yaml
 CATALOG_PATH=${SCRIPT_PATH}/../target/catalog
+# Naming
+ORIGINAL_OPERATOR_NAME="console-operator"
+OPERATOR_NAME="streamshub-operator"
+OPERATOR_INSTANCE_NAME="${OPERATOR_NAME}-v${VERSION}"
+OPERATOR_CSV_NAME="${OPERATOR_NAME}.v${VERSION}"
 
 YQ="$(which yq 2>/dev/null)" || :
 

--- a/operator/bin/modify-bundle-metadata.sh
+++ b/operator/bin/modify-bundle-metadata.sh
@@ -44,7 +44,7 @@ curr_time_date="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 echo "[DEBUG] Setting createdAt = ${curr_time_date}"
 ${YQ} eval -o yaml -i ".metadata.annotations.createdAt = \"${curr_time_date}\"" "${CSV_FILE_PATH}"
 
-# Change operator deployment name
+# Change operator name
 echo "[DEBUG] Renaming operator to ${OPERATOR_INSTANCE_NAME}"
 ${YQ} eval -o yaml -i ".metadata.name = \"${OPERATOR_CSV_NAME}\" | .metadata.name style=\"\"" "${CSV_FILE_PATH}"
 ${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].name = \"${OPERATOR_INSTANCE_NAME}\"" "${CSV_FILE_PATH}"
@@ -52,8 +52,9 @@ ${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].spec.selector.matchLabe
 ${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].spec.template.metadata.labels[\"app.kubernetes.io/instance\"] = \"${OPERATOR_INSTANCE_NAME}\"" "${CSV_FILE_PATH}"
 ${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].spec.template.metadata.labels[\"app.kubernetes.io/name\"] = \"${OPERATOR_INSTANCE_NAME}\"" "${CSV_FILE_PATH}"
 ${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].name = \"${OPERATOR_NAME}\"" "${CSV_FILE_PATH}"
-${YQ} eval -o yaml -i ".spec.install.spec.clusterPermissions.[].serviceAccountName = \"${OPERATOR_NAME}\"" "${CSV_FILE_PATH}"
+# Change serviceAccountName as well
 ${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].spec.template.spec.serviceAccountName = \"${OPERATOR_NAME}\"" "${CSV_FILE_PATH}"
+${YQ} eval -o yaml -i ".spec.install.spec.clusterPermissions.[].serviceAccountName = \"${OPERATOR_NAME}\"" "${CSV_FILE_PATH}"
 
 # Add skipRange if present
 if [[ -n "$SKIP_RANGE" ]]; then

--- a/operator/src/main/java/com/github/streamshub/console/LeaderConfiguration.java
+++ b/operator/src/main/java/com/github/streamshub/console/LeaderConfiguration.java
@@ -7,6 +7,6 @@ import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 @ApplicationScoped
 public class LeaderConfiguration extends LeaderElectionConfiguration {
     public LeaderConfiguration() {
-        super("console-operator-lease");
+        super("streamshub-console-operator-lease");
     }
 }

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -19,7 +19,7 @@ rules:
       # The cluster operator needs to access and manage leases for leader election
       - leases
     resourceNames:
-      - console-operator-lease
+      - streamshub-operator-lease
     verbs:
       - get
       - list
@@ -89,7 +89,7 @@ roleRef:
   name: consolereconciler-additional-cluster-role
 subjects:
   - kind: ServiceAccount
-    name: console-operator
+    name: streamshub-operator
 ---
 # Required in order to grant to console instances with OpenShift Cluster Monitoring integration
 kind: ClusterRoleBinding
@@ -102,4 +102,4 @@ roleRef:
   name: cluster-monitoring-view
 subjects:
   - kind: ServiceAccount
-    name: console-operator
+    name: streamshub-operator

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -19,7 +19,7 @@ rules:
       # The cluster operator needs to access and manage leases for leader election
       - leases
     resourceNames:
-      - streamshub-operator-lease
+      - streamshub-console-operator-lease
     verbs:
       - get
       - list
@@ -89,7 +89,7 @@ roleRef:
   name: consolereconciler-additional-cluster-role
 subjects:
   - kind: ServiceAccount
-    name: streamshub-operator
+    name: streamshub-console-operator
 ---
 # Required in order to grant to console instances with OpenShift Cluster Monitoring integration
 kind: ClusterRoleBinding
@@ -102,4 +102,4 @@ roleRef:
   name: cluster-monitoring-view
 subjects:
   - kind: ServiceAccount
-    name: streamshub-operator
+    name: streamshub-console-operator

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -6,7 +6,7 @@ console.deployment.default-ui-image=quay.io/streamshub/console-ui:${console.depl
 
 quarkus.container-image.build=true
 #quarkus.container-image.group=
-quarkus.container-image.name=streamshub-console-operator
+quarkus.container-image.name=console-operator
 
 quarkus.operator-sdk.activate-leader-election-for-profiles=prod
 quarkus.operator-sdk.controllers."consolereconciler".selector=${console.selector}

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -6,7 +6,7 @@ console.deployment.default-ui-image=quay.io/streamshub/console-ui:${console.depl
 
 quarkus.container-image.build=true
 #quarkus.container-image.group=
-quarkus.container-image.name=console-operator
+quarkus.container-image.name=streamshub-console-operator
 
 quarkus.operator-sdk.activate-leader-election-for-profiles=prod
 quarkus.operator-sdk.controllers."consolereconciler".selector=${console.selector}


### PR DESCRIPTION
This PR targets current generic `console-operator` naming and changes it to `streamshub-operator`. This change affects kubernetes resources like Operator, CSV, Pod, Deployment, but also a ServiceAccount. However this change ignores image names as their full name already contains `streamshub` part in the registry name.