### PR TITLE
fix: correct release failure and incorrect CSV name generation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,7 +98,7 @@ jobs:
 
       # ==================== Operator-Bundle ====================
       - name: Modify Bundle CSV Metadata
-        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"
+        run: ./operator/bin/modify-bundle-metadata.sh "VERSION=${{ env.PROJECT_VERSION }}" "SKIP_RANGE=>=0.0.1 <${{ env.PROJECT_VERSION }}"
 
       - name: Build Operator Bundle Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,8 @@ jobs:
 
       # ==================== Operator-Bundle ====================
       - name: Modify Bundle CSV Metadata
-        run: ./operator/bin/modify-bundle-metadata.sh
+        working-directory: target/checkout
+        run: ./operator/bin/modify-bundle-metadata.sh "VERSION=${{steps.metadata.outputs.current-version}}" "SKIP_RANGE=>=0.0.1 <${{steps.metadata.outputs.current-version}}"
 
       - name: Build and Push Operator Bundle Image
         uses: docker/build-push-action@v6
@@ -115,8 +116,7 @@ jobs:
           chmod +x opm
           sudo cp -v opm /usr/bin/
           rm -vf opm
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')
-          operator/bin/generate-catalog.sh ${VERSION}
+          operator/bin/generate-catalog.sh ${{steps.metadata.outputs.current-version}}
 
       - name: Build and Push Operator Catalog Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -98,7 +98,7 @@ jobs:
 
       # ==================== Operator-Bundle ====================
       - name: Modify Bundle CSV Metadata
-        run: ./operator/bin/modify-bundle-metadata.sh "SKIP_RANGE=>=0.0.1 <${{ env.NEXT_VERSION }}"
+        run: ./operator/bin/modify-bundle-metadata.sh "VERSION=${{ env.NEXT_VERSION }}" "SKIP_RANGE=>=0.0.1 <${{ env.NEXT_VERSION }}"
 
       - name: Build and Push Operator Bundle Image
         uses: docker/build-push-action@v6

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ include *compose.env
 IMAGE_REGISTRY ?= quay.io
 IMAGE_GROUP ?= streamshub
 VERSION ?= $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr '[:upper:]' '[:lower:]')
+CSV_VERSION ?= $(VERSION)
 
 CONSOLE_API_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_GROUP)/console-api:$(VERSION)
 CONSOLE_UI_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_GROUP)/console-ui:$(VERSION)
@@ -34,8 +35,8 @@ container-image-api-push: container-image-api
 
 container-image-operator:
 	mvn package -am -pl operator -Pcontainer-image -DskipTests -Dquarkus.container-image.image=$(CONSOLE_OPERATOR_IMAGE)
-	operator/bin/modify-bundle-metadata.sh SKOPEO_TRANSPORT=$(SKOPEO_TRANSPORT)
-	operator/bin/generate-catalog.sh $(VERSION)
+	operator/bin/modify-bundle-metadata.sh "VERSION=$(CSV_VERSION)" "SKIP_RANGE=$(SKIP_RANGE)" "SKOPEO_TRANSPORT=$(SKOPEO_TRANSPORT)"
+	operator/bin/generate-catalog.sh $(CSV_VERSION)
 	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_OPERATOR_BUNDLE_IMAGE) -f operator/target/bundle/console-operator/bundle.Dockerfile
 	$(CONTAINER_RUNTIME) build --platform=$(ARCH) -t $(CONSOLE_OPERATOR_CATALOG_IMAGE) -f operator/target/catalog.Dockerfile
 

--- a/operator/bin/generate-catalog.sh
+++ b/operator/bin/generate-catalog.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 SCRIPT_PATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
-source ${SCRIPT_PATH}/common.sh
+
 export VERSION="${1}"
+
+source ${SCRIPT_PATH}/common.sh
 
 echo "[INFO] Generate catalog"
 


### PR DESCRIPTION
Fixes #1279 

- correct working directory for bundle modifications during release
- make sure `common.sh` is not evaluated before the vars it depends on
- update package name in bundle annotations YAML and container image labels