### PR TITLE
Release 0.6.2 (attempt 2)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,4 +2,3 @@ name: Streaming Platform Console
 release:
   current-version: 0.6.2
   next-version: 0.6.3-SNAPSHOT
-


### PR DESCRIPTION
Attempt release 0.6.2 again, with debugging for catalog failure. I'm not able to reproduce the failure locally.