### PR TITLE
Content-specific page titles

### DIFF
--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getConsumerGroup } from "@/api/consumerGroups/actions";
 import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
 import { MembersTable } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/MembersTable";
@@ -5,6 +6,14 @@ import { KafkaParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/kafka.p
 import { PageSection } from "@/libs/patternfly/react-core";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
+
+export async function generateMetadata(props: { params: { kafkaId: string, groupId: string} }) {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("ConsumerGroup.title")} ${props.params.groupId} | ${t("common.title")}`,
+  };
+}
 
 export default function ConsumerGroupMembersPage({
   params: { kafkaId, groupId },

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getConsumerGroup } from "@/api/consumerGroups/actions";
 import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
 import { KafkaParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/kafka.params";
@@ -5,6 +6,14 @@ import { PageSection } from "@/libs/patternfly/react-core";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { ResetConsumerOffset } from "./ResetConsumerOffset";
+
+export async function generateMetadata(props: { params: { kafkaId: string, groupId: string} }) {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("ConsumerGroupsTable.reset_offset")} ${props.params.groupId} | ${t("common.title")}`,
+  };
+}
 
 export default function ResetOffsetPage({
   params: { kafkaId, groupId },

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getConsumerGroups } from "@/api/consumerGroups/actions";
 import { KafkaParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/kafka.params";
 import { PageSection } from "@/libs/patternfly/react-core";
@@ -10,6 +11,14 @@ import { ConsumerGroupState } from "@/api/consumerGroups/schema";
 import { ConnectedConsumerGroupTable } from "./ConnectedConsumerGroupTable";
 import { stringToInt } from "@/utils/stringToInt";
 import { notFound } from "next/navigation";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("ConsumerGroups.title")} | ${t("common.title")}`,
+  };
+}
 
 const sortMap: Record<(typeof SortableColumns)[number], string> = {
   name: "name",

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/[nodeId]/configuration/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/[nodeId]/configuration/page.tsx
@@ -1,7 +1,16 @@
+import { getTranslations } from "next-intl/server";
 import { getNodeConfiguration } from "@/api/nodes/actions";
 import { KafkaNodeParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/kafkaNode.params";
 import { PageSection } from "@/libs/patternfly/react-core";
 import { ConfigTable } from "./ConfigTable";
+
+export async function generateMetadata(props: { params: { kafkaId: string, nodeId: string  }}) {
+  const t = await getTranslations();
+
+  return {
+    title: `Broker ${props.params.nodeId} Configuration | ${t("common.title")}`,
+  };
+}
 
 export default async function NodeDetails({
   params: { kafkaId, nodeId },

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/page.tsx
@@ -9,6 +9,14 @@ import { Alert, PageSection } from "@/libs/patternfly/react-core";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("nodes.title")} | ${t("common.title")}`,
+  };
+}
+
 function nodeMetric(
   metrics: { value: string, nodeId: string }[] | undefined,
   nodeId: number,

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/rebalances/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/rebalances/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { KafkaParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/kafka.params";
 import { RebalanceTableColumn, RebalanceTableColumns } from "./RebalanceTable";
 import { PageSection } from "@/libs/patternfly/react-core";
@@ -7,6 +8,14 @@ import { ConnectedReabalancesTable } from "./ConnectedRebalancesTable";
 import { getRebalancesList } from "@/api/rebalance/actions";
 import { RebalanceMode, RebalanceStatus } from "@/api/rebalance/schema";
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("Rebalancing.title")} | ${t("common.title")}`,
+  };
+}
 
 const sortMap: Record<(typeof RebalanceTableColumns)[number], string> = {
   name: "name",

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/overview/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/overview/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getConsumerGroups } from "@/api/consumerGroups/actions";
 import { getKafkaCluster } from "@/api/kafka/actions";
 import { getTopics, getViewedTopics } from "@/api/topics/actions";
@@ -8,6 +9,14 @@ import { ConnectedTopicChartsCard } from "@/app/[locale]/(authorized)/kafka/[kaf
 import { ConnectedTopicsPartitionsCard } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/overview/ConnectedTopicsPartitionsCard";
 import { PageLayout } from "@/components/ClusterOverview/PageLayout";
 import { ConnectedRecentTopics } from "./ConnectedRecentTopics";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("overview.title")} | ${t("common.title")}`,
+  };
+}
 
 export default function OverviewPage({ params }: { params: KafkaParams }) {
   const kafkaCluster = getKafkaCluster(params.kafkaId, {

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/(page)/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/(page)/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getTopics } from "@/api/topics/actions";
 import { TopicStatus } from "@/api/topics/schema";
 import { KafkaParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/kafka.params";
@@ -11,6 +12,14 @@ import { Suspense } from "react";
 import { ConnectedTopicsTable } from "./ConnectedTopicsTable";
 
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("topics.title")} | ${t("common.title")}`,
+  };
+}
 
 const sortMap: Record<(typeof SortableColumns)[number], string> = {
   name: "name",

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/configuration/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/configuration/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getTopic, updateTopic } from "@/api/topics/actions";
 import { KafkaTopicParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/topics/kafkaTopic.params";
 import { PageSection } from "@/libs/patternfly/react-core";
@@ -5,6 +6,14 @@ import { redirect } from "@/i18n/routing";
 import { isReadonly } from "@/utils/env";
 import { Suspense } from "react";
 import { ConfigTable } from "./ConfigTable";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `Topic Configuration | ${t("common.title")}`,
+  };
+}
 
 export default function TopicConfiguration({
   params: { kafkaId, topicId },

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/consumer-groups/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/consumer-groups/page.tsx
@@ -1,9 +1,18 @@
+import { getTranslations } from "next-intl/server";
 import { getTopicConsumerGroups } from "@/api/consumerGroups/actions";
 import { ConsumerGroupsTable } from "./ConsumerGroupsTable";
 import { KafkaTopicParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/topics/kafkaTopic.params";
 import { PageSection } from "@/libs/patternfly/react-core";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `Topic Consumer Groups | ${t("common.title")}`,
+  };
+}
 
 export default function ConsumerGroupsPage({
   params: { kafkaId, topicId },

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/messages/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/messages/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { getTopicMessage } from "@/api/messages/actions";
 import { getTopic } from "@/api/topics/actions";
 import { KafkaTopicParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/topics/kafkaTopic.params";
@@ -7,6 +8,14 @@ import { MessagesSearchParams, parseSearchParams } from "./parseSearchParams";
 
 export const revalidate = 0;
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("message-browser.title")} | ${t("common.title")}`,
+  };
+}
 
 export default async function ConnectedMessagesPage({
   params: { kafkaId, topicId },

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/partitions/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/partitions/page.tsx
@@ -1,8 +1,17 @@
+import { getTranslations } from "next-intl/server";
 import { getTopic } from "@/api/topics/actions";
 import { KafkaTopicParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/topics/kafkaTopic.params";
 import { redirect } from "@/i18n/routing";
 import { Suspense } from "react";
 import { PartitionsTable } from "./PartitionsTable";
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `Partitions | ${t("common.title")}`,
+  };
+}
 
 export default function PartitionsPage({
   params: { kafkaId, topicId },

--- a/ui/app/[locale]/(public)/(home)/page.tsx
+++ b/ui/app/[locale]/(public)/(home)/page.tsx
@@ -31,6 +31,14 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import styles from "./home.module.css";
 
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("homepage.title")} | ${t("common.title")}`,
+  };
+}
+
 export default async function Home() {
   const t = await getTranslations();
   const allClusters = await getKafkaClusters();

--- a/ui/app/[locale]/(public)/kafka/[kafkaId]/login/page.tsx
+++ b/ui/app/[locale]/(public)/kafka/[kafkaId]/login/page.tsx
@@ -1,6 +1,15 @@
 import { getKafkaClusters } from "@/api/kafka/actions";
 import { redirect } from "@/i18n/routing";
 import { SignInPage } from "./SignInPage";
+import { getTranslations } from "next-intl/server";;
+
+export async function generateMetadata() {
+  const t = await getTranslations();
+
+  return {
+    title: `${t("login-in-page.title")} | ${t("common.title")}`,
+  };
+}
 
 export default async function SignIn({
   searchParams,

--- a/ui/app/[locale]/layout.tsx
+++ b/ui/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import { getMessages, getTranslations } from "next-intl/server";
-import { useNow, useTimeZone } from "next-intl";
 import { ReactNode } from "react";
 import NextIntlProvider from "./NextIntlProvider";
 import "../globals.css";

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -28,6 +28,7 @@
     }
   },
   "login-in-page": {
+    "title": "Login",
     "login_sub_title": "Enter your credentials",
     "username": "Username",
     "password": "Password",
@@ -55,7 +56,7 @@
     }
   },
   "homepage": {
-    "title": "Integration Developer Hub",
+    "title": "Home",
     "connected_kafka_clusters": "Connected Kafka clusters",
     "page_header": "Welcome to the {product} console",
     "page_subtitle": "The {brand} {product} console provides a user interface for managing and monitoring your streaming resources",
@@ -74,6 +75,7 @@
     "title": "Overview"
   },
   "nodes": {
+    "title": "Brokers",
     "kpis_offline": "Prometheus can't be reached, or is not configured. Information on the page will be incomplete. Please check your configuration.",
     "broker_id": "Broker ID",
     "status": "Status",
@@ -533,11 +535,16 @@
     "end_offset": "End offset",
     "end_offset_tooltip": "The highest offset in the Kafka topic, representing the latest available message."
   },
+  "ConsumerGroups": {
+    "title": "Consumer Groups"
+  },
   "ConsumerGroup": {
+    "title": "Consumer Group",
     "reset_offset": "Reset offset",
     "delete": "Delete"
   },
   "Rebalancing": {
+    "title": "Rebalance",
     "approve_rebalance_proposal": "Approve Rebalance Proposal?",
     "stop_rebalance": "Stop Rebalance",
     "refresh_rebalance": "Refresh Rebalance",


### PR DESCRIPTION
Set page titles based on the content. This allows for a more usable browser history. Most of the titles here are not specific to the Kafka or Topic name viewed, which can be added later.

All titles have the format `{page specific name} | StreamsHub console`.

Closes #1210