### PR TITLE
Update strimzi-test-container to 0.110.0 with Kafka 4.0

### DIFF
--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/DeploymentManager.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/deployment/DeploymentManager.java
@@ -99,7 +99,8 @@ public class DeploymentManager {
                 .withCreateContainerCmdModifier(cmd -> cmd.withName(name("kafka")))
                 .withKafkaConfigurationMap(Map.of(
                     "auto.create.topics.enable", "false",
-                    "group.initial.rebalance.delay.ms", "0"
+                    "group.initial.rebalance.delay.ms", "0",
+                    "group.coordinator.new.enable", "false"
                 ))
                 .withNetwork(testNetwork);
 

--- a/api/src/test/resources/Dockerfile.kafka
+++ b/api/src/test/resources/Dockerfile.kafka
@@ -1,4 +1,4 @@
-FROM quay.io/strimzi-test-container/test-container:0.109.1-kafka-3.9.0
+FROM quay.io/strimzi-test-container/test-container:0.110.0-kafka-4.0.0
 # No operations, this is only a placeholder used to manage the image
 # version via dependabot. The FROM statement is always expected to
 # present on the first line of this file.

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <!-- Test Dependencies -->
         <hamcrest.version>3.0</hamcrest.version>
-        <strimzi-test-container.version>0.109.1</strimzi-test-container.version>
+        <strimzi-test-container.version>0.110.0</strimzi-test-container.version>
 
         <!-- Plugin Versions -->
         <maven.compiler.version>3.14.0</maven.compiler.version>


### PR DESCRIPTION
* Bump strimzi-test-container to 0.110.0
* Bump Kafka version in API integration tests to 4.0
* Set `group.coordinator.new.enable=false` to still allow blank/empty consumer group ID compatibility
* Make create/delete topic operations in test helpers blocking to ensure topics are fully created or removed
* Make delete consumer group operations in test helpers blocking for same reason