### PR TITLE
Change image tags with digests in bundle metadata

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,9 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    env:
+      PLATFORMS: linux/amd64,linux/arm64
+
     steps:
       # ==================== Setup ====================
       - name: Checkout
@@ -64,7 +67,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ui/
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           push: true
           tags: |
@@ -91,7 +94,7 @@ jobs:
           mvn verify -P container-image -B --no-transfer-progress \
             -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
             -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
-            -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
+            -Dquarkus.docker.buildx.platform=${{ env.PLATFORMS }}
 
       # ==================== Operator-Bundle ====================
       - name: Modify Bundle CSV Metadata
@@ -101,7 +104,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: operator/target/bundle/console-operator/
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           push: true
           file: operator/target/bundle/console-operator/bundle.Dockerfile
@@ -121,7 +124,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: operator/target/
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           push: true
           file: operator/target/catalog.Dockerfile

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -197,6 +197,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set Image Tag Env
+        run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Cache Maven Packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -220,9 +237,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: target
-
-      - name: Set Image Tag Env
-        run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Modify CSV Annotation
         run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -185,12 +185,25 @@ jobs:
 
   modify-bundle-metadata:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     needs:
       - build-api
       - build-ui
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Download API and UI Images
         uses: actions/download-artifact@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -213,5 +213,4 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') || github.repository == 'streamshub/console' }}
     uses: ./.github/workflows/playwright-tests.yml
     needs:
-      - build-api
-      - build-ui
+      - build-images

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -222,6 +222,11 @@ jobs:
         with:
           driver-opts: network=host
 
+      - name: Download API and UI Images
+        uses: actions/download-artifact@v4
+        with:
+          name: target
+
       - name: Build and Test Operator
         run: |
           export QUARKUS_CONTAINER_IMAGE_REGISTRY="localhost:5000"
@@ -233,10 +238,26 @@ jobs:
             -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
             -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
 
-      - name: Download API and UI Images
+      - name: Download API Image
         uses: actions/download-artifact@v4
         with:
-          name: target
+          name: backend-images
+          path: |
+            console-api-${{ env.PROJECT_VERSION }}.tar
+
+      - name: Download UI Image
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-images
+          path: |
+            console-ui-${{ env.PROJECT_VERSION }}.tar
+
+      - name: Load API and UI Images
+        run: |
+          ls
+          docker load -i console-api-${{ env.PROJECT_VERSION }}.tar
+          docker load -i console-ui-${{ env.PROJECT_VERSION }}.tar
+          docker images
 
       - name: Modify CSV Annotation
         run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -138,7 +138,7 @@ jobs:
             operator/target/catalog/
             operator/target/kubernetes/*.yml
 
-      - name: Archive Test Results
+      - name: Archive Failed Tests Results
         uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      # ==================== SETUP ====================
+      # ==================== Setup ====================
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -71,7 +71,7 @@ jobs:
             localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
 
       # ==================== API & Operator ====================
-      - name: Test Projects And Build API And Operator Images
+      - name: Test Projects and Build API and Operator Images
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           SONAR_ORG: ${{secrets.SONAR_ORG}}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           driver-opts: network=host
 
-      - name: Build and Test
+      - name: Build and Test API
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           SONAR_ORG: ${{secrets.SONAR_ORG}}
@@ -64,7 +64,7 @@ jobs:
           export QUARKUS_CONTAINER_IMAGE_PUSH=true
           export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
           export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
-          mvn verify -P container-image -B --no-transfer-progress \
+          mvn verify --pl api -P container-image -B --no-transfer-progress \
             -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
             -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
             -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
@@ -183,7 +183,7 @@ jobs:
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook"
 
-  modify-bundle-metadata:
+  build-operator:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -204,6 +204,17 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
+
+      - name: Build and Test Operator
+        run: |
+          export QUARKUS_CONTAINER_IMAGE_REGISTRY="localhost:5000"
+          export QUARKUS_CONTAINER_IMAGE_PUSH=true
+          export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
+          export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
+          mvn verify --pl operator -P container-image -B --no-transfer-progress \
+            -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
+            -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
+            -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
 
       - name: Download API and UI Images
         uses: actions/download-artifact@v4
@@ -226,6 +237,7 @@ jobs:
           file: operator/target/bundle/console-operator/bundle.Dockerfile
           tags: |
             localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}`
+
       - name: Save Operator and Catalog Images
         run: |
           docker pull localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,7 +64,7 @@ jobs:
           export QUARKUS_CONTAINER_IMAGE_PUSH=true
           export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
           export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
-          mvn verify --pl api -P container-image -B --no-transfer-progress \
+          mvn verify -am -pl api -P container-image -B --no-transfer-progress \
             -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
             -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
             -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
@@ -211,7 +211,7 @@ jobs:
           export QUARKUS_CONTAINER_IMAGE_PUSH=true
           export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
           export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
-          mvn verify --pl operator -P container-image -B --no-transfer-progress \
+          mvn verify -am -pl operator -P container-image -B --no-transfer-progress \
             -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
             -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
             -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,49 +69,8 @@ jobs:
             -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
             -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
 
-      - name: Modify CSV Annotation
-        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"
 
-      - name: Build Operator Bundle Image
-        uses: docker/build-push-action@v6
-        with:
-          context: operator/target/bundle/console-operator/
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          file: operator/target/bundle/console-operator/bundle.Dockerfile
-          tags: |
-            localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-
-      - name: Build Operator Catalog
-        run: |
-          curl -L -o opm https://github.com/operator-framework/operator-registry/releases/download/v1.43.1/linux-amd64-opm
-          chmod +x opm
-          sudo cp -v opm /usr/bin/
-          rm -vf opm
-          operator/bin/generate-catalog.sh ${{ env.PROJECT_VERSION }}
-
-      - name: Build Operator Catalog Image
-        uses: docker/build-push-action@v6
-        with:
-          context: operator/target/
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          file: operator/target/catalog.Dockerfile
-          tags: |
-            localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
-
-      - name: Attach Kubernetes Resources
-        uses: actions/upload-artifact@v4
-        with:
-          name: k8s-resources
-          path: |
-            operator/target/bundle/
-            operator/target/catalog/
-            operator/target/kubernetes/*.yml
-
-      - name: Archive Results
+      - name: Archive API Test Results
         uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -137,17 +96,10 @@ jobs:
             !**/target/failsafe-reports/**/*
             !**/target/surefire-reports/**/*
 
