### PR TITLE
fix: choose node icon based on aggregate status

### DIFF
--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/DistributionChart.stories.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/DistributionChart.stories.tsx
@@ -9,8 +9,14 @@ const sampleData = {
 
 const sampleNodesCount = {
   totalNodes: 10,
-  totalBrokers: 7,
-  totalControllers: 3,
+  brokers: {
+    total: 7,
+    warning: false
+  },
+  controllers: {
+    total: 3,
+    warning: false
+  },
   leadControllerId: "1",
 };
 

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/DistributionChart.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/DistributionChart.tsx
@@ -40,8 +40,14 @@ export function DistributionChart({
   data: Record<string, { leaders?: number; followers?: number }>;
   nodesCount: {
     totalNodes: number;
-    totalBrokers: number;
-    totalControllers: number;
+    brokers: {
+        total: number;
+        warning: boolean;
+    };
+    controllers: {
+        total: number;
+        warning: boolean;
+    };
     leadControllerId: string;
   };
 }) {
@@ -111,10 +117,15 @@ export function DistributionChart({
                   {t("DistributionChart.controller_role")}
                 </DescriptionListTerm>
                 <DescriptionListDescription>
-                  <Icon status={"warning"}>
-                    <ExclamationTriangleIcon />
-                  </Icon>
-                  &nbsp; {nodesCount.totalControllers}
+                  { nodesCount.controllers.warning ?
+                    <Icon status={"warning"}>
+                      <ExclamationTriangleIcon />
+                    </Icon> :
+                    <Icon status={"success"}>
+                      <CheckCircleIcon />
+                    </Icon>
+                  }
+                  &nbsp; {nodesCount.controllers.total}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
@@ -122,10 +133,15 @@ export function DistributionChart({
                   {t("DistributionChart.broker_role")}
                 </DescriptionListTerm>
                 <DescriptionListDescription>
-                  <Icon status={"success"}>
-                    <CheckCircleIcon />
-                  </Icon>
-                  &nbsp; {nodesCount.totalBrokers}
+                  { nodesCount.brokers.warning ?
+                    <Icon status={"warning"}>
+                      <ExclamationTriangleIcon />
+                    </Icon> :
+                    <Icon status={"success"}>
+                      <CheckCircleIcon />
+                    </Icon>
+                  }
+                  &nbsp; {nodesCount.brokers.total}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/page.tsx
@@ -109,8 +109,14 @@ async function AsyncNodesTable({
 } & KafkaParams) {
   const nodeCounts = {
     totalNodes: 0,
-    totalBrokers: 0,
-    totalControllers: 0,
+    brokers: {
+        total: 0,
+        warning: false
+    },
+    controllers: {
+        total: 0,
+        warning: false
+    },
     leadControllerId: "",
   };
 
@@ -156,12 +162,23 @@ async function AsyncNodesTable({
   nodeCounts.totalNodes = Object.values(
     nodes.meta.summary.statuses.combined ?? 0,
   ).reduce((tally, value) => tally + value, 0);
-  nodeCounts.totalBrokers = Object.values(
+
+  nodeCounts.brokers.total = Object.values(
     nodes.meta.summary.statuses.brokers ?? 0,
   ).reduce((tally, value) => tally + value, 0);
-  nodeCounts.totalControllers = Object.values(
+  // Set warning if any are not running
+  nodeCounts.brokers.warning = Object.keys(
+    nodes.meta.summary.statuses.brokers ?? {}
+  ).some(key => key !== "Running");
+
+  nodeCounts.controllers.total = Object.values(
     nodes.meta.summary.statuses.controllers ?? 0,
   ).reduce((tally, value) => tally + value, 0);
+  // Set warning if any are not running leader or follower (e.g. lagged or unknown)
+  nodeCounts.controllers.warning = Object.keys(
+    nodes.meta.summary.statuses.controllers ?? {}
+  ).some(key => key !== "QuorumLeader" && key !== "QuorumFollower");
+
   nodeCounts.leadControllerId = nodes.meta.summary.leaderId ?? "";
 
   return (

--- a/ui/utils/config.ts
+++ b/ui/utils/config.ts
@@ -106,7 +106,7 @@ async function getOrLoadConfig(): Promise<ConsoleConfig> {
                         }
                     };
                 }
-            } else {
+            } else if (trustStoreCfg?.type !== undefined) {
                 log.warn("console configuration with OIDC non-PEM truststore is not supported");
             }
 


### PR DESCRIPTION
Also suppress non-PEM truststore warning when no truststore is configured at all.

With OK statuses:
![image](https://github.com/user-attachments/assets/bddb12b0-66e0-4bde-8f4e-63ad09667c77)


With warning statuses:
![image](https://github.com/user-attachments/assets/8e0bc559-0643-4a63-8911-542d72d22b8c)
