### PR TITLE
Bug fix in reset offset page

### DIFF
--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -1,0 +1,22 @@
+import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
+import { BreadcrumbLink } from "@/components/Navigation/BreadcrumbLink";
+import { BreadcrumbItem } from "@/libs/patternfly/react-core";
+
+export default function ConsumerGroupsActiveBreadcrumb({
+  params: { groupId, kafkaId },
+}: {
+  params: KafkaConsumerGroupMembersParams;
+}) {
+  return [
+    <BreadcrumbLink
+      key={"cg"}
+      href={`/kafka/${kafkaId}/consumer-groups`}
+      showDivider={true}
+    >
+      Consumer groups
+    </BreadcrumbLink>,
+    <BreadcrumbItem key={"cgm"} showDivider={true} isActive={true}>
+      {decodeURIComponent(groupId) === "+" ? <i>Empty Name</i> : groupId}
+    </BreadcrumbItem>,
+  ];
+}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -1,0 +1,38 @@
+import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
+import { AppHeader } from "@/components/AppHeader";
+import { Suspense } from "react";
+import { useTranslations } from "next-intl";
+
+export default function Page({
+  params: { kafkaId, groupId },
+}: {
+  params: KafkaConsumerGroupMembersParams;
+}) {
+  return (
+    <Suspense fallback={<Header params={{ kafkaId, groupId }} />}>
+      <ConnectedAppHeader params={{ kafkaId, groupId }} />
+    </Suspense>
+  );
+}
+
+async function ConnectedAppHeader({
+  params: { kafkaId, groupId },
+}: {
+  params: KafkaConsumerGroupMembersParams;
+}) {
+  return <Header params={{ kafkaId, groupId }} />;
+}
+
+function Header({
+  params: { kafkaId, groupId },
+}: {
+  params: KafkaConsumerGroupMembersParams;
+}) {
+  const t = useTranslations();
+
+  return (
+    <AppHeader
+      title={decodeURIComponent(groupId) === "+" ? <i>Empty Name</i> : groupId}
+    />
+  );
+}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
@@ -196,26 +196,24 @@ export function ConsumerGroupsTable({
             const allTopics: Record<string, string | undefined> = {};
             row.attributes.members
               ?.flatMap((m) => m.assignments ?? [])
-              .forEach((a) =>
-                allTopics[a.topicName] = a.topicId,
-              );
-            row.attributes.offsets?.forEach((a) =>
-              allTopics[a.topicName] = a.topicId,
+              .forEach((a) => (allTopics[a.topicName] = a.topicId));
+            row.attributes.offsets?.forEach(
+              (a) => (allTopics[a.topicName] = a.topicId),
             );
             return (
               <Td key={key} dataLabel={t("ConsumerGroupsTable.topics")}>
                 <LabelGroup>
-                  {Object.entries(allTopics).map(
-                    ([topicName, topicId]) => (
-                      <LabelLink
-                        key={topicName}
-                        color={"blue"}
-                        href={topicId ? `/kafka/${kafkaId}/topics/${topicId}` : "#"}
-                      >
-                        {topicName}
-                      </LabelLink>
-                    )
-                  )}
+                  {Object.entries(allTopics).map(([topicName, topicId]) => (
+                    <LabelLink
+                      key={topicName}
+                      color={"blue"}
+                      href={
+                        topicId ? `/kafka/${kafkaId}/topics/${topicId}` : "#"
+                      }
+                    >
+                      {topicName}
+                    </LabelLink>
+                  ))}
                 </LabelGroup>
               </Td>
             );
@@ -232,7 +230,10 @@ export function ConsumerGroupsTable({
           items={[
             {
               title: t("ConsumerGroupsTable.reset_offset"),
-              description: t("ConsumerGroupsTable.reset_offset_description"),
+              description:
+                row.attributes.state === "EMPTY"
+                  ? null
+                  : t("ConsumerGroupsTable.reset_offset_description"),
               onClick: () => onResetOffset(row),
             },
           ]}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/DryrunSelect.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/DryrunSelect.tsx
@@ -15,9 +15,11 @@ import { useState } from "react";
 export function DryrunSelect({
   openDryrun,
   cliCommand,
+  isDisabled,
 }: {
   openDryrun: () => void;
   cliCommand: string;
+  isDisabled: boolean;
 }) {
   const t = useTranslations("ConsumerGroupsTable");
 
@@ -45,6 +47,7 @@ export function DryrunSelect({
                 key="split-action-secondary"
                 aria-label={t("dry_run")}
                 onClick={openDryrun}
+                isDisabled={isDisabled}
               >
                 {t("dry_run")}
               </MenuToggleAction>,
@@ -60,6 +63,7 @@ export function DryrunSelect({
           value={0}
           key={t("run_and_show_result")}
           onClick={openDryrun}
+          isDisabled={isDisabled}
         >
           <PlayIcon /> {t("run_and_show_result")}
         </DropdownItem>
@@ -72,6 +76,7 @@ export function DryrunSelect({
           }}
           aria-describedby="tooltip-ref1"
           ref={tooltipRef}
+          isDisabled={isDisabled}
         >
           <CopyIcon /> {t("copy_dry_run_command")}
           {isCopied && (

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/DryrunSelect.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/DryrunSelect.tsx
@@ -44,6 +44,7 @@ export function DryrunSelect({
                 id="split-button-action-secondary-with-toggle-button"
                 key="split-action-secondary"
                 aria-label={t("dry_run")}
+                onClick={openDryrun}
               >
                 {t("dry_run")}
               </MenuToggleAction>,

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetConsumerOffset.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetConsumerOffset.tsx
@@ -12,7 +12,7 @@ import { updateConsumerGroup } from "@/api/consumerGroups/actions";
 import { Dryrun } from "./Dryrun";
 import { LoadingPage } from "./LoadingPage";
 import { ResetOffset } from "./ResetOffset";
-import { Page } from "@/libs/patternfly/react-core";
+import { Page, PageSection } from "@/libs/patternfly/react-core";
 import { useTranslations } from "next-intl";
 import { useAlert } from "@/components/AlertContext";
 
@@ -208,19 +208,21 @@ export function ResetConsumerOffset({
       kafkaId,
       consumerGroupName,
       uniqueOffsets,
-      true // dryRun
+      true, // dryRun
     );
 
     if (response.payload) {
       const res = response.payload;
-      const offsets: Offset[] = Array.from(res.attributes?.offsets ?? []).map(o => {
-        return {
+      const offsets: Offset[] = Array.from(res.attributes?.offsets ?? []).map(
+        (o) => {
+          return {
             topicId: o.topicId!,
             topicName: o.topicName,
             partition: o.partition,
             offset: o.offset,
-        }
-      });
+          };
+        },
+      );
 
       setNewOffsetData(offsets);
       setShowDryRun(true);
@@ -280,7 +282,7 @@ export function ResetConsumerOffset({
   };
 
   return (
-    <Page>
+    <PageSection isFilled={true} hasOverflowScroll={true}>
       {isLoading ? (
         <LoadingPage />
       ) : showDryRun ? (
@@ -316,6 +318,6 @@ export function ResetConsumerOffset({
           cliCommand={generateCliCommand()}
         />
       )}
-    </Page>
+    </PageSection>
   );
 }

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
@@ -83,6 +83,20 @@ export function ResetOffset({
   onOffsetSelect: (value: OffsetValue) => void;
 }) {
   const t = useTranslations("ConsumerGroupsTable");
+
+  const isDisabled =
+    (selectTopic === "allTopics" ||
+      (selectTopic === "selectedTopic" &&
+        offset.topicName &&
+        (selectPartition === "allPartitions" ||
+          (selectPartition === "selectedPartition" &&
+            offset.partition !== undefined)))) &&
+    (selectOffset === "custom"
+      ? offset.offset
+      : selectOffset === "specificDateTime"
+        ? offset.offset
+        : selectOffset === "latest" || selectOffset === "earliest");
+
   return (
     <Panel>
       <PanelHeader>
@@ -224,20 +238,14 @@ export function ResetOffset({
               <Button
                 variant="primary"
                 onClick={handleSave}
-                isDisabled={isLoading}
+                isDisabled={isLoading || !isDisabled}
               >
                 {t("save")}
               </Button>
               <DryrunSelect
                 openDryrun={openDryrun}
                 cliCommand={cliCommand}
-                isDisabled={
-                  selectOffset === "custom"
-                    ? !offset.offset
-                    : selectOffset === "specificDateTime"
-                      ? !offset.offset
-                      : selectOffset !== "latest" && selectOffset !== "earliest"
-                }
+                isDisabled={!isDisabled}
               />
               <Button
                 variant="link"

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
@@ -84,7 +84,7 @@ export function ResetOffset({
 }) {
   const t = useTranslations("ConsumerGroupsTable");
 
-  const isDisabled =
+  const isEnabled =
     (selectTopic === "allTopics" ||
       (selectTopic === "selectedTopic" &&
         offset.topicName &&
@@ -238,14 +238,14 @@ export function ResetOffset({
               <Button
                 variant="primary"
                 onClick={handleSave}
-                isDisabled={isLoading || !isDisabled}
+                isDisabled={isLoading || !isEnabled}
               >
                 {t("save")}
               </Button>
               <DryrunSelect
                 openDryrun={openDryrun}
                 cliCommand={cliCommand}
-                isDisabled={!isDisabled}
+                isDisabled={!isEnabled}
               />
               <Button
                 variant="link"

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
@@ -170,8 +170,13 @@ export function ResetOffset({
                     id="custom-offset-input"
                     name={t("custom_offset")}
                     value={offset.offset}
-                    onChange={(_event, value) => handleOffsetChange(value)}
+                    onChange={(_event, value) => {
+                      if (/^\d*$/.test(value)) {
+                        handleOffsetChange(value);
+                      }
+                    }}
                     type="number"
+                    min={0}
                   />
                 </FormGroup>
               )}
@@ -223,7 +228,17 @@ export function ResetOffset({
               >
                 {t("save")}
               </Button>
-              <DryrunSelect openDryrun={openDryrun} cliCommand={cliCommand} />
+              <DryrunSelect
+                openDryrun={openDryrun}
+                cliCommand={cliCommand}
+                isDisabled={
+                  selectOffset === "custom"
+                    ? !offset.offset
+                    : selectOffset === "specificDateTime"
+                      ? !offset.offset
+                      : selectOffset !== "latest" && selectOffset !== "earliest"
+                }
+              />
               <Button
                 variant="link"
                 onClick={closeResetOffset}


### PR DESCRIPTION
1. **Reset Offset Button Visibility**: Fix an issue where the "Reset Offset" button remains visible while already on the reset offset form. This occurs when navigating from the "Reset Offset" button on the consumer group page (but not when accessed via the list kebab menu).
2. **Remove Description Text in Kebab Menu**: Remove the description text in the kebab menu for consumer groups where the status is empty.
3. **Disable Dryrun Button Until Offset is Selected**: Ensure the "Dryrun" button remains disabled until an offset value is selected.
4. **Restrict Custom Input to Non-Negative Values**: Prevent negative numbers from being entered in the "Custom Offset" input field.