### PR TITLE
[Operator] Modify CSV to add support for OperatorHub on arm64,amd64,ppc64le,s390x

### DIFF
--- a/operator/bin/modify-bundle-metadata.sh
+++ b/operator/bin/modify-bundle-metadata.sh
@@ -111,6 +111,11 @@ ${YQ} eval -o yaml -i '.spec.relatedImages += [{
   "image": "'${ui_image_with_digest}'"
 }]' "${CSV_FILE_PATH}"
 
+${YQ} eval -o yaml -i ".metadata.labels[\"operatorframework.io/arch.amd64\"] = \"supported\"" "${CSV_FILE_PATH}"
+${YQ} eval -o yaml -i ".metadata.labels[\"operatorframework.io/arch.arm64\"] = \"supported\"" "${CSV_FILE_PATH}"
+${YQ} eval -o yaml -i ".metadata.labels[\"operatorframework.io/arch.ppc64le\"] = \"supported\"" "${CSV_FILE_PATH}"
+${YQ} eval -o yaml -i ".metadata.labels[\"operatorframework.io/arch.s390x\"] = \"supported\"" "${CSV_FILE_PATH}"
+
 # Add skipRange if present
 if [[ -n "$SKIP_RANGE" ]]; then
     echo "[DEBUG] Setting skipRange = \"${SKIP_RANGE}\""


### PR DESCRIPTION
This PR makes Console Operator to be visible in OperatorHub. Previously this was not possible. Even though the Operator could be installed via subscription from CLI and was fully functional, it did not show up in the Openshift OperatorHub, making it harder for users to install using UI.