### PR TITLE
fix: include topic size in pagination cursor when sorted by bytes

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/model/Topic.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/Topic.java
@@ -16,8 +16,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.json.Json;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue.ValueType;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -237,6 +239,10 @@ public class Topic extends RelatableResource<Topic.Attributes, Topic.Relationshi
         super(id, API_TYPE, new Attributes(name, internal), new Relationships());
     }
 
+    private Topic(String id, Attributes attributes) {
+        super(id, API_TYPE, attributes, new Relationships());
+    }
+
     public static Topic fromTopicListing(org.apache.kafka.clients.admin.TopicListing listing) {
         return new Topic(listing.name(), listing.isInternal(), listing.topicId().toString());
     }
@@ -268,7 +274,19 @@ public class Topic extends RelatableResource<Topic.Attributes, Topic.Relationshi
 
         JsonObject attr = cursor.getJsonObject("attributes");
 
-        Topic topic = new Topic(attr.getString(Fields.NAME, null), false, cursor.getString("id"));
+        Topic topic = new Topic(cursor.getString("id"), new Attributes(attr.getString(Fields.NAME, null), false) {
+            @Override
+            public BigInteger getTotalLeaderLogBytes() {
+                if (attr.containsKey(Fields.TOTAL_LEADER_LOG_BYTES)) {
+                    var value = attr.get(Fields.TOTAL_LEADER_LOG_BYTES);
+                    return value.getValueType() == ValueType.NUMBER ?
+                            JsonNumber.class.cast(value).bigIntegerValue() :
+                            null;
+                }
+
+                return null;
+            }
+        });
 
         if (attr.containsKey(Fields.CONFIGS)) {
             var configs = attr.getJsonObject(Fields.CONFIGS)
@@ -290,6 +308,15 @@ public class Topic extends RelatableResource<Topic.Attributes, Topic.Relationshi
 
         if (sortFields.contains(Fields.NAME)) {
             attrBuilder.add(Fields.NAME, attributes.name);
+        }
+
+        if (sortFields.contains(Fields.TOTAL_LEADER_LOG_BYTES)) {
+            var bytes = attributes.getTotalLeaderLogBytes();
+            if (bytes != null) {
+                attrBuilder.add(Fields.TOTAL_LEADER_LOG_BYTES, bytes);
+            } else {
+                attrBuilder.addNull(Fields.TOTAL_LEADER_LOG_BYTES);
+            }
         }
 
         JsonObjectBuilder sortedConfigsBuilder = Json.createObjectBuilder();


### PR DESCRIPTION
Fixes #147

Note, issue 147 mentions sorting by `recordCount` which is no longer supported and can be ignored.