### PR TITLE
fix: bump example Kafka version from 3.7.0 to 3.9.0

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -230,13 +230,14 @@ jobs:
           mkdir ./resources
           kubectl get all,catalogsources,operatorgroups -n olm -o yaml > ./resources/olm.yaml
           kubectl get all,subscriptions,csv,operatorgroups,installplans -n operators -o yaml > ./resources/operators.yaml
+          kubectl get all -n ${TARGET_NAMESPACE} -o yaml > ./resources/${TARGET_NAMESPACE}.yaml
+          kubectl logs -n operators -l strimzi.io/kind=cluster-operator --all-containers=true --tail -1 > ./resources/strimzi-cluster-operator-logs.txt
           kubectl logs -n operators -l app.kubernetes.io/name=streamshub-console-operator --all-containers=true --tail -1 > ./resources/streamshub-console-operator-logs.txt
-          kubectl get all -n $TARGET_NAMESPACE -o yaml > ./resources/$TARGET_NAMESPACE.yaml
-          kubectl logs -n ${TARGET_NAMESPACE} -l app.kubernetes.io/instance=example-console-deployment --all-containers=true --tail -1 > ./resources/$TARGET_NAMESPACE-console-logs.txt
+          kubectl logs -n ${TARGET_NAMESPACE} -l app.kubernetes.io/instance=example-console-deployment --all-containers=true --tail -1 > ./resources/${TARGET_NAMESPACE}-console-logs.txt
 
       - name: Archive Resource Backup
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: k8s-resources-failed
+          name: playwright-tests-k8s-resources-failed
           path: ./resources

--- a/examples/kafka/030-Kafka-console-kafka.yaml
+++ b/examples/kafka/030-Kafka-console-kafka.yaml
@@ -45,4 +45,4 @@ spec:
         configMapKeyRef:
           name: console-kafka-metrics
           key: kafka-metrics-config.yml
-    version: 3.7.0
+    version: 3.9.0


### PR DESCRIPTION
Fix failing Playwright tests. Strimzi 0.45 removes support for Kafka 3.7.0