### PR TITLE
Remove CRD model `builderPackage`, use subpackages for operator handlers

### DIFF
--- a/operator/src/main/java/com/github/streamshub/console/ConsoleReconciler.java
+++ b/operator/src/main/java/com/github/streamshub/console/ConsoleReconciler.java
@@ -17,15 +17,15 @@ import com.github.streamshub.console.dependents.ConsoleResource;
 import com.github.streamshub.console.dependents.ConsoleSecret;
 import com.github.streamshub.console.dependents.ConsoleService;
 import com.github.streamshub.console.dependents.ConsoleServiceAccount;
-import com.github.streamshub.console.dependents.DeploymentReadyCondition;
-import com.github.streamshub.console.dependents.IngressReadyCondition;
 import com.github.streamshub.console.dependents.PrometheusClusterRole;
 import com.github.streamshub.console.dependents.PrometheusClusterRoleBinding;
 import com.github.streamshub.console.dependents.PrometheusConfigMap;
 import com.github.streamshub.console.dependents.PrometheusDeployment;
-import com.github.streamshub.console.dependents.PrometheusPrecondition;
 import com.github.streamshub.console.dependents.PrometheusService;
 import com.github.streamshub.console.dependents.PrometheusServiceAccount;
+import com.github.streamshub.console.dependents.conditions.DeploymentReadyCondition;
+import com.github.streamshub.console.dependents.conditions.IngressReadyCondition;
+import com.github.streamshub.console.dependents.conditions.PrometheusPrecondition;
 
 import io.javaoperatorsdk.operator.AggregatedOperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Cleaner;

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/Console.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/Console.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 
 @Version("v1alpha1")
 @Group("console.streamshub.github.com")
