### PR TITLE
fix: use common aggregate coverage data file in root, remove editable

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -313,7 +313,7 @@
                                 <exclude>com/github/streamshub/console/api/support/TrustAllCertificateManager.class</exclude>
                             </excludes>
                             <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
-                            <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
+                            <destFile>${project.basedir}/../target/jacoco.exec</destFile>
                             <append>true</append>
                         </configuration>
                     </execution>
@@ -326,7 +326,7 @@
                             <excludes>
                                 <exclude>com/github/streamshub/console/api/support/TrustAllCertificateManager.class</exclude>
                             </excludes>
-                            <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
+                            <destFile>${project.basedir}/../target/jacoco.exec</destFile>
                             <append>true</append>
                         </configuration>
                     </execution>
@@ -338,12 +338,15 @@
                         <phase>verify</phase>
                         <configuration>
                             <includeCurrentProject>true</includeCurrentProject>
+                            <dataFileIncludes>
+                                <dataFileInclude>${project.basedir}/../target/jacoco.exec</dataFileInclude>
+                            </dataFileIncludes>
                             <excludes>
                                 <exclude>com/github/streamshub/console/config/**/*Builder.class</exclude>
                                 <exclude>com/github/streamshub/console/config/**/*Fluent.class</exclude>
                                 <exclude>com/github/streamshub/console/config/**/*Nested.class</exclude>
                             </excludes>
-                            <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                            <outputDirectory>${project.basedir}/../target/coverage</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -88,6 +88,10 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <destFile>${project.basedir}/../target/jacoco.exec</destFile>
+                            <append>true</append>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>default-report</id>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -123,7 +123,9 @@
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
-                        <quarkus.jacoco.report-location>${project.build.directory}/site/jacoco</quarkus.jacoco.report-location>
+                        <quarkus.jacoco.data-file>${project.basedir}/../target/jacoco.exec</quarkus.jacoco.data-file>
+                        <quarkus.jacoco.reuse-data-file>true</quarkus.jacoco.reuse-data-file>
+                        <quarkus.jacoco.report-location>${project.basedir}/../target/coverage</quarkus.jacoco.report-location>
                     </systemProperties>
                 </configuration>
             </plugin>

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVar.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVar.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConfigVar {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVarSource.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVarSource.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapEnvSource;
 import io.fabric8.kubernetes.api.model.SecretEnvSource;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidationRule(
         value = "has(self.configMapRef) || has(self.secretRef)",

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVars.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConfigVars.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConfigVars {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
@@ -13,7 +13,7 @@ import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 // Enable validation rules for unique names when array maxItems and string maxLength can be specified
 // to influence Kubernetes's estimated rule cost.

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Credentials.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Credentials.java
@@ -7,7 +7,7 @@ import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
 @ValidationRule(value = "has(self.kafkaUser)", message = "kafkaUser is required")
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Credentials {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/CredentialsKafkaUser.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/CredentialsKafkaUser.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CredentialsKafkaUser {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Images.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Images.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Images {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/KafkaCluster.java
@@ -8,7 +8,7 @@ import io.fabric8.generator.annotation.Required;
 import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidationRule(
         // The `namespace` property must be wrapped in double underscore to escape it

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/SchemaRegistry.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SchemaRegistry {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/TrustStore.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/TrustStore.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TrustStore {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Value.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Value {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ValueReference.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ValueReference.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ValueReference {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/containers/ContainerSpec.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/containers/ContainerSpec.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ContainerSpec {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/containers/ContainerTemplateSpec.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/containers/ContainerTemplateSpec.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ContainerTemplateSpec {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/containers/Containers.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/containers/Containers.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Containers {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSource.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSource.java
@@ -9,7 +9,7 @@ import com.github.streamshub.console.api.v1alpha1.spec.TrustStore;
 import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MetricsSource {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSourceAuthentication.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/metrics/MetricsSourceAuthentication.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.ValidationRule;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidationRule(
         value = "has(self.token) || (has(self.username) && has(self.password))",

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/Condition.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/Condition.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Condition {
 

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.javaoperatorsdk.operator.api.ObservedGenerationAwareStatus;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConsoleStatus extends ObservedGenerationAwareStatus {
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <!-- Sonar settings -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>streamshub</sonar.organization>
+        <sonar.coverage.jacoco.xmlReportPaths>target/coverage/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.exclusions>api/src/main/java/com/github/streamshub/console/api/support/TrustAllCertificateManager.java</sonar.exclusions>
         <!-- Ignore duplicates in configuration model classes -->
         <sonar.cpd.exclusions>


### PR DESCRIPTION
Closes #1557 

- Remove editable on `@Buildable` classes that do not yet disable it
- Aggregate coverage data to common file in root project. The operator module will run the report (via Quarkus Jacoco support) which generates the XML data submitted to Sonar
- Fix flaky test race condition in `NodesResourceIT`