### PR TITLE
Refine node list summary, based on entries prior to applying filters

### DIFF
--- a/ui/api/kafka/schema.ts
+++ b/ui/api/kafka/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { NodesListMetaSummary } from "../nodes/schema";
 
 export const ClusterListSchema = z.object({
   id: z.string(),
@@ -97,7 +98,9 @@ const ClusterDetailSchema = z.object({
   }),
   relationships: z.object({
     nodes: z.object({
-      meta: z.record(z.any()).optional(),
+      meta: z.object({
+        summary: NodesListMetaSummary
+      }),
       data: z.array(z.any()),
     }).optional(),
   }),

--- a/ui/api/nodes/schema.ts
+++ b/ui/api/nodes/schema.ts
@@ -48,8 +48,7 @@ export type KafkaNode = z.infer<typeof NodeSchema>;
 
 export const NodesListMetaSummary = z.object({
   nodePools: z.record(z.string(), z.array(z.string())),
-  statuses: z.record(z.string(), z.record(z.string(), z.number())),
-  totalNodes: z.number(),
+  statuses: z.record(z.enum(["brokers", "controllers", "combined"]), z.record(z.string(), z.number())),
 });
 
 export type NodesListMetaSummary = z.infer<typeof NodesListMetaSummary>;

--- a/ui/api/nodes/schema.ts
+++ b/ui/api/nodes/schema.ts
@@ -46,7 +46,18 @@ export const NodeSchema = z.object({
 
 export type KafkaNode = z.infer<typeof NodeSchema>;
 
+export const NodesListMetaSummary = z.object({
+  nodePools: z.record(z.string(), z.array(z.string())),
+  statuses: z.record(z.string(), z.record(z.string(), z.number())),
+  totalNodes: z.number(),
+});
+
+export type NodesListMetaSummary = z.infer<typeof NodesListMetaSummary>;
+
 export const NodesResponseSchema = z.object({
+  meta: z.object({
+    summary: NodesListMetaSummary,
+  }),
   data: z.array(NodeSchema),
 });
 

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/nodes/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/nodes/page.tsx
@@ -11,8 +11,12 @@ import {
   Spinner,
   Split,
   SplitItem,
+  Tooltip,
 } from "@/libs/patternfly/react-core";
-import { CheckCircleIcon } from "@/libs/patternfly/react-icons";
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from "@/libs/patternfly/react-icons";
 import { Suspense } from "react";
 import { useTranslations } from "next-intl";
 
@@ -28,9 +32,13 @@ export default function NodesHeader({ params }: { params: KafkaParams }) {
 
 async function ConnectedHeader({ params }: { params: KafkaParams }) {
   const cluster = (await getKafkaCluster(params.kafkaId))?.payload;
+  const combinedStatuses = cluster?.relationships.nodes?.meta?.summary?.statuses?.combined || {};
+
   return (
     <Header
-      total={cluster?.relationships.nodes?.meta?.count || 0}
+      total={Object.values(combinedStatuses).reduce((sum, count) => sum + count, 0)}
+      ok={combinedStatuses["Healthy"] ?? 0}
+      warning={combinedStatuses["Unhealthy"] ?? 0}
       kafkaId={cluster?.id}
       cruiseControlEnable={cluster?.attributes.cruiseControlEnabled || false}
     />
@@ -39,10 +47,14 @@ async function ConnectedHeader({ params }: { params: KafkaParams }) {
 
 function Header({
   total,
+  ok,
+  warning,
   kafkaId,
   cruiseControlEnable,
 }: {
   total?: number;
+  ok?: number;
+  warning?: number;
   kafkaId: string | undefined;
   cruiseControlEnable: boolean;
 }) {
@@ -54,17 +66,42 @@ function Header({
           <SplitItem>{t("nodes.title")}</SplitItem>
           <SplitItem>
             <Label
-              color={"green"}
-              icon={
-                total === undefined ? (
-                  <Spinner size={"sm"} />
-                ) : (
-                  <CheckCircleIcon />
-                )
-              }
+              icon={total === undefined ? <Spinner size={"sm"} /> : undefined}
             >
-              {total && <Number value={total} />}
+              {total !== undefined && <Number value={total} />}&nbsp;total
             </Label>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content={"Number of healthy nodes"}>
+              <Label
+                icon={
+                  ok === undefined ? (
+                    <Spinner size={"sm"} />
+                  ) : (
+                    <CheckCircleIcon />
+                  )
+                }
+                color={"cyan"}
+              >
+                {ok !== undefined && <Number value={ok} />}
+              </Label>
+            </Tooltip>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content={"Number of unhealthy nodes"}>
+              <Label
+                icon={
+                  warning === undefined ? (
+                    <Spinner size={"sm"} />
+                  ) : (
+                    <ExclamationTriangleIcon />
+                  )
+                }
+                color={"orange"}
+              >
+                {warning !== undefined && <Number value={warning} />}
+              </Label>
+            </Tooltip>
           </SplitItem>
         </Split>
       }

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/nodes/rebalances/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/nodes/rebalances/page.tsx
@@ -11,8 +11,12 @@ import {
   Spinner,
   Split,
   SplitItem,
+  Tooltip,
 } from "@/libs/patternfly/react-core";
-import { CheckCircleIcon } from "@/libs/patternfly/react-icons";
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from "@/libs/patternfly/react-icons";
 import { Suspense } from "react";
 import { useTranslations } from "next-intl";
 
@@ -28,9 +32,13 @@ export default function NodesHeader({ params }: { params: KafkaParams }) {
 
 async function ConnectedHeader({ params }: { params: KafkaParams }) {
   const cluster = (await getKafkaCluster(params.kafkaId))?.payload;
+  const combinedStatuses = cluster?.relationships.nodes?.meta?.summary?.statuses?.combined || {};
+
   return (
     <Header
-      total={cluster?.relationships.nodes?.meta?.count || 0}
+      total={Object.values(combinedStatuses).reduce((sum, count) => sum + count, 0)}
+      ok={combinedStatuses["Healthy"] ?? 0}
+      warning={combinedStatuses["Unhealthy"] ?? 0}
       kafkaId={cluster?.id}
       cruiseControlEnable={cluster?.attributes.cruiseControlEnabled || false}
     />
@@ -39,10 +47,14 @@ async function ConnectedHeader({ params }: { params: KafkaParams }) {
 
 function Header({
   total,
+  ok,
+  warning,
   kafkaId,
   cruiseControlEnable,
 }: {
   total?: number;
+  ok?: number;
+  warning?: number;
   kafkaId: string | undefined;
   cruiseControlEnable: boolean;
 }) {
@@ -54,17 +66,42 @@ function Header({
           <SplitItem>{t("nodes.title")}</SplitItem>
           <SplitItem>
             <Label
-              color={"green"}
-              icon={
-                total === undefined ? (
-                  <Spinner size={"sm"} />
-                ) : (
-                  <CheckCircleIcon />
-                )
-              }
+              icon={total === undefined ? <Spinner size={"sm"} /> : undefined}
             >
-              {total && <Number value={total} />}
+              {total !== undefined && <Number value={total} />}&nbsp;total
             </Label>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content={"Number of healthy nodes"}>
+              <Label
+                icon={
+                  ok === undefined ? (
+                    <Spinner size={"sm"} />
+                  ) : (
+                    <CheckCircleIcon />
+                  )
+                }
+                color={"cyan"}
+              >
+                {ok !== undefined && <Number value={ok} />}
+              </Label>
+            </Tooltip>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content={"Number of unhealthy nodes"}>
+              <Label
+                icon={
+                  warning === undefined ? (
+                    <Spinner size={"sm"} />
+                  ) : (
+                    <ExclamationTriangleIcon />
+                  )
+                }
+                color={"orange"}
+              >
+                {warning !== undefined && <Number value={warning} />}
+              </Label>
+            </Tooltip>
           </SplitItem>
         </Split>
       }

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/overview/ConnectedClusterCard.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/overview/ConnectedClusterCard.tsx
@@ -46,8 +46,9 @@ export async function ConnectedClusterCard({
     grpResp.errors ? undefined : (grpResp.payload?.meta.page.total ?? 0),
   );
 
-  const brokersTotal = res?.relationships.nodes?.meta?.summary?.brokersCount ?? 0;
-  const brokersOnline = res?.relationships.nodes?.meta?.summary?.brokersRunning ?? 0;
+  const brokerStatuses = res?.relationships.nodes?.meta?.summary?.statuses?.brokers || {};
+  const brokersTotal = Object.values(brokerStatuses).reduce((sum, count) => sum + count, 0);
+  const brokersOnline = brokerStatuses["Running"] ?? 0;
 
   return (
     <ClusterCard

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/create/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/create/page.tsx
@@ -49,10 +49,13 @@ export default async function CreateTopicPage({
     }
   }
 
+  const combinedStatuses = cluster?.relationships.nodes?.meta?.summary?.statuses?.combined || {};
+  const nodeCount = Object.values(combinedStatuses).reduce((sum, count) => sum + count, 0);
+
   return (
     <CreateTopic
       kafkaId={kafkaId}
-      maxReplicas={cluster.relationships.nodes?.meta?.count}
+      maxReplicas={nodeCount}
       initialOptions={tempOptions}
       onSave={onSave}
     />


### PR DESCRIPTION
Summary includes information for the entire dataset. Also correctly indicate node health/status counts in the header.

![image](https://github.com/user-attachments/assets/87974ada-846a-4979-8b28-cf2b09cd1ba6)
