### PR TITLE
build(deps): bump quarkus.platform.version in /api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- Dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.15.3</quarkus.platform.version>
+        <quarkus.platform.version>3.15.4</quarkus.platform.version>
         <strimzi-api.version>0.45.0</strimzi-api.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <apicurio-registry.version>2.6.8.Final</apicurio-registry.version>


### PR DESCRIPTION
Bumps `quarkus.platform.version` from 3.15.3 to 3.15.4.

Combines #1517 and #1560 for the `0.6.x` branch.

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.15.3 to 3.15.4
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.15.3...3.15.4)

Updates `io.quarkus.platform:quarkus-bom` from 3.15.3 to 3.15.4
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.15.3...3.15.4)

Updates `io.quarkus.platform:quarkus-operator-sdk-bom` from 3.15.3 to 3.15.4
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.15.3...3.15.4)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-operator-sdk-bom dependency-type: direct:production update-type: version-update:semver-patch ...