-      - name: Save Images
+      - name: Save API Image
         run: |
           docker pull localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
-
           docker save -o console-api-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-bundle-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-catalog-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
 
       - name: Archive Images
         uses: actions/upload-artifact@v4
@@ -155,9 +107,6 @@ jobs:
           name: backend-images
           path: |
             console-api-${{ env.PROJECT_VERSION }}.tar
-            console-operator-${{ env.PROJECT_VERSION }}.tar
-            console-operator-bundle-${{ env.PROJECT_VERSION }}.tar
-            console-operator-catalog-${{ env.PROJECT_VERSION }}.tar
 
   build-ui:
     runs-on: ubuntu-latest
@@ -202,7 +151,7 @@ jobs:
           tags: |
             localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
 
-      - name: Save Image
+      - name: Save UI Image
         run: |
           docker pull localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
           docker save -o console-ui-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
@@ -233,6 +182,47 @@ jobs:
           npx --yes concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook"
+
+  modify-metadata:
+    runs-on: ubuntu-latest
+    needs:
+      - build-api
+      - build-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Modify CSV Annotation
+        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"
+
+      - name: Build Operator Bundle Image
+        uses: docker/build-push-action@v6
+        with:
+          context: operator/target/bundle/console-operator/
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          file: operator/target/bundle/console-operator/bundle.Dockerfile
+          tags: |
+            localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}`
+      - name: Save Operator and Catalog Images
+        run: |
+          docker pull localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
+          docker pull localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
+          docker pull localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
+
+          docker save -o console-operator-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
+          docker save -o console-operator-bundle-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
+          docker save -o console-operator-catalog-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
+
+      - name: Archive Images
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-images
+          path: |
+            console-operator-${{ env.PROJECT_VERSION }}.tar
+            console-operator-bundle-${{ env.PROJECT_VERSION }}.tar
+            console-operator-catalog-${{ env.PROJECT_VERSION }}.tar
 
   Playwright:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') || github.repository == 'streamshub/console' }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -183,7 +183,7 @@ jobs:
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook"
 
-  modify-metadata:
+  modify-bundle-metadata:
     runs-on: ubuntu-latest
     needs:
       - build-api
@@ -191,6 +191,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download API and UI Images
+        uses: actions/download-artifact@v4
+        with:
+          name: target
+
+      - name: Set Image Tag Env
+        run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Modify CSV Annotation
         run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       registry:
         image: registry:2
@@ -169,31 +169,24 @@ jobs:
 
       - name: Save [UI, API, Operator, Operator-Bundle, Operator-Catalog] Images To Files
         run: |
-          docker pull localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
-         
-          docker save -o console-ui-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
-          docker save -o console-api-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-bundle-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-catalog-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
+          mkdir streamshub-images
+
+          for img in console-ui console-api console-operator console-operator-bundle console-operator-catalog ; do
+              skopeo sync --all --scoped --src docker --src-tls-verify=false --dest dir \
+                localhost:5000/streamshub/${img}:${{ env.PROJECT_VERSION }} \
+                $(pwd)/streamshub-images
+          done
+
+          tar -czf streamshub-images.tgz -C streamshub-images .
 
       - name: Archive [UI, API, Operator-Bundle, Operator, Operator-Catalog] Image Files
         uses: actions/upload-artifact@v4
         with:
           name: streamshub-images
-          path: |
-            console-ui-${{ env.PROJECT_VERSION }}.tar
-            console-api-${{ env.PROJECT_VERSION }}.tar
-            console-operator-${{ env.PROJECT_VERSION }}.tar
-            console-operator-bundle-${{ env.PROJECT_VERSION }}.tar
-            console-operator-catalog-${{ env.PROJECT_VERSION }}.tar
+          path: streamshub-images.tgz
 
   test-storybook:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ on:
     types: [ opened, reopened, synchronize ]
 
 jobs:
-  build-api:
+  build-images:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -19,13 +19,14 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      # ==================== SETUP ====================
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set Image Tag Env
         run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-      - name: Set up JDK 17
+      - name: Set Up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -39,98 +40,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up QEMU
+      - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
+      - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 
-      - name: Build and Test API
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          SONAR_ORG: ${{secrets.SONAR_ORG}}
-          SONAR_PROJECT: ${{secrets.SONAR_PROJECT}}
-          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-        run: |
-          #
-          # Set write-transformed-bytecode-to-build-output for IT coverage. Do NOT use the container image
-          # created by this step.
-          #
-          # See: https://quarkus.io/guides/tests-with-coverage#coverage-for-integration-tests
-          #
-          export QUARKUS_CONTAINER_IMAGE_REGISTRY="localhost:5000"
-          export QUARKUS_CONTAINER_IMAGE_PUSH=true
-          export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
-          export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
-          mvn verify -am -pl api -P container-image -B --no-transfer-progress \
-            -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
-            -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
-            -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
-
-
-      - name: Archive API Test Results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: artifacts
-          path: api/target/failsafe-reports/
-
-      ## Save the context information for use in Sonar analysis
-      - name: Save Build Context
-        run: |
-          mkdir -vp target
-          echo "$GITHUB_CONTEXT" > target/build-context.json
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      ## Attach the target directory for use in Sonar analysis
-      - name: Attach Build Output
-        uses: actions/upload-artifact@v4
-        with:
-          name: target
-          path: |
-            **/target/
-            !**/target/**/*.jar
-            !**/target/failsafe-reports/**/*
-            !**/target/surefire-reports/**/*
-
-      - name: Save API Image
-        run: |
-          docker pull localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
-          docker save -o console-api-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
-
-      - name: Archive Images
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-images
-          path: |
-            console-api-${{ env.PROJECT_VERSION }}.tar
-
-  build-ui:
-    runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set Image Tag Env
-        run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: network=host
-
-      - name: Build UI
+      # ==================== UI ====================
+      - name: Build UI Project
         working-directory: ui
         run: |
           npm ci --omit=dev
@@ -151,17 +70,124 @@ jobs:
           tags: |
             localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
 
-      - name: Save UI Image
+      # ==================== API & Operator ====================
+      - name: Test Projects And Build API And Operator Images
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          SONAR_ORG: ${{secrets.SONAR_ORG}}
+          SONAR_PROJECT: ${{secrets.SONAR_PROJECT}}
+          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
         run: |
-          docker pull localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
-          docker save -o console-ui-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
+          #
+          # Set write-transformed-bytecode-to-build-output for IT coverage. Do NOT use the container image
+          # created by this step.
+          #
+          # See: https://quarkus.io/guides/tests-with-coverage#coverage-for-integration-tests
+          #
+          export QUARKUS_CONTAINER_IMAGE_REGISTRY="localhost:5000"
+          export QUARKUS_CONTAINER_IMAGE_PUSH=true
+          export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
+          export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
+          mvn verify -P container-image -B --no-transfer-progress \
+            -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
+            -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
+            -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
 
-      - name: Archive Image
+      # ==================== Operator-Bundle ====================
+      - name: Modify Bundle CSV Metadata
+        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"
+
+      - name: Build Operator Bundle Image
+        uses: docker/build-push-action@v6
+        with:
+          context: operator/target/bundle/console-operator/
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          file: operator/target/bundle/console-operator/bundle.Dockerfile
+          tags: |
+            localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
+
+      # ==================== Operator-Catalog ====================
+      - name: Generate Operator Catalog Config
+        run: |
+          curl -L -o opm https://github.com/operator-framework/operator-registry/releases/download/v1.43.1/linux-amd64-opm
+          chmod +x opm
+          sudo cp -v opm /usr/bin/
+          rm -vf opm
+          operator/bin/generate-catalog.sh ${{ env.PROJECT_VERSION }}
+
+      - name: Build Operator Catalog Image
+        uses: docker/build-push-action@v6
+        with:
+          context: operator/target/
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          file: operator/target/catalog.Dockerfile
+          tags: |
+            localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
+
+      # ==================== Archive artifacts ====================
+      - name: Archive Operator Kubernetes Resources
         uses: actions/upload-artifact@v4
         with:
-          name: frontend-images
+          name: k8s-resources
+          path: |
+            operator/target/bundle/
+            operator/target/catalog/
+            operator/target/kubernetes/*.yml
+
+      - name: Archive Test Results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: artifacts
+          path: api/target/failsafe-reports/
+
+      ## Save the context information for use in Sonar analysis
+      - name: Save Build Context
+        run: |
+          mkdir -vp target
+          echo "$GITHUB_CONTEXT" > target/build-context.json
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      ## Attach the target directory for use in Sonar analysis
+      - name: Archive Build Output
+        uses: actions/upload-artifact@v4
+        with:
+          name: target
+          path: |
+            **/target/
+            !**/target/**/*.jar
+            !**/target/failsafe-reports/**/*
+            !**/target/surefire-reports/**/*
+
+      - name: Save [UI, API, Operator, Operator-Bundle, Operator-Catalog] Images To Files
+        run: |
+          docker pull localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
+          docker pull localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
+          docker pull localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
+          docker pull localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
+          docker pull localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
+         
+          docker save -o console-ui-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
+          docker save -o console-api-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}
+          docker save -o console-operator-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
+          docker save -o console-operator-bundle-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
+          docker save -o console-operator-catalog-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
+
+      - name: Archive [UI, API, Operator-Bundle, Operator, Operator-Catalog] Image Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: streamshub-images
           path: |
             console-ui-${{ env.PROJECT_VERSION }}.tar
+            console-api-${{ env.PROJECT_VERSION }}.tar
+            console-operator-${{ env.PROJECT_VERSION }}.tar
+            console-operator-bundle-${{ env.PROJECT_VERSION }}.tar
+            console-operator-catalog-${{ env.PROJECT_VERSION }}.tar
 
   test-storybook:
     runs-on: ubuntu-latest
@@ -182,115 +208,6 @@ jobs:
           npx --yes concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook"
-
-  build-operator:
-    runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    needs:
-      - build-api
-      - build-ui
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set Image Tag Env
-        run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-
-      - name: Cache Maven Packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: network=host
-
-      - name: Download API and UI Images
-        uses: actions/download-artifact@v4
-        with:
-          name: target
-
-      - name: Build and Test Operator
-        run: |
-          export QUARKUS_CONTAINER_IMAGE_REGISTRY="localhost:5000"
-          export QUARKUS_CONTAINER_IMAGE_PUSH=true
-          export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.PROJECT_VERSION }}"
-          export QUARKUS_KUBERNETES_VERSION="${{ env.PROJECT_VERSION }}"
-          mvn verify -am -pl operator -P container-image -B --no-transfer-progress \
-            -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
-            -Dquarkus.package.write-transformed-bytecode-to-build-output=true \
-            -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
-
-      - name: Download API Image
-        uses: actions/download-artifact@v4
-        with:
-          name: backend-images
-          path: |
-            console-api-${{ env.PROJECT_VERSION }}.tar
-
-      - name: Download UI Image
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-images
-          path: |
-            console-ui-${{ env.PROJECT_VERSION }}.tar
-
-      - name: Load API and UI Images
-        run: |
-          ls
-          docker load -i console-api-${{ env.PROJECT_VERSION }}.tar
-          docker load -i console-ui-${{ env.PROJECT_VERSION }}.tar
-          docker images
-
-      - name: Modify CSV Annotation
-        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"
-
-      - name: Build Operator Bundle Image
-        uses: docker/build-push-action@v6
-        with:
-          context: operator/target/bundle/console-operator/
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          file: operator/target/bundle/console-operator/bundle.Dockerfile
-          tags: |
-            localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}`
-
-      - name: Save Operator and Catalog Images
-        run: |
-          docker pull localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-          docker pull localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
-
-          docker save -o console-operator-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-bundle-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-bundle:${{ env.PROJECT_VERSION }}
-          docker save -o console-operator-catalog-${{ env.PROJECT_VERSION }}.tar localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}
-
-      - name: Archive Images
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-images
-          path: |
-            console-operator-${{ env.PROJECT_VERSION }}.tar
-            console-operator-bundle-${{ env.PROJECT_VERSION }}.tar
-            console-operator-catalog-${{ env.PROJECT_VERSION }}.tar
 
   Playwright:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') || github.repository == 'streamshub/console' }}

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -36,17 +36,11 @@ jobs:
           echo "CLUSTER_DOMAIN=$(minikube ip).nip.io" >> $GITHUB_ENV
           echo "CONSOLE_URL=https://example-console.$(minikube ip).nip.io" >> $GITHUB_ENV
 