-@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @CSVMetadata(
     displayName = "Console Instance",

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVar.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVar.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConfigVar {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVarSource.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVarSource.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapEnvSource;
 import io.fabric8.kubernetes.api.model.SecretEnvSource;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidationRule(
         value = "has(self.configMapRef) || has(self.secretRef)",

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVars.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVars.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConfigVars {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
@@ -10,7 +10,7 @@ import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 // Enable validation rules for unique names when array maxItems and string maxLength can be specified
 // to influence Kubernetes's estimated rule cost.

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Credentials.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Credentials.java
@@ -7,7 +7,7 @@ import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
 @ValidationRule(value = "has(self.kafkaUser)", message = "kafkaUser is required")
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Credentials {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/CredentialsKafkaUser.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/CredentialsKafkaUser.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CredentialsKafkaUser {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Images.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Images.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Images {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
@@ -7,7 +7,7 @@ import io.fabric8.generator.annotation.Required;
 import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidationRule(
         // The `namespace` property must be wrapped in double underscore to escape it

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SchemaRegistry {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/TrustStore.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/TrustStore.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TrustStore {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Value {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ValueReference.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ValueReference.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ValueReference {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSource.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSource.java
@@ -9,7 +9,7 @@ import com.github.streamshub.console.api.v1alpha1.spec.TrustStore;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MetricsSource {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSourceAuthentication.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSourceAuthentication.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidationRule(
         value = "has(self.token) || (has(self.username) && has(self.password))",

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/Condition.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/Condition.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Condition {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.javaoperatorsdk.operator.api.ObservedGenerationAwareStatus;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConsoleStatus extends ObservedGenerationAwareStatus {
 

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleClusterRole.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleClusterRole.java
@@ -2,6 +2,8 @@ package com.github.streamshub.console.dependents;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import com.github.streamshub.console.dependents.discriminators.ConsoleLabelDiscriminator;
+
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleClusterRoleBinding.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleClusterRoleBinding.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
+import com.github.streamshub.console.dependents.discriminators.ConsoleLabelDiscriminator;
 
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleDeployment.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleDeployment.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
 import com.github.streamshub.console.api.v1alpha1.spec.Images;
+import com.github.streamshub.console.dependents.discriminators.ConsoleLabelDiscriminator;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.KubernetesResource;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleMonitoringClusterRoleBinding.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleMonitoringClusterRoleBinding.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
 import com.github.streamshub.console.api.v1alpha1.spec.metrics.MetricsSource.Type;
+import com.github.streamshub.console.dependents.discriminators.ConsoleLabelDiscriminator;
 
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleService.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleService.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
+import com.github.streamshub.console.dependents.discriminators.ConsoleLabelDiscriminator;
 
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleServiceAccount.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleServiceAccount.java
@@ -2,6 +2,8 @@ package com.github.streamshub.console.dependents;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import com.github.streamshub.console.dependents.discriminators.ConsoleLabelDiscriminator;
+
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @ApplicationScoped

--- a/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusClusterRole.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusClusterRole.java
@@ -2,6 +2,8 @@ package com.github.streamshub.console.dependents;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import com.github.streamshub.console.dependents.discriminators.PrometheusLabelDiscriminator;
+
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 

--- a/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusClusterRoleBinding.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusClusterRoleBinding.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
+import com.github.streamshub.console.dependents.discriminators.PrometheusLabelDiscriminator;
 
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusDeployment.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusDeployment.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
+import com.github.streamshub.console.dependents.discriminators.PrometheusLabelDiscriminator;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.operator.api.reconciler.Context;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusService.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusService.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
+import com.github.streamshub.console.dependents.discriminators.PrometheusLabelDiscriminator;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.javaoperatorsdk.operator.api.reconciler.Context;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusServiceAccount.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/PrometheusServiceAccount.java
@@ -2,6 +2,8 @@ package com.github.streamshub.console.dependents;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import com.github.streamshub.console.dependents.discriminators.PrometheusLabelDiscriminator;
+
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @ApplicationScoped

--- a/operator/src/main/java/com/github/streamshub/console/dependents/conditions/DeploymentReadyCondition.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/conditions/DeploymentReadyCondition.java
@@ -1,4 +1,4 @@
-package com.github.streamshub.console.dependents;
+package com.github.streamshub.console.dependents.conditions;
 
 import org.jboss.logging.Logger;
 

--- a/operator/src/main/java/com/github/streamshub/console/dependents/conditions/IngressReadyCondition.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/conditions/IngressReadyCondition.java
@@ -1,4 +1,4 @@
-package com.github.streamshub.console.dependents;
+package com.github.streamshub.console.dependents.conditions;
 
 import java.util.Collection;
 import java.util.Optional;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/conditions/PrometheusPrecondition.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/conditions/PrometheusPrecondition.java
@@ -1,4 +1,4 @@
-package com.github.streamshub.console.dependents;
+package com.github.streamshub.console.dependents.conditions;
 
 import java.util.Collections;
 import java.util.Optional;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/discriminators/BaseLabelDiscriminator.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/discriminators/BaseLabelDiscriminator.java
@@ -1,4 +1,4 @@
-package com.github.streamshub.console.dependents;
+package com.github.streamshub.console.dependents.discriminators;
 
 import java.util.Map;
 import java.util.Optional;

--- a/operator/src/main/java/com/github/streamshub/console/dependents/discriminators/ConsoleLabelDiscriminator.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/discriminators/ConsoleLabelDiscriminator.java
@@ -1,8 +1,10 @@
-package com.github.streamshub.console.dependents;
+package com.github.streamshub.console.dependents.discriminators;
 
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.github.streamshub.console.dependents.ConsoleResource;
 
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 

--- a/operator/src/main/java/com/github/streamshub/console/dependents/discriminators/PrometheusLabelDiscriminator.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/discriminators/PrometheusLabelDiscriminator.java
@@ -1,4 +1,6 @@
-package com.github.streamshub.console.dependents;
+package com.github.streamshub.console.dependents.discriminators;
+
+import com.github.streamshub.console.dependents.ConsoleResource;
 
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 


### PR DESCRIPTION
No change to the operator's functionality, only cleaning up and organizing the class structure.