### PR TITLE
fix: correct list structures in security rule examples

### DIFF
--- a/docs/sources/modules/deploying/ref-authentication-options.adoc
+++ b/docs/sources/modules/deploying/ref-authentication-options.adoc
@@ -17,7 +17,7 @@ The configuration introduces the following additional properties for console dep
 
 `security`:: Properties that define the connection details for the console to connect with the OIDC provider.
 `subjects`:: Specifies the subjects (users or groups) and their roles in terms of JWT claims or explicit subject names, determining access permissions.
-`roles`:: Defines the roles and associated access rules for users, specifying which resources (like Kafka clusters) they can interact with and what operations they are permitted to perform.  
+`roles`:: Defines the roles and associated access rules for users, specifying which resources (like Kafka clusters) they can interact with and what operations they are permitted to perform.
 
 .Example security configuration for all clusters
 [source,yaml]
@@ -45,7 +45,7 @@ spec:
               name: my-oidc-configmap
               key: ca.jks
         password: # <5>
-          value: truststore-password      
+          value: truststore-password
     subjects:
       - claim: groups # <6>
         include: # <7>
@@ -66,23 +66,23 @@ spec:
     roles:
       - name: developers
         rules:
-          - resources: # <10> 
+          - resources: # <10>
               - kafkas
-          - resourceNames: # <11>
+            resourceNames: # <11>
               - <dev_cluster_a>
               - <dev_cluster_b>
-          - privileges: # <12>
+            privileges: # <12>
               - '*'
       - name: administrators
         rules:
           - resources:
               - kafkas
-          - privileges:
+            privileges:
               - '*'
   kafkaClusters:
     - name: console-kafka
       namespace: kafka
-      listener: secure                     
+      listener: secure
       credentials:
         kafkaUser:
           name: console-kafka-user1
@@ -118,7 +118,7 @@ spec:
   kafkaClusters:
     - name: console-kafka
       namespace: kafka
-      listener: secure                      
+      listener: secure
       credentials:
         kafkaUser:
           name: console-kafka-user1
@@ -131,7 +131,7 @@ spec:
                   - topics/records
                   - consumerGroups
                   - rebalances
-              - privileges:
+                privileges:
                   - get
                   - list
           - name: administrators
@@ -142,31 +142,31 @@ spec:
                   - consumerGroups
                   - rebalances
                   - nodes/configs
-              - privileges:
+                privileges:
                   - get
                   - list
               - resources:
                   - consumerGroups
                   - rebalances
-              - privileges:
+                privileges:
                   - update
 ----
 
 [discrete]
 == Optional OIDC authentication properties
 
-The following properties can be used to further configure `oidc` authentication.  
+The following properties can be used to further configure `oidc` authentication.
 These apply to any part of the console configuration that supports `authentication.oidc`, such as schema registries or metrics providers.
 
-grantType::  
+grantType::
 Specifies the OIDC grant type to use. Required when using non-interactive authentication flows, where no user login is involved.
 Supported values:
 +
-* `CLIENT`: Requires a client ID and secret.  
+* `CLIENT`: Requires a client ID and secret.
 * `PASSWORD`: Requires a client ID and secret, plus user credentials (`username` and `password`) provided through `grantOptions`.
 
-grantOptions::  
-Additional parameters specific to the selected grant type.  
+grantOptions::
+Additional parameters specific to the selected grant type.
 Use `grantOptions` to provide properties such as `username` and `password` when using the `PASSWORD` grant type.
 +
 [source,yaml]
@@ -177,16 +177,16 @@ oidc:
     password: <my_password>
 ----
 
-method::  
-Method for passing the client ID and secret to the OIDC provider.  
+method::
+Method for passing the client ID and secret to the OIDC provider.
 Supported values:
 +
-* `BASIC`: (default) Uses HTTP Basic authentication.  
+* `BASIC`: (default) Uses HTTP Basic authentication.
 * `POST`: Sends credentials as form parameters.
 
-scopes::  
-Optional list of access token scopes to request from the OIDC provider.  
-Defaults are usually defined by the OIDC client configuration.  
+scopes::
+Optional list of access token scopes to request from the OIDC provider.
+Defaults are usually defined by the OIDC client configuration.
 Specify this property if access to the target service requires additional or alternative scopes not granted by default.
 +
 [source,yaml]
@@ -198,5 +198,5 @@ oidc:
     - registry:write
 ----
 
-absoluteExpiresIn::  
+absoluteExpiresIn::
 Optional boolean. If set to `true`, the `expires_in` token property is treated as an absolute timestamp instead of a duration.


### PR DESCRIPTION
Remove incorrect `-` from security rules. Their presence results in additional list entries where each of the entries are missing one or the other require key, `privileges` or `resources`.