-      - name: Download Backend Images
+      - name: Download Images
         uses: actions/download-artifact@v4
         with:
-          name: backend-images
-          path: backend-images
-
-      - name: Download Frontend Images
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-images
-          path: frontend-images
+          name: streamshub-images
+          path: streamshub-images
 
       - name: Prepare minikube
         run: |
@@ -57,15 +51,11 @@ jobs:
           SOCAT_PID=${!}
 
           # Load images
-          for img in console-api console-operator console-operator-bundle console-operator-catalog ; do
+          for img in console-api console-ui console-operator console-operator-bundle console-operator-catalog ; do
               skopeo copy --dest-tls-verify=false \
-                docker-archive:backend-images/${img}-${{ env.PROJECT_VERSION }}.tar \
+                docker-archive:streamshub/${img}-${{ env.PROJECT_VERSION }}.tar \
                 docker://localhost:5000/streamshub/${img}:${{ env.PROJECT_VERSION }}
           done
-
-          skopeo copy --dest-tls-verify=false \
-            docker-archive:frontend-images/console-ui-${{ env.PROJECT_VERSION }}.tar \
-            docker://localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}
 
           kill ${SOCAT_PID}
 

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -51,9 +51,9 @@ jobs:
           SOCAT_PID=${!}
 
           # Load images
