### PR TITLE
Apicurio Registry direct dependency management, remove Nimbus JOSE mgmt

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -74,15 +74,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kafka-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apicurio-registry-avro</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -91,6 +83,11 @@
         <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
 
         <dependency>
@@ -120,7 +117,6 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-serdes-protobuf-serde</artifactId>
-            <version>${apicurio-registry.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.github.streamshub.console.kafka.systemtest.deployment.ApicurioResourceManager;
 import com.github.streamshub.console.kafka.systemtest.deployment.KafkaResourceManager;
 import com.github.streamshub.console.kafka.systemtest.deployment.KeycloakResourceManager;
 import com.github.streamshub.console.kafka.systemtest.deployment.StrimziCrdResourceManager;
@@ -37,6 +38,7 @@ public class TestPlainProfile implements QuarkusTestProfile {
     @Override
     public List<TestResourceEntry> testResources() {
         return List.of(
+                new TestResourceEntry(ApicurioResourceManager.class, Collections.emptyMap(), true),
                 new TestResourceEntry(StrimziCrdResourceManager.class, Collections.emptyMap(), true),
                 new TestResourceEntry(KeycloakResourceManager.class, Collections.emptyMap(), true),
                 new TestResourceEntry(KafkaResourceManager.class, Map.of("profile", PROFILE), true));
@@ -50,11 +52,7 @@ public class TestPlainProfile implements QuarkusTestProfile {
 
                 schemaRegistries:
                   - name: test-registry
-                    ###
-                    # This is the property used by Dev Services for Apicurio Registry
-                    # https://quarkus.io/guides/apicurio-registry-dev-services
-                    ###
-                    url: ${mp.messaging.connector.smallrye-kafka.apicurio.registry.url}
+                    url: ${console.test.apicurio-url}
 
                 kafka:
                   clusters:

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/ApicurioResourceManager.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/ApicurioResourceManager.java
@@ -1,0 +1,50 @@
+package com.github.streamshub.console.kafka.systemtest.deployment;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class ApicurioResourceManager implements QuarkusTestResourceLifecycleManager {
+
+    GenericContainer<?> apicurio;
+
+    @Override
+    @SuppressWarnings("resource")
+    public Map<String, String> start() {
+        int port = 8080;
+        String apicurioImage;
+
+        try (InputStream in = getClass().getResourceAsStream("/Dockerfile.apicurio");
+             BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+            apicurioImage = reader.readLine().substring("FROM ".length());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        apicurio = new GenericContainer<>(apicurioImage)
+                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("systemtests.apicurio"), true))
+                .withExposedPorts(port)
+                .waitingFor(Wait.forListeningPort());
+
+        apicurio.start();
+
+        String urlTemplate = "http://localhost:%d/apis/registry/v2/";
+        var apicurioUrl = urlTemplate.formatted(apicurio.getMappedPort(port));
+        return Map.of("console.test.apicurio-url", apicurioUrl);
+    }
+
+    @Override
+    public void stop() {
+        apicurio.stop();
+    }
+}

--- a/api/src/test/resources/Dockerfile.apicurio
+++ b/api/src/test/resources/Dockerfile.apicurio
@@ -1,0 +1,4 @@
+FROM quay.io/apicurio/apicurio-registry-mem:2.6.7.Final
+# No operations, this is only a placeholder used to manage the image
+# version via dependabot. The FROM statement is always expected to
+# present on the first line of this file.

--- a/pom.xml
+++ b/pom.xml
@@ -87,16 +87,25 @@
                 <artifactId>kafka-clients</artifactId>
                 <version>3.9.0</version>
             </dependency>
-            <!-- Manage nimbus-jose-jwt for CVE-2023-52428 -->
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.41.2</version>
-            </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>
                 <artifactId>kafka-oauth-client</artifactId>
                 <version>${strimzi-oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-client</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serdes-protobuf-serde</artifactId>
+                <version>${apicurio-registry.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>


### PR DESCRIPTION
- CVE-free version of Nimbus JOSE managed by Quarkus
- Remove use of quarkus-kafka-clients and quarkus-apicurio-registry-avro
- Add Apicurio resource manager and test container to replace dev services previously provided by quarkus-apicurio-registry-avro