### PR TITLE
fix: properly implement topic mutate operations for KafkaTopic CRs

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/service/TopicDescribeService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/TopicDescribeService.java
@@ -92,6 +92,9 @@ public class TopicDescribeService {
     @Inject
     KafkaContext kafkaContext;
 
+    /**
+     * @see com.github.streamshub.console.api.support.InformerFactory#topics InformerFactory topics field
+     */
     @Inject
     @Named("KafkaTopics")
     Map<String, Map<String, Map<String, KafkaTopic>>> managedTopics;

--- a/api/src/main/java/com/github/streamshub/console/api/service/TopicService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/TopicService.java
@@ -128,7 +128,7 @@ public class TopicService {
                     .stream()
                     .findFirst()
                     .map(List::size)
-                    .map(Short.class::cast);
+                    .map(Integer::shortValue);
             newTopic = new org.apache.kafka.clients.admin.NewTopic(
                     topicName,
                     topic.replicasAssignments()
@@ -159,7 +159,9 @@ public class TopicService {
                     .thenApply(nothing1 -> NewTopic.fromKafkaModel(topicName, result))
                     .toCompletionStage();
         } else {
-            Map<String, Object> newConfigs = new LinkedHashMap<>(newTopic.configs());
+            Map<String, Object> newConfigs = Optional.ofNullable(newTopic.configs())
+                    .<Map<String, Object>>map(LinkedHashMap::new)
+                    .orElse(null);
 
             KafkaTopic topicResource = new KafkaTopicBuilder()
                     .withNewMetadata()

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -33,6 +33,8 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
 
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeLogDirsOptions;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
@@ -53,6 +55,7 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.eclipse.microprofile.config.Config;
@@ -94,6 +97,7 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.strimzi.api.ResourceLabels;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
@@ -123,6 +127,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -1929,6 +1934,44 @@ class TopicsResourceIT {
     }
 
     @Test
+    void testDeleteTopicWithStrimziManagement() {
+        String topicName = "t-" + UUID.randomUUID().toString();
+        String topicId = topicUtils.createTopics(List.of(topicName), 1).get(topicName);
+        utils.apply(client, new KafkaTopicBuilder()
+                .withNewMetadata()
+                    .withNamespace("default")
+                    .withName(topicName)
+                    .addToLabels(ResourceLabels.STRIMZI_CLUSTER_LABEL, clusterName1)
+                .endMetadata()
+                .withNewSpec()
+                    .withTopicName(topicName)
+                    .withPartitions(1)
+                .endSpec()
+                .withNewStatus()
+                    .withTopicId(topicId)
+                    .withTopicName(topicName)
+                    .addNewCondition()
+                        .withType("Ready")
+                        .withStatus("True")
+                    .endCondition()
+                .endStatus()
+                .build());
+
+        // Wait for the managed topic list to include the topic
+        await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> Optional.ofNullable(managedTopics.get("default"))
+                    .map(clustersInNamespace -> clustersInNamespace.get(clusterName1))
+                    .map(topicsInCluster -> topicsInCluster.get(topicName))
+                    .isPresent());
+
+        whenRequesting(req -> req.delete("{topicId}", clusterId1, topicId))
+            .assertThat()
+            .statusCode(is(Status.NO_CONTENT.getStatusCode()));
+
+        assertNull(client.resources(KafkaTopic.class).inNamespace("default").withName(topicName).get());
+    }
+
+    @Test
     void testPatchTopicWithAllOptions() {
         String topicName = UUID.randomUUID().toString();
         Map<String, String> topicIds = topicUtils.createTopics(List.of(topicName), 3);
@@ -2061,6 +2104,116 @@ class TopicsResourceIT {
                     description.appendValue(expectedResponse);
                 }
             });
+    }
+
+    @Test
+    void testPatchTopicWithStrimziManagement() {
+        String topicName = "t-" + UUID.randomUUID().toString();
+        String topicId = topicUtils.createTopics(List.of(topicName), 1).get(topicName);
+        utils.apply(client, new KafkaTopicBuilder()
+                .withNewMetadata()
+                    .withNamespace("default")
+                    .withName(topicName)
+                    .addToLabels(ResourceLabels.STRIMZI_CLUSTER_LABEL, clusterName1)
+                .endMetadata()
+                .withNewSpec()
+                    .withTopicName(topicName)
+                    .withPartitions(1)
+                    .addToConfig(TopicConfig.SEGMENT_BYTES_CONFIG, String.valueOf(16 * Math.pow(1024, 2)))
+                    .addToConfig(TopicConfig.COMPRESSION_TYPE_CONFIG, "gzip")
+                    .addToConfig(TopicConfig.CLEANUP_POLICY_CONFIG, "delete")
+                .endSpec()
+                .withNewStatus()
+                    .withTopicId(topicId)
+                    .withTopicName(topicName)
+                    .addNewCondition()
+                        .withType("Ready")
+                        .withStatus("True")
+                    .endCondition()
+                .endStatus()
+                .build());
+
+        // Wait for the managed topic list to include the topic
+        await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> Optional.ofNullable(managedTopics.get("default"))
+                    .map(clustersInNamespace -> clustersInNamespace.get(clusterName1))
+                    .map(topicsInCluster -> topicsInCluster.get(topicName))
+                    .isPresent());
+
+        var response = CompletableFuture.supplyAsync(() ->
+            whenRequesting(req -> req
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .body(Json.createObjectBuilder()
+                        .add("meta", Json.createObjectBuilder()
+                                .add("validateOnly", false))
+                        .add("data", Json.createObjectBuilder()
+                                .add("id", topicId)
+                                .add("type", "topics")
+                                .add("attributes", Json.createObjectBuilder()
+                                        .add("numPartitions", 2) // adding partition
+                                        .add("configs", Json.createObjectBuilder()
+                                                // remove
+                                                .add(TopicConfig.SEGMENT_BYTES_CONFIG, JsonValue.NULL)
+                                                // change
+                                                .add(TopicConfig.COMPRESSION_TYPE_CONFIG, Json.createObjectBuilder()
+                                                        .add("value", "lz4"))
+                                                // add
+                                                .add(TopicConfig.RETENTION_MS_CONFIG, Json.createObjectBuilder()
+                                                        .add("value", "86400000"))
+                                        )
+                                )
+                        )
+                        .build()
+                        .toString())
+                .patch("{topicId}", clusterId1, topicId)));
+
+        // check that the API has changed the KafkaTopic CR
+        var topicClient = client.resources(KafkaTopic.class).inNamespace("default").withName(topicName);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            var topic = topicClient.get();
+            assertNotNull(topic);
+            assertEquals(2, topic.getSpec().getPartitions());
+            var expectedConfigs = Map.ofEntries(
+                Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, "delete"),
+                Map.entry(TopicConfig.COMPRESSION_TYPE_CONFIG, "lz4"),
+                Map.entry(TopicConfig.RETENTION_MS_CONFIG, "86400000")
+            );
+            var actualConfigs = topic.getSpec().getConfig();
+            assertEquals(expectedConfigs, actualConfigs);
+        });
+
+        // Acting as Strimzi Topic Operator
+        topicUtils.createPartitions(topicName, 2);
+        topicUtils.alterTopicConfigs(topicName, List.of(
+            new AlterConfigOp(new ConfigEntry(TopicConfig.SEGMENT_BYTES_CONFIG, ""), AlterConfigOp.OpType.DELETE),
+            new AlterConfigOp(new ConfigEntry(TopicConfig.COMPRESSION_TYPE_CONFIG, "lz4"), AlterConfigOp.OpType.SET),
+            new AlterConfigOp(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, "86400000"), AlterConfigOp.OpType.SET)
+        ));
+
+        // update the generation to allow the response to complete
+        topicClient.editStatus(t -> {
+            return new KafkaTopicBuilder(t)
+                    .editStatus()
+                        .withObservedGeneration(t.getMetadata().getGeneration())
+                    .endStatus()
+                    .build();
+        });
+
+        response.join().assertThat().statusCode(is(Status.NO_CONTENT.getStatusCode()));
+
+        // Confirm values are expected
+        whenRequesting(req -> req
+                .queryParam("fields[topics]", "name,partitions,configs")
+                .get("{topicId}", clusterId1, topicId))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("data.attributes.partitions.size()", is(2))
+            .body("data.attributes.configs.'segment.bytes'.value", is("1073741824"))
+            .body("data.attributes.configs.'segment.bytes'.source", is(ConfigEntry.ConfigSource.DEFAULT_CONFIG.name()))
+            .body("data.attributes.configs.'compression.type'.value", is("lz4"))
+            .body("data.attributes.configs.'compression.type'.source", is(ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG.name()))
+            .body("data.attributes.configs.'retention.ms'.value", is("86400000"))
+            .body("data.attributes.configs.'retention.ms'.source", is(ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG.name()));
     }
 
     @Test

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -1892,7 +1892,7 @@ class TopicsResourceIT {
         // Acting as Strimzi Topic Operator
         String topicId = topicUtils.createTopics(List.of(topicName), 1).get(topicName);
         var topicClient = client.resources(KafkaTopic.class).inNamespace("default").withName(topicName);
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertNotNull(topicClient.get()));
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertNotNull(topicClient.get()));
         topicClient.editStatus(t -> {
             return new KafkaTopicBuilder(t)
                     .withNewStatus()
@@ -2169,7 +2169,7 @@ class TopicsResourceIT {
 
         // check that the API has changed the KafkaTopic CR
         var topicClient = client.resources(KafkaTopic.class).inNamespace("default").withName(topicName);
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             var topic = topicClient.get();
             assertNotNull(topic);
             assertEquals(2, topic.getSpec().getPartitions());

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/configuration/ConfigTable.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/configuration/ConfigTable.tsx
@@ -190,7 +190,7 @@ export function ConfigTable({
                   <TextInput
                     id={`property-${name}`}
                     placeholder={property.value}
-                    value={options[name] || ""}
+                    value={options[name] || property.value}
                     onChange={(_, value) => {
                       if (value.trim() !== "") {
                         setOptions({
@@ -202,6 +202,7 @@ export function ConfigTable({
                         delete newOpts[name];
                         setOptions(newOpts);
                       }
+                      property.value = value;
                     }}
                     validated={validated}
                     isDisabled={isEditing[name] === "saving"}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9996,9 +9996,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -10012,7 +10012,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "^6.1.0",
+    "@patternfly/quickstarts": "^6.1.0",
     "@patternfly/react-charts": "^8.1.0",
     "@patternfly/react-core": "^6.1.0",
     "@patternfly/react-drag-drop": "^6.1.0",
@@ -23,7 +24,6 @@
     "@patternfly/react-table": "^6.1.0",
     "@patternfly/react-tokens": "^6.1.0",
     "@patternfly/react-user-feedback": "^6.0.0",
-    "@patternfly/quickstarts": "^6.1.0",
     "@stdlib/string-truncate": "^0.2.2",
     "@stdlib/string-truncate-middle": "^0.2.2",
     "@tanstack/react-virtual": "^3.13.9",


### PR DESCRIPTION
The operations to create, update, and delete topics did not consider whether a Kafka cluster is using the Strimzi Topic Operator (for creation) or whether an existing topic is backed by a Strimzi `KafkaTopic` CR. This change addresses the gap by:

- create a `KafkaTopic` CR during topic creation if the topic entity operator is enabled for a Kafka CR. Otherwise, create directly in Kafka
- update the `KafkaTopic` CR for managed topics, else directly in Kafka
- delete the `KafkaTopic` CR for managed topics, else directly in Kafka

This functionality is not accessible in the UI when read-only mode is enabled.