-          for img in console-api console-ui console-operator console-operator-bundle console-operator-catalog ; do
+          for img in console-ui console-api console-operator console-operator-bundle console-operator-catalog ; do
               skopeo copy --dest-tls-verify=false \
-                docker-archive:streamshub/${img}-${{ env.PROJECT_VERSION }}.tar \
+                docker-archive:streamshub-images/${img}-${{ env.PROJECT_VERSION }}.tar \
                 docker://localhost:5000/streamshub/${img}:${{ env.PROJECT_VERSION }}
           done
 

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -11,11 +11,16 @@ env:
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download Images
+        uses: actions/download-artifact@v4
+        with:
+          name: streamshub-images
 
       - name: Start minikube
         id: minikube
@@ -36,12 +41,6 @@ jobs:
           echo "CLUSTER_DOMAIN=$(minikube ip).nip.io" >> $GITHUB_ENV
           echo "CONSOLE_URL=https://example-console.$(minikube ip).nip.io" >> $GITHUB_ENV
 
-      - name: Download Images
-        uses: actions/download-artifact@v4
-        with:
-          name: streamshub-images
-          path: streamshub-images
-
       - name: Prepare minikube
         run: |
           set -x
@@ -50,12 +49,13 @@ jobs:
           socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000 &
           SOCAT_PID=${!}
 
