### PR TITLE
fix: set releaseProfiles via POM, force disable release-preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           export GIT_REVISION=$(git rev-parse --short release)
 
           # Build and push the release images using the commit tagged in `release:prepare`
-          mvn -B -P container-image release:perform --no-transfer-progress \
+          mvn -B release:perform --no-transfer-progress \
             '-Drelease.arguments=-Dquarkus.docker.buildx.platform=${{ env.PLATFORMS }}'
 
       # ==================== UI ====================

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
                     <preparationProfiles>release-preparation</preparationProfiles>
                     <preparationGoals>verify</preparationGoals>
                     <completionGoals>verify</completionGoals>
+                    <releaseProfiles>container-image,!release-preparation</releaseProfiles>
                     <pushChanges>false</pushChanges>
                     <localCheckout>true</localCheckout>
                     <remoteTagging>false</remoteTagging>


### PR DESCRIPTION
Set the `container-image` release profile via POM and explicitly disable the `release-preparation` profile with the same mechanism. For some reason, `release-preparation` is activated during `release:perform`, leading to an additional execution of the `operator/bin/release-prepare.sh` script, which generates garbage and fails the release.