### PR TITLE
fix: include namespace in cluster-scoped names, refine CR conditions

### DIFF
--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
@@ -36,6 +36,15 @@ public class ConsoleStatus {
         return conditions;
     }
 
+    /*
+     * Setter used by Jackson. Without this the field is replaced with an unsorted
+     * HashSet by Jackson using reflection.
+     */
+    public void setConditions(Set<Condition> conditions) {
+        this.conditions.clear();
+        this.conditions.addAll(conditions);
+    }
+
     @JsonIgnore
     public boolean hasCondition(String type) {
         return conditions.stream().anyMatch(c -> type.equals(c.getType()));

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/status/ConsoleStatus.java
@@ -42,6 +42,11 @@ public class ConsoleStatus {
     }
 
     @JsonIgnore
+    public boolean hasActiveCondition(String type) {
+        return conditions.stream().filter(Condition::isActive).anyMatch(c -> type.equals(c.getType()));
+    }
+
+    @JsonIgnore
     public Condition getCondition(String type) {
         return conditions.stream()
             .filter(c -> type.equals(c.getType()))

--- a/operator/src/main/java/com/github/streamshub/console/dependents/BaseClusterRole.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/BaseClusterRole.java
@@ -34,6 +34,11 @@ abstract class BaseClusterRole extends KubernetesDependentResource<ClusterRole, 
     }
 
     @Override
+    public String instanceName(Console primary) {
+        return primary.getMetadata().getNamespace() + "-" + ConsoleResource.super.instanceName(primary);
+    }
+
+    @Override
     public Optional<ClusterRole> getSecondaryResource(Console primary, Context<Console> context) {
         return ConsoleResource.super.getSecondaryResource(primary, context);
     }

--- a/operator/src/main/java/com/github/streamshub/console/dependents/BaseClusterRoleBinding.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/BaseClusterRoleBinding.java
@@ -34,6 +34,11 @@ abstract class BaseClusterRoleBinding extends KubernetesDependentResource<Cluste
     }
 
     @Override
+    public String instanceName(Console primary) {
+        return primary.getMetadata().getNamespace() + "-" + ConsoleResource.super.instanceName(primary);
+    }
+
+    @Override
     public Optional<ClusterRoleBinding> getSecondaryResource(Console primary, Context<Console> context) {
         return ConsoleResource.super.getSecondaryResource(primary, context);
     }

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConfigurationProcessor.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConfigurationProcessor.java
@@ -145,10 +145,13 @@ public class ConfigurationProcessor implements DependentResource<HasMetadata, Co
     @Override
     public ReconcileResult<HasMetadata> reconcile(Console primary, Context<Console> context) {
         if (buildSecretData(primary, context)) {
-            LOGGER.debugf("Validation gate passed: %s", primary.getMetadata().getName());
+            LOGGER.debugf("Validation gate passed: %s/%s",
+                    primary.getMetadata().getNamespace(),
+                    primary.getMetadata().getName());
             context.managedWorkflowAndDependentResourceContext().put(NAME, Boolean.TRUE);
         } else {
-            LOGGER.debugf("Validation gate failed: %s; %s",
+            LOGGER.debugf("Validation gate failed: %s/%s; %s",
+                    primary.getMetadata().getNamespace(),
                     primary.getMetadata().getName(),
                     primary.getStatus().getCondition(Types.ERROR).getMessage());
             context.managedWorkflowAndDependentResourceContext().put(NAME, Boolean.FALSE);
@@ -192,7 +195,7 @@ public class ConfigurationProcessor implements DependentResource<HasMetadata, Co
         }
 
         context.managedWorkflowAndDependentResourceContext().put("ConsoleSecretData", data);
-        return !status.hasCondition(Types.ERROR);
+        return !status.hasActiveCondition(Types.ERROR);
     }
 
     private void buildConsoleConfig(Console primary, Context<Console> context,

--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTestBase.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTestBase.java
@@ -28,6 +28,7 @@ import com.github.streamshub.console.dependents.ConsoleSecret;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -78,6 +79,21 @@ abstract class ConsoleReconcilerTestBase {
     public static <T extends HasMetadata> T apply(KubernetesClient client, T resource) {
         client.resource(resource).serverSideApply();
         return client.resource(resource).patchStatus();
+    }
+
+    Namespace createNamespace(String name) {
+        Namespace ns = client.resource(new NamespaceBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(Map.of("streamshub-operator/test", "true"))
+                .endMetadata()
+                .build())
+            .serverSideApply();
+
+        ns.getSpec().setFinalizers(null);
+        ns.getMetadata().setFinalizers(null);
+
+        return client.resource(ns).update();
     }
 
     @SafeVarargs
@@ -151,13 +167,7 @@ abstract class ConsoleReconcilerTestBase {
 
         operator.start();
 
-        client.resource(new NamespaceBuilder()
-                .withNewMetadata()
-                    .withName(KAFKA_NS)
-                    .withLabels(Map.of("streamshub-operator/test", "true"))
-                .endMetadata()
-                .build())
-            .serverSideApply();
+        createNamespace(KAFKA_NS);
 
         kafkaCR = new KafkaBuilder()
                 .withNewMetadata()
@@ -189,24 +199,22 @@ abstract class ConsoleReconcilerTestBase {
 
         kafkaCR = apply(client, kafkaCR);
 
-        client.resource(new NamespaceBuilder()
-                .withNewMetadata()
-                    .withName(CONSOLE_NS)
-                    .withLabels(Map.of("streamshub-operator/test", "true"))
-                .endMetadata()
-                .build())
-            .serverSideApply();
+        createNamespace(CONSOLE_NS);
     }
 
-    Console createConsole(ConsoleBuilder builder) {
+    Console createConsole(ConsoleBuilder builder, String namespace) {
         var meta = new ObjectMetaBuilder(builder.getMetadata())
-                .withNamespace(CONSOLE_NS)
+                .withNamespace(namespace)
                 .withName(CONSOLE_NAME)
                 .build();
 
         builder = builder.withMetadata(meta);
 
         return client.resource(builder.build()).create();
+    }
+
+    Console createConsole(ConsoleBuilder builder) {
+        return createConsole(builder, CONSOLE_NS);
     }
 
     void awaitReady(Console resource) {


### PR DESCRIPTION
Fixes #1779 

- Correct the naming of cluster-scoped resources owned by the Console CR to avoid conflicts
- Fix status check of the configuration handler to only consider errors set in the CR's status during the current reconciliation
- Improve the reporting of conditions by checking for resources that encountered exceptions and ignoring the primary exception if already reported by the exceptions of individual resources