+          mkdir streamshub-images
+          tar -xzf streamshub-images.tgz -C streamshub-images
+
           # Load images
-          for img in console-ui console-api console-operator console-operator-bundle console-operator-catalog ; do
-              skopeo copy --dest-tls-verify=false \
-                docker-archive:streamshub-images/${img}-${{ env.PROJECT_VERSION }}.tar \
-                docker://localhost:5000/streamshub/${img}:${{ env.PROJECT_VERSION }}
-          done
+          skopeo sync --all --scoped --src dir --dest docker --dest-tls-verify=false \
+            streamshub-images/localhost:5000/streamshub \
+            localhost:5000/streamshub
 
           kill ${SOCAT_PID}
 
@@ -99,15 +99,7 @@ jobs:
               sourceNamespace: olm' | kubectl apply -n operators -f -
 
           # Install Console Operator
-          yq ea '.spec.sourceNamespace = "olm", .spec.config = {
-                "env": [{
-                  "name": "CONSOLE_DEPLOYMENT_DEFAULT_API_IMAGE",
-                  "value": "localhost:5000/streamshub/console-api:${{ env.PROJECT_VERSION }}"
-                }, {
-                  "name": "CONSOLE_DEPLOYMENT_DEFAULT_UI_IMAGE",
-                  "value": "localhost:5000/streamshub/console-ui:${{ env.PROJECT_VERSION }}"
-                }]
-              }' ./install/operator-olm/020-Subscription-console-operator.yaml \
+          yq ea '.spec.sourceNamespace = "olm"' ./install/operator-olm/020-Subscription-console-operator.yaml \
             | kubectl apply -n operators -f -
 
           wait_operator() {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,10 @@ jobs:
     if: ${{github.event.pull_request.merged == true}}
     env:
       GITHUB_TOKEN: ${{secrets.RELEASE_TOKEN}}
+      PLATFORMS: linux/amd64,linux/arm64
 
     steps:
+      # ==================== Setup ====================
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -39,6 +41,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
+          username: "${{ secrets.IMAGE_REPO_USERNAME }}"
+          password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
+
+      # ==================== UI ====================
+      - name: Build UI
+        working-directory: target/checkout/ui
+        run: |
+          npm ci --omit=dev
+          export BACKEND_URL=http://example
+          export NEXTAUTH_SECRET=examplesecret
+          export LOG_LEVEL=info
+          export CONSOLE_MODE=read-only
+          npm run build
+
+      - name: Build and Push UI Image
+        uses: docker/build-push-action@v6
+        with:
+          context: target/checkout/ui/
+          platforms: ${{ env.PLATFORMS }}
+          provenance: false
+          push: true
+          tags: |
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-ui:${{steps.metadata.outputs.current-version}}
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-ui:latest
+
+      # ==================== API & Operator ====================
       - name: Build and Push API and Operator Image
         run: |
           git config --global user.name "github-actions[bot]"
@@ -57,23 +89,17 @@ jobs:
           export GIT_REVISION=$(git rev-parse --short release)
           # Build and push the release images using the commit tagged in `release:prepare`
           mvn -B -P container-image release:perform --no-transfer-progress \
-            '-Drelease.arguments=-Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64'
+            '-Drelease.arguments=-Dquarkus.docker.buildx.platform=${{ env.PLATFORMS }}'
 
-      - name: Login to Quay
-        uses: docker/login-action@v3
-        with:
-          registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
-          username: "${{ secrets.IMAGE_REPO_USERNAME }}"
-          password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
-
-      - name: Modify CSV Annotation
+      # ==================== Operator-Bundle ====================
+      - name: Modify Bundle CSV Metadata
         run: ./operator/bin/modify-bundle-metadata.sh
 
       - name: Build and Push Operator Bundle Image
         uses: docker/build-push-action@v6
         with:
           context: target/checkout/operator/target/bundle/console-operator/
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           push: true
           file: target/checkout/operator/target/bundle/console-operator/bundle.Dockerfile
@@ -81,7 +107,8 @@ jobs:
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-bundle:${{steps.metadata.outputs.current-version}}
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-bundle:latest
 
-      - name: Build Operator Catalog
+      # ==================== Operator-Catalog ====================
+      - name: Generate Operator Catalog Config
         working-directory: target/checkout
         run: |
           curl -L -o opm https://github.com/operator-framework/operator-registry/releases/download/v1.43.1/linux-amd64-opm
@@ -95,7 +122,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: target/checkout/operator/target/
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           push: true
           file: target/checkout/operator/target/catalog.Dockerfile
@@ -103,27 +130,7 @@ jobs:
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-catalog:${{steps.metadata.outputs.current-version}}
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-catalog:latest
 
-      - name: Build UI
-        working-directory: target/checkout/ui
-        run: |
-          npm ci --omit=dev
-          export BACKEND_URL=http://example
-          export NEXTAUTH_SECRET=examplesecret
-          export LOG_LEVEL=info
-          export CONSOLE_MODE=read-only
-          npm run build
-
-      - name: Build and Push UI Image
-        uses: docker/build-push-action@v6
-        with:
-          context: target/checkout/ui/
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          tags: |
-            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-ui:${{steps.metadata.outputs.current-version}}
-            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-ui:latest
-
+      # ==================== GitHub Release ====================
       - name: Prepare Operator Resources
         run: |
           RELEASE_K8S_PATH='target/checkout/operator/target/kubernetes'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,8 +12,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: snapshot
-
+    env:
+      PLATFORMS: linux/amd64,linux/arm64
     steps:
+      # ==================== Setup ====================
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -48,22 +50,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and Push API and Operator Image
-        run: |
-          export QUARKUS_CONTAINER_IMAGE_REGISTRY="${{ secrets.IMAGE_REPO_HOSTNAME }}"
-          export QUARKUS_CONTAINER_IMAGE_GROUP="${{ secrets.IMAGE_REPO_NAMESPACE }}"
-          export QUARKUS_CONTAINER_IMAGE_USERNAME="${{ secrets.IMAGE_REPO_USERNAME }}"
-          export QUARKUS_CONTAINER_IMAGE_PASSWORD="${{ secrets.IMAGE_REPO_PASSWORD }}"
-          export QUARKUS_CONTAINER_IMAGE_PUSH="true"
-          export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.NEXT_VERSION }}"
-          export QUARKUS_CONTAINER_IMAGE_ADDITIONAL_TAGS=snapshot-${{github.ref_name}}
-          export QUARKUS_KUBERNETES_VERSION="${{ env.NEXT_VERSION }}"
-          export GIT_REVISION=$(git rev-parse --short HEAD)
-          # Build and push the snapshot images
-          mvn -B -P container-image verify --no-transfer-progress -DskipTests \
-            -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
-            -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
-
       - name: Login to Quay
         uses: docker/login-action@v3
         with:
