### PR TITLE
Configuration of trust stores for Prometheus and Apicurio clients

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -16,6 +16,7 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.streamshub.console.api.support.serdes.ApicurioClient;
 import com.github.streamshub.console.api.support.serdes.ForceCloseable;
 import com.github.streamshub.console.api.support.serdes.MultiformatDeserializer;
 import com.github.streamshub.console.api.support.serdes.MultiformatSerializer;
@@ -190,7 +191,7 @@ public class KafkaContext implements Closeable {
             this.config = config;
 
             if (config != null) {
-                registryClient = RegistryClientFactory.create(config.getUrl());
+                registryClient = RegistryClientFactory.create(new ApicurioClient(config));
             } else {
                 registryClient = null;
             }

--- a/api/src/main/java/com/github/streamshub/console/api/support/serdes/ApicurioClient.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/serdes/ApicurioClient.java
@@ -1,0 +1,220 @@
+package com.github.streamshub.console.api.support.serdes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.github.streamshub.console.config.SchemaRegistryConfig;
+
+import io.apicurio.registry.rest.client.impl.ErrorHandler;
+import io.apicurio.rest.client.auth.Auth;
+import io.apicurio.rest.client.error.RestClientErrorHandler;
+import io.apicurio.rest.client.request.Request;
+import io.apicurio.rest.client.spi.ApicurioHttpClient;
+import io.apicurio.rest.client.util.RegistryDateDeserializer;
+import io.apicurio.rest.client.util.UriUtil;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+
+import static com.github.streamshub.console.support.StringSupport.replaceNonAlphanumeric;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Apicurio client based on {@code io.apicurio.rest.client.JdkHttpClient}, but
+ * with awareness of Quarkus TLS registry configuration and removing other
+ * unused options for mTLS keystores, headers, etc.
+ *
+ * @see https://github.com/Apicurio/apicurio-common-rest-client/blob/0868773f61e33d40dcac88608aa111e26ab71bc7/rest-client-jdk/src/main/java/io/apicurio/rest/client/JdkHttpClient.java
+ */
+public class ApicurioClient implements ApicurioHttpClient {
+
+    public static final String INVALID_EMPTY_HTTP_KEY = "";
+    private final HttpClient client;
+    private final String endpoint;
+    private final Auth auth;
+    private final RestClientErrorHandler errorHandler;
+
+    private static final ThreadLocal<Map<String, String>> HEADERS = ThreadLocal.withInitial(Collections::emptyMap);
+
+    public ApicurioClient(SchemaRegistryConfig config) {
+        String url = config.getUrl();
+
+        if (!url.endsWith("/")) {
+            url += "/";
+        }
+
+        final HttpClient.Builder httpClientBuilder = handleConfiguration(config);
+        this.endpoint = url;
+        this.auth = null;
+        this.client = httpClientBuilder.build();
+        this.errorHandler = new ErrorHandler();
+    }
+
+    private HttpClient.Builder handleConfiguration(SchemaRegistryConfig config) {
+        HttpClient.Builder clientBuilder = HttpClient.newBuilder();
+        clientBuilder.version(HttpClient.Version.HTTP_1_1);
+
+        var tlsConfig = getTlsConfiguration(config.getName());
+
+        if (tlsConfig.isPresent()) {
+            try {
+                clientBuilder = clientBuilder.sslContext(tlsConfig.get().createSSLContext());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return clientBuilder;
+    }
+
+    Optional<TlsConfiguration> getTlsConfiguration(String sourceName) {
+        String dotSeparatedSource = "schema.registry." + replaceNonAlphanumeric(sourceName, '.');
+        String dashSeparatedSource = "schema-registry-" + replaceNonAlphanumeric(sourceName, '-');
+        var tlsRegistry = CDI.current().select(TlsConfigurationRegistry.class).get();
+        return tlsRegistry.get(dotSeparatedSource).or(() -> tlsRegistry.get(dashSeparatedSource));
+    }
+
+    @Override
+    public <T> T sendRequest(Request<T> request) {
+        try {
+            requireNonNull(request.getOperation(), "Request operation cannot be null");
+            requireNonNull(request.getResponseType(), "Response type cannot be null");
+
+            final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(UriUtil.buildURI(endpoint + request.getRequestPath(), request.getQueryParams(), request.getPathParams()));
+
+            //Add current request headers
+            HEADERS.get().forEach(requestBuilder::header);
+            HEADERS.remove();
+
+            Map<String, String> headers = request.getHeaders();
+            if (this.auth != null) {
+                //make headers mutable...
+                headers = new HashMap<>(headers);
+                this.auth.apply(headers);
+            }
+            headers.forEach(requestBuilder::header);
+
+            switch (request.getOperation()) {
+                case GET:
+                    requestBuilder.GET();
+                    break;
+                case PUT:
+                    requestBuilder.PUT(HttpRequest.BodyPublishers.ofByteArray(request.getData().readAllBytes()));
+                    break;
+                case POST:
+                    if (request.getDataString() != null) {
+                        requestBuilder.POST(HttpRequest.BodyPublishers.ofString(request.getDataString()));
+                    } else {
+                        requestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(request.getData().readAllBytes()));
+                    }
+                    break;
+                case DELETE:
+                    requestBuilder.DELETE();
+                    break;
+                default:
+                    throw new IllegalStateException("Operation not allowed");
+            }
+
+            return client.sendAsync(requestBuilder.build(), new BodyHandler<>(request.getResponseType(), errorHandler))
+                    .join()
+                    .body()
+                    .get();
+
+        } catch (IOException e) {
+            throw errorHandler.parseError(e);
+        }
+    }
+
+    @Override
+    public void setNextRequestHeaders(Map<String, String> headers) {
+        HEADERS.set(headers);
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return HEADERS.get();
+    }
+
+    @Override
+    public void close() {
+        // No-op
+    }
+
+    /**
+     * From {@code io.apicurio.rest.client.handler.BodyHandler}
+     *
+     * @see https://github.com/Apicurio/apicurio-common-rest-client/blob/0868773f61e33d40dcac88608aa111e26ab71bc7/rest-client-jdk/src/main/java/io/apicurio/rest/client/handler/BodyHandler.java
+     */
+    private static class BodyHandler<W> implements HttpResponse.BodyHandler<Supplier<W>> {
+
+        private final TypeReference<W> wClass;
+        private final RestClientErrorHandler errorHandler;
+        private static final ObjectMapper MAPPER = new ObjectMapper();
+        static {
+            SimpleModule module = new SimpleModule("Custom date handler");
+            module.addDeserializer(Date.class, new RegistryDateDeserializer());
+            MAPPER.registerModule(module);
+        }
+
+        public BodyHandler(TypeReference<W> wClass, RestClientErrorHandler errorHandler) {
+            this.wClass = wClass;
+            this.errorHandler = errorHandler;
+            MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        }
+
+        @Override
+        public HttpResponse.BodySubscriber<Supplier<W>> apply(HttpResponse.ResponseInfo responseInfo) {
+            return asJSON(wClass, responseInfo, errorHandler);
+        }
+
+        public static <W> HttpResponse.BodySubscriber<Supplier<W>> asJSON(TypeReference<W> targetType, HttpResponse.ResponseInfo responseInfo, RestClientErrorHandler errorHandler) {
+            HttpResponse.BodySubscriber<InputStream> upstream = HttpResponse.BodySubscribers.ofInputStream();
+            return HttpResponse.BodySubscribers.mapping(
+                    upstream,
+                    inputStream -> toSupplierOfType(inputStream, targetType, responseInfo, errorHandler));
+        }
+
+        @SuppressWarnings("unchecked")
+        public static <W> Supplier<W> toSupplierOfType(InputStream body, TypeReference<W> targetType, HttpResponse.ResponseInfo responseInfo, RestClientErrorHandler errorHandler) {
+            return () -> {
+                try {
+                    if (isFailure(responseInfo)) {
+                        throw errorHandler.handleErrorResponse(body, responseInfo.statusCode());
+                    } else {
+                        final String typeName = targetType.getType().getTypeName();
+                        if (typeName.contains("InputStream")) {
+                            return (W) body;
+                        } else if (typeName.contains("Void")) {
+                            //Intended null return
+                            return null;
+                        } else {
+                            return MAPPER.readValue(body, targetType);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            };
+        }
+
+        private static boolean isFailure(HttpResponse.ResponseInfo responseInfo) {
+            return responseInfo.statusCode() / 100 != 2;
+        }
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -74,7 +74,7 @@ console.kafka.admin.default.api.timeout.ms=10000
 ########
 #%dev.quarkus.http.auth.proactive=false
 #%dev.quarkus.http.auth.permission."oidc".policy=permit
-%dev.quarkus.tls.trust-all=true
+#%dev.quarkus.tls.trust-all=true
 %dev.quarkus.kubernetes-client.trust-certs=true
 %dev.quarkus.log.category."io.vertx.core.impl.BlockedThreadChecker".level=OFF
 %dev.quarkus.log.category."com.github.streamshub.console".level=DEBUG

--- a/common/src/main/java/com/github/streamshub/console/support/StringSupport.java
+++ b/common/src/main/java/com/github/streamshub/console/support/StringSupport.java
@@ -2,7 +2,11 @@ package com.github.streamshub.console.support;
 
 import java.util.Locale;
 
-public class StringSupport {
+public final class StringSupport {
+
+    private StringSupport() {
+        // No instances
+    }
 
     public static boolean isAsciiLetterOrDigit(char c) {
         return 'a' <= c && c <= 'z' ||

--- a/common/src/main/java/com/github/streamshub/console/support/StringSupport.java
+++ b/common/src/main/java/com/github/streamshub/console/support/StringSupport.java
@@ -1,0 +1,37 @@
+package com.github.streamshub.console.support;
+
+import java.util.Locale;
+
+public class StringSupport {
+
+    public static boolean isAsciiLetterOrDigit(char c) {
+        return 'a' <= c && c <= 'z' ||
+                'A' <= c && c <= 'Z' ||
+                '0' <= c && c <= '9';
+    }
+
+    public static String replaceNonAlphanumeric(final String name, char replacement) {
+        return replaceNonAlphanumeric(name, replacement, new StringBuilder(name.length()));
+    }
+
+    public static String replaceNonAlphanumeric(final String name, char replacement, final StringBuilder sb) {
+        int length = name.length();
+        for (int i = 0; i < length; i++) {
+            char c = name.charAt(i);
+            if (isAsciiLetterOrDigit(c)) {
+                sb.append(c);
+            } else {
+                sb.append(replacement);
+                if (c == '"' && i + 1 == length) {
+                    sb.append(replacement);
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    public static String toEnv(String name) {
+        return replaceNonAlphanumeric(name, '_').toUpperCase(Locale.ROOT);
+    }
+
+}

--- a/common/src/test/java/com/github/streamshub/console/support/StringSupportTest.java
+++ b/common/src/test/java/com/github/streamshub/console/support/StringSupportTest.java
@@ -1,0 +1,28 @@
+package com.github.streamshub.console.support;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringSupportTest {
+
+    @Test
+    void testReplaceNonAlphanumericStringChar() {
+        String actual = StringSupport.replaceNonAlphanumeric("hyphenated-segment", '.');
+        assertEquals("hyphenated.segment", actual);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "console.config.\"Hyphenated-Segment-1\".value, CONSOLE_CONFIG__HYPHENATED_SEGMENT_1__VALUE",
+        "console.config.\"Hyphenated-Segment-1\", CONSOLE_CONFIG__HYPHENATED_SEGMENT_1__",
+        "console.config.{Braced-Segment}, CONSOLE_CONFIG__BRACED_SEGMENT_",
+    })
+    void testToEnv(String input, String expected) {
+        String actual = StringSupport.toEnv(input);
+        assertEquals(expected, actual);
+    }
+
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
@@ -22,6 +22,12 @@ public class SchemaRegistry {
     @JsonPropertyDescription("URL of the Apicurio Registry server API.")
     private String url;
 
+    @JsonPropertyDescription("""
+            Trust store configuration for when the schema registry uses \
+            TLS certificates signed by an unknown CA.
+            """)
+    private TrustStore trustStore;
+
     public String getName() {
         return name;
     }
@@ -36,5 +42,13 @@ public class SchemaRegistry {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public TrustStore getTrustStore() {
+        return trustStore;
+    }
+
+    public void setTrustStore(TrustStore trustStore) {
+        this.trustStore = trustStore;
     }
 }

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/TrustStore.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/TrustStore.java
@@ -1,0 +1,74 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TrustStore {
+
+    @JsonProperty("type")
+    private Type type; // NOSONAR
+
+    @JsonProperty("content")
+    @JsonPropertyDescription("Content of the trust store")
+    private Value content;
+
+    @JsonProperty("password")
+    @JsonPropertyDescription("Content used to access the trust store, if necessary")
+    private Value password;
+
+    @JsonProperty("alias")
+    @JsonPropertyDescription("Alias to select the appropriate certificate when multiple certificates are included.")
+    private String alias;
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public Value getContent() {
+        return content;
+    }
+
+    public void setContent(Value content) {
+        this.content = content;
+    }
+
+    public Value getPassword() {
+        return password;
+    }
+
+    public void setPassword(Value password) {
+        this.password = password;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public enum Type {
+        PEM("pem"), PKCS12("p12"), JKS("jks");
+
+        private final String value;
+
+        private Type(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
@@ -1,0 +1,37 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Value {
+
+    @JsonProperty("value")
+    @JsonPropertyDescription("Literal string to be used for this value")
+    private String value; // NOSONAR
+
+    @JsonProperty("valueFrom")
+    @JsonPropertyDescription("Reference to an external source to use for this value")
+    private ValueReference valueFrom;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public ValueReference getValueFrom() {
+        return valueFrom;
+    }
+
+    public void setValueFrom(ValueReference valueFrom) {
+        this.valueFrom = valueFrom;
+    }
+
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
@@ -1,5 +1,6 @@
 package com.github.streamshub.console.api.v1alpha1.spec;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -17,6 +18,18 @@ public class Value {
     @JsonProperty("valueFrom")
     @JsonPropertyDescription("Reference to an external source to use for this value")
     private ValueReference valueFrom;
+
+    public Value() {
+    }
+
+    private Value(String value) {
+        this.value = value;
+    }
+
+    @JsonIgnore
+    public static Value of(String value) {
+        return value != null ? new Value(value) : null;
+    }
 
     public String getValue() {
         return value;

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ValueReference.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ValueReference.java
@@ -1,0 +1,39 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
+import io.fabric8.kubernetes.api.model.SecretKeySelector;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ValueReference {
+
+    @JsonProperty("configMapKeyRef")
+    @JsonPropertyDescription("Reference to a ConfigMap entry value")
+    private ConfigMapKeySelector configMapKeyRef;
+
+    @JsonProperty("secretKeyRef")
+    @JsonPropertyDescription("Reference to a Secret entry value")
+    private SecretKeySelector secretKeyRef;
+
+    public ConfigMapKeySelector getConfigMapKeyRef() {
+        return configMapKeyRef;
+    }
+
+    public void setConfigMapKeyRef(ConfigMapKeySelector configMapKeyRef) {
+        this.configMapKeyRef = configMapKeyRef;
+    }
+
+    public SecretKeySelector getSecretKeyRef() {
+        return secretKeyRef;
+    }
+
+    public void setSecretKeyRef(SecretKeySelector secretKeyRef) {
+        this.secretKeyRef = secretKeyRef;
+    }
+
+}

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSource.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSource.java
@@ -2,7 +2,9 @@ package com.github.streamshub.console.api.v1alpha1.spec.metrics;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.github.streamshub.console.api.v1alpha1.spec.TrustStore;
 
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
@@ -16,6 +18,13 @@ public class MetricsSource {
     @Required
     private Type type;
     private String url;
+
+    @JsonPropertyDescription("""
+            Trust store configuration for when the metrics source uses \
+            TLS certificates signed by an unknown CA.
+            """)
+    private TrustStore trustStore;
+
     private MetricsSourceAuthentication authentication;
 
     public String getName() {
@@ -40,6 +49,14 @@ public class MetricsSource {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public TrustStore getTrustStore() {
+        return trustStore;
+    }
+
+    public void setTrustStore(TrustStore trustStore) {
+        this.trustStore = trustStore;
     }
 
     public MetricsSourceAuthentication getAuthentication() {

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleDeployment.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleDeployment.java
@@ -97,8 +97,6 @@ public class ConsoleDeployment extends CRUDKubernetesDependentResource<Deploymen
                         .editMatchingContainer(c -> "console-api".equals(c.getName()))
                             .withImage(imageAPI)
                             .addAllToVolumeMounts(getResourcesByType(trustResources, VolumeMount.class))
-                            // Remove first to avoid duplicates
-                            .removeMatchingFromEnv(env -> envVars.stream().anyMatch(e -> env.getName().equals(e.getName())))
                             .addAllToEnv(envVars)
                         .endContainer()
                         .editMatchingContainer(c -> "console-ui".equals(c.getName()))

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleSecret.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleSecret.java
@@ -5,10 +5,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,6 +35,9 @@ import com.github.streamshub.console.api.v1alpha1.spec.ConfigVars;
 import com.github.streamshub.console.api.v1alpha1.spec.Credentials;
 import com.github.streamshub.console.api.v1alpha1.spec.KafkaCluster;
 import com.github.streamshub.console.api.v1alpha1.spec.SchemaRegistry;
+import com.github.streamshub.console.api.v1alpha1.spec.TrustStore;
+import com.github.streamshub.console.api.v1alpha1.spec.Value;
+import com.github.streamshub.console.api.v1alpha1.spec.ValueReference;
 import com.github.streamshub.console.api.v1alpha1.spec.metrics.MetricsSource;
 import com.github.streamshub.console.api.v1alpha1.spec.metrics.MetricsSource.Type;
 import com.github.streamshub.console.config.ConsoleConfig;
@@ -40,9 +46,15 @@ import com.github.streamshub.console.config.PrometheusConfig;
 import com.github.streamshub.console.config.SchemaRegistryConfig;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteIngress;
@@ -58,12 +70,18 @@ import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserStatus;
 
+import static com.github.streamshub.console.support.StringSupport.replaceNonAlphanumeric;
+import static com.github.streamshub.console.support.StringSupport.toEnv;
+
 @ApplicationScoped
 @KubernetesDependent(labelSelector = ConsoleResource.MANAGEMENT_SELECTOR)
 public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Console> implements ConsoleResource {
 
     public static final String NAME = "console-secret";
+
     private static final String EMBEDDED_METRICS_NAME = "streamshub.console.embedded-prometheus";
+    private static final String METRICS_TRUST_PREFIX = "metrics-source-truststore.";
+    private static final String REGISTRY_TRUST_PREFIX = "schema-registry-truststore.";
     private static final Random RANDOM = new SecureRandom();
 
     @Inject
@@ -98,6 +116,8 @@ public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Conso
             throw new UncheckedIOException(e);
         }
 
+        buildTrustStores(primary, context, data);
+
         updateDigest(context, "console-digest", data);
 
         return new SecretBuilder()
@@ -108,6 +128,119 @@ public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Conso
                 .endMetadata()
                 .withData(data)
                 .build();
+    }
+
+    /**
+     * Generate additional entries in the secret for metric source trust stores. Also, this
+     * method will add to the context the resources to be added to the console deployment to
+     * access the secret entries.
+     */
+    private void buildTrustStores(Console primary, Context<Console> context, Map<String, String> data) {
+        Map<Class<?>, List<?>> deploymentResources = new HashMap<>();
+
+        for (var metricsSource : Optional.ofNullable(primary.getSpec().getMetricsSources())
+                .orElse(Collections.emptyList())) {
+            var truststore = metricsSource.getTrustStore();
+
+            if (truststore != null) {
+                reconcileTrustStore(primary, context, data, metricsSource.getName(), METRICS_TRUST_PREFIX, truststore, "metrics-source", deploymentResources);
+            }
+        }
+
+        for (var registry : Optional.ofNullable(primary.getSpec().getSchemaRegistries())
+                .orElse(Collections.emptyList())) {
+            var truststore = registry.getTrustStore();
+
+            if (truststore != null) {
+                reconcileTrustStore(primary, context, data, registry.getName(), REGISTRY_TRUST_PREFIX, truststore, "schema-registry", deploymentResources);
+            }
+        }
+
+        context.managedDependentResourceContext().put("TrustStoreResources", deploymentResources);
+    }
+
+    @SuppressWarnings("java:S107") // Ignore Sonar warning for too many args
+    private void reconcileTrustStore(
+            Console primary,
+            Context<Console> context,
+            Map<String, String> data,
+            String sourceName,
+            String sourcePrefix,
+            TrustStore truststore,
+            String bucketPrefix,
+            Map<Class<?>, List<?>> deploymentResources) {
+
+        String namespace = primary.getMetadata().getNamespace();
+        String secretName = instanceName(primary);
+        String typeCode = truststore.getType().toString();
+        String volumeName = replaceNonAlphanumeric(sourcePrefix + sourceName, '-');
+
+        @SuppressWarnings("unchecked")
+        List<Volume> volumes = (List<Volume>) deploymentResources.computeIfAbsent(Volume.class, k -> new ArrayList<>());
+
+        volumes.add(new VolumeBuilder()
+                .withName(volumeName)
+                .withNewSecret()
+                    .withSecretName(secretName)
+                    .addNewItem()
+                        .withKey(sourcePrefix + sourceName + ".content")
+                        .withPath(sourcePrefix + sourceName + "." + typeCode)
+                    .endItem()
+                    .withDefaultMode(420)
+                .endSecret()
+                .build());
+
+        @SuppressWarnings("unchecked")
+        List<VolumeMount> mounts = (List<VolumeMount>) deploymentResources.computeIfAbsent(VolumeMount.class, k -> new ArrayList<>());
+
+        mounts.add(new VolumeMountBuilder()
+                .withName(volumeName)
+                .withMountPath("/etc/ssl/" + sourcePrefix + sourceName + "." + typeCode)
+                .withSubPath(sourcePrefix + sourceName + "." + typeCode)
+                .build());
+
+        String configTemplate = "quarkus.tls.\"" + bucketPrefix + "-%s\".trust-store.%s.%s";
+
+        @SuppressWarnings("unchecked")
+        List<EnvVar> vars = (List<EnvVar>) deploymentResources.computeIfAbsent(EnvVar.class, k -> new ArrayList<>());
+
+        if (putMetricsTrustStoreValue(data, sourceName, "content", getValue(context, namespace, truststore.getContent()))) {
+            String pathKey = switch (truststore.getType()) {
+                case JKS, PKCS12 -> "path";
+                case PEM -> "certs";
+            };
+
+            vars.add(new EnvVarBuilder()
+                    .withName(toEnv(configTemplate.formatted(sourceName, typeCode, pathKey)))
+                    .withValue("/etc/ssl/" + sourcePrefix + sourceName + "." + typeCode)
+                    .build());
+        }
+
+        if (putMetricsTrustStoreValue(data, sourceName, "password", getValue(context, namespace, truststore.getPassword()))) {
+            vars.add(new EnvVarBuilder()
+                    .withName(toEnv(configTemplate.formatted(sourceName, typeCode, "password")))
+                    .withNewValueFrom()
+                        .withNewSecretKeyRef(sourcePrefix + sourceName + ".password", secretName, false)
+                    .endValueFrom()
+                    .build());
+        }
+
+        if (putMetricsTrustStoreValue(data, sourceName, "alias", truststore.getAlias())) {
+            vars.add(new EnvVarBuilder()
+                    .withName(toEnv(configTemplate.formatted(sourceName, typeCode, "alias")))
+                    .withNewValueFrom()
+                        .withNewSecretKeyRef(sourcePrefix + sourceName + ".alias", secretName, false)
+                    .endValueFrom()
+                    .build());
+        }
+    }
+
+    private boolean putMetricsTrustStoreValue(Map<String, String> data, String sourceName, String key, String value) {
+        if (value != null) {
+            data.put(METRICS_TRUST_PREFIX + sourceName + "." + key, value);
+            return true;
+        }
+        return false;
     }
 
     private static String base64String(int length) {
@@ -393,6 +526,45 @@ public class ConsoleSecret extends CRUDKubernetesDependentResource<Secret, Conso
             }
             target.put(key, decode ? decodeString(value) : value);
         });
+    }
+
+    /**
+     * Fetch the string value from the given valueSpec. The return string
+     * will be encoded for use in the Console secret data map.
+     */
+    String getValue(Context<Console> context, String namespace, Value valueSpec) {
+        if (valueSpec == null) {
+            return null;
+        }
+
+        return Optional.ofNullable(valueSpec.getValue())
+                .map(this::encodeString)
+            .or(() -> Optional.ofNullable(valueSpec.getValueFrom())
+                    .map(ValueReference::getConfigMapKeyRef)
+                    .map(ref -> getValue(context, ConfigMap.class, namespace, ref.getName(), ref.getKey(), ref.getOptional(), ConfigMap::getData))
+                    .map(this::encodeString))
+            .or(() -> Optional.ofNullable(valueSpec.getValueFrom())
+                    .map(ValueReference::getSecretKeyRef)
+                    .map(ref -> getValue(context, Secret.class, namespace, ref.getName(), ref.getKey(), ref.getOptional(), Secret::getData))
+                    /* No need to call encodeString, the value is already encoded from Secret */)
+            .orElse(null);
+    }
+
+    <S extends HasMetadata> String getValue(Context<Console> context,
+            Class<S> sourceType,
+            String namespace,
+            String name,
+            String key,
+            Boolean optional,
+            Function<S, Map<String, String>> dataProvider) {
+
+        S source = getResource(context, sourceType, namespace, name, Boolean.TRUE.equals(optional));
+
+        if (source != null) {
+            return dataProvider.apply(source).get(key);
+        }
+
+        return null;
     }
 
     static <T extends HasMetadata> T getResource(

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
@@ -13,13 +13,6 @@ spec:
     spec:
       serviceAccountName: placeholder
       volumes:
-      - name: kubernetes-ca
-        configMap:
-          name: kube-root-ca.crt
-          items:
-          - key: ca.crt
-            path: kubernetes-ca.pem
-          defaultMode: 420
       - name: cache
         emptyDir: {}
       - name: config
@@ -33,15 +26,10 @@ spec:
         - containerPort: 8080
           name: http
         volumeMounts:
-        - name: kubernetes-ca
-          mountPath: /etc/ssl/kubernetes-ca.pem
-          subPath: kubernetes-ca.pem
         - name: config
           mountPath: /deployments/console-config.yaml
           subPath: console-config.yaml
         env:
-        - name: QUARKUS_TLS_TRUST_STORE_PEM_CERTS
-          value: /etc/ssl/kubernetes-ca.pem
         - name: CONSOLE_CONFIG_PATH
           value: /deployments/console-config.yaml
         startupProbe:

--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTest.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTest.java
@@ -225,22 +225,7 @@ class ConsoleReconcilerTest {
             .editStatus(this::setReady);
         LOGGER.info("Set ready replicas for Prometheus deployment");
 
-        var consoleIngress = client.network().v1().ingresses()
-            .inNamespace(consoleCR.getMetadata().getNamespace())
-            .withName("console-1-console-ingress")
-            .get();
-
-        consoleIngress = consoleIngress.edit()
-                    .editOrNewStatus()
-                        .withNewLoadBalancer()
-                            .addNewIngress()
-                                .withHostname("ingress.example.com")
-                            .endIngress()
-                        .endLoadBalancer()
-                    .endStatus()
-                    .build();
-        client.resource(consoleIngress).patchStatus();
-        LOGGER.info("Set ingress status for Console ingress");
+        setConsoleIngressReady(consoleCR);
 
         await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
             var console = client.resources(Console.class)
@@ -860,6 +845,25 @@ class ConsoleReconcilerTest {
             ConsoleConfig consoleConfig = YAML.readValue(configDecoded, ConsoleConfig.class);
             assertion.accept(consoleConfig);
         });
+    }
+
+    private void setConsoleIngressReady(Console consoleCR) {
+        var consoleIngress = client.network().v1().ingresses()
+                .inNamespace(consoleCR.getMetadata().getNamespace())
+                .withName("console-1-console-ingress")
+                .get();
+
+        consoleIngress = consoleIngress.edit()
+                    .editOrNewStatus()
+                        .withNewLoadBalancer()
+                            .addNewIngress()
+                                .withHostname("ingress.example.com")
+                            .endIngress()
+                        .endLoadBalancer()
+                    .endStatus()
+                    .build();
+        client.resource(consoleIngress).patchStatus();
+        LOGGER.info("Set ingress status for Console ingress");
     }
 
     private Deployment setReady(Deployment deployment) {


### PR DESCRIPTION
Closes #1277 

--- 

Approach

This change allows for a trust store to be configured for metrics source (Prometheus) and schema registry (Apicurio) clients. The trust store may be set in the Console CR along with the URLs for each connection type.

For example:
```yaml
...
spec:
  metricsSources:
    - name: ocp-prometheus
      type: openshift-monitoring
      url: https://thanos-querier.mycluster.example.com
      truststore:
        type: PEM  # also supports JKS or PKCS12
        alias: "" # optional, only for JKS or PKCS12
        password: {} # optional, only for JKS or PKCS12. Same structure as `content` below
        content:
          # only one of `value` or `valueFrom` is used
          value: |
            -----BEGIN CERTIFICATE-----
            MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
            ...
            emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
            -----END CERTIFICATE-----
          # May use a ConfigMap or Secret key when no literal value is given
          valueFrom:
            configMapKeyRef: {}
            secretKeyRef: {}
...
```

The operator will then read the trust store content either directly from the CR for literal values or from the ConfigMap or Secret, copy to the Console secret being reconciled, and create a volume/mount and appropriate Quarkus environment vars for a TLS configuration bucket [1] specific to the connection. 

The clients in the API server will then obtain the trust store/SSL context from the TLS bucket named by convention and use for the connection to the remote service.

[1] https://quarkus.io/guides/tls-registry-reference#using-the-tls-registry

