### PR TITLE
fix: allow duplicate Kafka cluster names in different namespaces

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -64,7 +64,7 @@ public class KafkaContext implements Closeable {
     public static String clusterId(KafkaClusterConfig clusterConfig, Optional<Kafka> kafkaResource) {
         return Optional.ofNullable(clusterConfig.getId())
                 .or(() -> kafkaResource.map(Kafka::getStatus).map(KafkaStatus::getClusterId))
-                .orElseGet(clusterConfig::getName);
+                .orElseGet(clusterConfig::clusterKeyEncoded);
     }
 
     @Override

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestPlainProfile.java
@@ -154,6 +154,7 @@ public class TestPlainProfile implements QuarkusTestProfile {
                         sasl.jaas.config: something
 
                     - name: test-kafkaY
+                      id: test-kafkaY
                       properties:
                         bootstrap.servers: ${console.test.external-bootstrap}
                 """);

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -1,5 +1,6 @@
 package com.github.streamshub.console.config;
 
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -44,6 +45,11 @@ public class KafkaClusterConfig implements Named {
     @JsonIgnore
     public String clusterKey() {
         return hasNamespace() ? "%s/%s".formatted(namespace, name) : name;
+    }
+
+    @JsonIgnore
+    public String clusterKeyEncoded() {
+        return Base64.getUrlEncoder().encodeToString(clusterKey().getBytes());
     }
 
     @JsonIgnore

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaConfig.java
@@ -17,13 +17,22 @@ import io.sundr.builder.annotations.Buildable;
 @Buildable(editableEnabled = false)
 public class KafkaConfig {
 
+    static final String UNIQUE_NAMES_MESSAGE = "Kafka cluster name and namespace combinations must be unique";
+
     @Valid
     List<KafkaClusterConfig> clusters = new ArrayList<>();
 
+    private boolean uniqueNames() {
+        if (clusters == null) {
+            return true;
+        }
+        return clusters.stream().map(KafkaClusterConfig::clusterKey).distinct().count() == clusters.size();
+    }
+
     @JsonIgnore
-    @AssertTrue(message = "Kafka cluster names must be unique")
+    @AssertTrue(message = UNIQUE_NAMES_MESSAGE)
     public boolean hasUniqueClusterNames() {
-        return Named.uniqueNames(clusters);
+        return uniqueNames();
     }
 
     @JsonIgnore

--- a/common/src/test/java/com/github/streamshub/console/config/ConsoleConfigTest.java
+++ b/common/src/test/java/com/github/streamshub/console/config/ConsoleConfigTest.java
@@ -2,6 +2,7 @@ package com.github.streamshub.console.config;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -89,7 +90,21 @@ class ConsoleConfigTest {
         var violations = validator.validate(config);
 
         assertEquals(1, violations.size());
-        assertEquals("Kafka cluster names must be unique", violations.iterator().next().getMessage());
+        assertEquals(KafkaConfig.UNIQUE_NAMES_MESSAGE, violations.iterator().next().getMessage());
+    }
+
+    @Test
+    void testKafkaNamesWithUniqueNamespacesPassValidation() {
+        for (String name : List.of("name1", "name2", "name1")) {
+            KafkaClusterConfig cluster = new KafkaClusterConfig();
+            cluster.setName(name);
+            cluster.setNamespace(UUID.randomUUID().toString());
+            config.getKafka().getClusters().add(cluster);
+        }
+
+        var violations = validator.validate(config);
+
+        assertTrue(violations.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Same as #1752, for `0.8.5`

* fix: allow duplicate Kafka cluster names in different namespaces
* Add test case