@@ -71,50 +57,7 @@ jobs:
           username: "${{ secrets.IMAGE_REPO_USERNAME }}"
           password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
 
-      - name: Modify CSV Annotation
-        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.NEXT_VERSION }}"
-
-      - name: Build and Push Operator Bundle Image
-        uses: docker/build-push-action@v6
-        with:
-          context: operator/target/bundle/console-operator/
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          file: operator/target/bundle/console-operator/bundle.Dockerfile
-          tags: |
-            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-bundle:${{ env.NEXT_VERSION }}
-            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-bundle:snapshot-${{github.ref_name}}
-
-      - name: Build Operator Catalog
-        run: |
-          curl -L -o opm https://github.com/operator-framework/operator-registry/releases/download/v1.43.1/linux-amd64-opm
-          chmod +x opm
-          sudo cp -v opm /usr/bin/
-          rm -vf opm
-          operator/bin/generate-catalog.sh ${{ env.NEXT_VERSION }}
-
-      - name: Build and Push Operator Catalog Image
-        uses: docker/build-push-action@v6
-        with:
-          context: operator/target/
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          file: operator/target/catalog.Dockerfile
-          tags: |
-            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-catalog:${{ env.NEXT_VERSION }}
-            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-catalog:snapshot-${{github.ref_name}}
-
-      - name: Attach Kubernetes Resources
-        uses: actions/upload-artifact@v4
-        with:
-          name: k8s-resources
-          path: |
-            operator/target/bundle/
-            operator/target/catalog/
-            operator/target/kubernetes/*.yml
-
+      # ==================== UI ====================
       - name: Build UI
         working-directory: ui
         run: |
@@ -129,9 +72,75 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ui/
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           push: true
           tags: |
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-ui:${{ env.NEXT_VERSION }}
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-ui:snapshot-${{github.ref_name}}
+
+      # ==================== API & Operator ====================
+      - name: Build and Push API and Operator Image
+        run: |
+          export QUARKUS_CONTAINER_IMAGE_REGISTRY="${{ secrets.IMAGE_REPO_HOSTNAME }}"
+          export QUARKUS_CONTAINER_IMAGE_GROUP="${{ secrets.IMAGE_REPO_NAMESPACE }}"
+          export QUARKUS_CONTAINER_IMAGE_USERNAME="${{ secrets.IMAGE_REPO_USERNAME }}"
+          export QUARKUS_CONTAINER_IMAGE_PASSWORD="${{ secrets.IMAGE_REPO_PASSWORD }}"
+          export QUARKUS_CONTAINER_IMAGE_PUSH="true"
+          export QUARKUS_CONTAINER_IMAGE_TAG="${{ env.NEXT_VERSION }}"
+          export QUARKUS_CONTAINER_IMAGE_ADDITIONAL_TAGS=snapshot-${{github.ref_name}}
+          export QUARKUS_KUBERNETES_VERSION="${{ env.NEXT_VERSION }}"
+          export GIT_REVISION=$(git rev-parse --short HEAD)
+          # Build and push the snapshot images
+          mvn -B -P container-image verify --no-transfer-progress -DskipTests \
+            -Dquarkus.kubernetes.namespace='$${NAMESPACE}' \
+            -Dquarkus.docker.buildx.platform=${{ env.PLATFORMS }}
+
+      # ==================== Operator-Bundle ====================
+      - name: Modify Bundle CSV Metadata
+        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.NEXT_VERSION }}"
+
+      - name: Build and Push Operator Bundle Image
+        uses: docker/build-push-action@v6
+        with:
+          context: operator/target/bundle/console-operator/
+          platforms: ${{ env.PLATFORMS }}
+          provenance: false
+          push: true
+          file: operator/target/bundle/console-operator/bundle.Dockerfile
+          tags: |
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-bundle:${{ env.NEXT_VERSION }}
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-bundle:snapshot-${{github.ref_name}}
+
+      # ==================== Operator-Catalog ====================
+      - name: Generate Operator Catalog Config
+        run: |
+          curl -L -o opm https://github.com/operator-framework/operator-registry/releases/download/v1.43.1/linux-amd64-opm
+          chmod +x opm
+          sudo cp -v opm /usr/bin/
+          rm -vf opm
+          operator/bin/generate-catalog.sh ${{ env.NEXT_VERSION }}
+
+      - name: Build and Push Operator Catalog Image
+        uses: docker/build-push-action@v6
+        with:
+          context: operator/target/
+          platforms: ${{ env.PLATFORMS }}
+          provenance: false
+          push: true
+          file: operator/target/catalog.Dockerfile
+          tags: |
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-catalog:${{ env.NEXT_VERSION }}
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/console-operator-catalog:snapshot-${{github.ref_name}}
+
+      # ==================== Archive artifacts ====================
+      - name: Attach Kubernetes Resources
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-resources
+          path: |
+            operator/target/bundle/
+            operator/target/catalog/
+            operator/target/kubernetes/*.yml
+
+      

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include *compose.env
 
 IMAGE_REGISTRY ?= quay.io
 IMAGE_GROUP ?= streamshub
-VERSION = $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')
+VERSION ?= $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')
 
 CONSOLE_API_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_GROUP)/console-api:$(VERSION)
 CONSOLE_UI_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_GROUP)/console-ui:$(VERSION)
@@ -52,7 +52,7 @@ container-image-ui:
 	export CONSOLE_MODE=read-only && \
 	npm run build && \
 	cd $(CURDIR) && \
-	$(CONTAINER_RUNTIME) build -t $(CONSOLE_UI_IMAGE) ./ui -f ./ui/Dockerfile
+	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_UI_IMAGE) ./ui -f ./ui/Dockerfile
 
 container-image-ui-push: container-image-ui
 	$(CONTAINER_RUNTIME) push $(CONSOLE_UI_IMAGE)

--- a/operator/bin/common.sh
+++ b/operator/bin/common.sh
@@ -5,6 +5,7 @@ SCRIPT_PATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 BUNDLE_PATH=${SCRIPT_PATH}/../target/bundle/console-operator/
 CSV_FILE_PATH=${BUNDLE_PATH}/manifests/console-operator.clusterserviceversion.yaml
 CATALOG_PATH=${SCRIPT_PATH}/../target/catalog
+OPERATOR_CATALOG_CONFIG_YAML_PATH=${CATALOG_PATH}/operator.yaml
 # Operator naming
 ORIGINAL_OPERATOR_NAME="console-operator"
 OPERATOR_NAME="streamshub-console-operator"

--- a/operator/bin/generate-catalog.sh
+++ b/operator/bin/generate-catalog.sh
@@ -10,10 +10,10 @@ rm -rvf ${CATALOG_PATH} ${CATALOG_PATH}.Dockerfile
 mkdir -p ${CATALOG_PATH}
 
 opm generate dockerfile ${CATALOG_PATH}
-opm init ${OPERATOR_NAME} --default-channel=alpha --output=yaml > ${CATALOG_PATH}/operator.yaml
-opm render ${BUNDLE_PATH} --output=yaml >> ${CATALOG_PATH}/operator.yaml
+opm init ${OPERATOR_NAME} --default-channel=alpha --output=yaml > ${OPERATOR_CATALOG_CONFIG_YAML_PATH}
+opm render ${BUNDLE_PATH} --output=yaml >> ${OPERATOR_CATALOG_CONFIG_YAML_PATH}
 
-cat << EOF >> ${CATALOG_PATH}/operator.yaml
+cat << EOF >> ${OPERATOR_CATALOG_CONFIG_YAML_PATH}
 ---
 schema: olm.channel
 package: ${OPERATOR_NAME}
@@ -23,8 +23,8 @@ entries:
 EOF
 
 # Rename package names
-${YQ} eval -o yaml -i ". |= select(.package == \"${ORIGINAL_OPERATOR_NAME}\").package = \"${OPERATOR_NAME}\"" "${CATALOG_PATH}/operator.yaml"
-${YQ} eval -o yaml -i "(.properties[] | select(.value.packageName == \"${ORIGINAL_OPERATOR_NAME}\") | .value.packageName) = \"${OPERATOR_NAME}\"" "${CATALOG_PATH}/operator.yaml"
+${YQ} eval -o yaml -i ". |= select(.package == \"${ORIGINAL_OPERATOR_NAME}\").package = \"${OPERATOR_NAME}\"" "${OPERATOR_CATALOG_CONFIG_YAML_PATH}"
+${YQ} eval -o yaml -i "(.properties[] | select(.value.packageName == \"${ORIGINAL_OPERATOR_NAME}\") | .value.packageName) = \"${OPERATOR_NAME}\"" "${OPERATOR_CATALOG_CONFIG_YAML_PATH}"
 
 opm validate ${CATALOG_PATH}
 

--- a/operator/bin/modify-bundle-metadata.sh
+++ b/operator/bin/modify-bundle-metadata.sh
@@ -32,8 +32,8 @@ operator_image_with_tag=$(${YQ} eval "${yq_image_expression}" "${CSV_FILE_PATH}"
 echo "[DEBUG] Original operator image name with tag = ${operator_image_with_tag}"
 
 # Derive Registry and Tag for UI and API images
-image_registry=$(echo "${operator_image_with_tag}" | rev | cut -d':' -f2- | rev | sed "s|\/${operator_name}||")
-image_tag=$(echo "${operator_image_with_tag}" | cut -d':' -f2- )
+image_registry=$(echo "${operator_image_with_tag}" | cut -d'/' -f1)
+image_tag=$(echo "${operator_image_with_tag}" | rev | cut -d':' -f1 | rev)
 echo "[DEBUG] Image registry = ${image_registry}"
 echo "[DEBUG] Image tag = ${image_tag}"
 

--- a/operator/bin/modify-bundle-metadata.sh
+++ b/operator/bin/modify-bundle-metadata.sh
@@ -32,7 +32,7 @@ operator_image_with_tag=$(${YQ} eval "${yq_image_expression}" "${CSV_FILE_PATH}"
 echo "[DEBUG] Original operator image name with tag = ${operator_image_with_tag}"
 
 # Derive Registry and Tag for UI and API images
-image_registry=$(echo "${operator_image_with_tag}" | cut -d'/' -f1)
+image_registry=$(echo "${operator_image_with_tag}" | rev | cut -d'/' -f2- | rev)
 image_tag=$(echo "${operator_image_with_tag}" | rev | cut -d':' -f1 | rev)
 echo "[DEBUG] Image registry = ${image_registry}"
 echo "[DEBUG] Image tag = ${image_tag}"

--- a/operator/bin/modify-bundle-metadata.sh
+++ b/operator/bin/modify-bundle-metadata.sh
@@ -48,6 +48,7 @@ ${YQ} eval -o yaml -i ".spec.relatedImages = null" "${CSV_FILE_PATH}"
 echo "[DEBUG] Setting container image = ${operator_image_with_digest}"
 ${YQ} eval -o yaml -i ".spec.relatedImages += [{\"name\": \"${OPERATOR_NAME}\", \"image\": \"${operator_image_with_digest}\"}]" "${CSV_FILE_PATH}";
 ${YQ} eval -o yaml -i ".metadata.annotations.containerImage = \"${operator_image_with_digest}\"" "${CSV_FILE_PATH}"
+${YQ} eval -o yaml -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image = \"${operator_image_with_digest}\"" "${CSV_FILE_PATH}"
 
 # Add current createdAt time
 curr_time_date="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"


### PR DESCRIPTION
This PR introduces the use of SHA digests for built images in operator environment variables. Instead of relying on image tags, which can be unreliable for snapshot and latest tagged images, the operator now explicitly references UI and API images using their SHA digests.
The API and UI images will now always pull the correct version, ensuring consistency and avoiding issues caused by tag mismatches. 

This change was necessary because previously, using snapshot images with tags could result in the wrong image being pulled due to the console deployment's `IfNotPresent` image pull policy.