### PR TITLE
fix: use comma as component delimiter for Kafka Connect identifiers

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaConnectService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaConnectService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -383,7 +384,7 @@ public class KafkaConnectService {
         StringBuilder encoded = new StringBuilder(base);
         for (String v : values) {
             if (!encoded.isEmpty()) {
-                encoded.append('.');
+                encoded.append(',');
             }
             encoded.append(Base64.getUrlEncoder().encodeToString(v.getBytes(StandardCharsets.UTF_8)));
         }
@@ -392,7 +393,7 @@ public class KafkaConnectService {
 
     static String[] decode(String value) {
         List<String> decoded = new ArrayList<>();
-        for (String v : value.split("\\.")) {
+        for (String v : value.split(Pattern.quote(","))) {
             decoded.add(new String(Base64.getUrlDecoder().decode(v), StandardCharsets.UTF_8));
         }
         return decoded.toArray(String[]::new);

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaConnectorsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaConnectorsResourceIT.java
@@ -239,7 +239,7 @@ class KafkaConnectorsResourceIT implements ClientRequestFilter {
     void testDescribeConnector(String connectCluster, String connectorName) {
         var enc = Base64.getUrlEncoder();
         String connectorID = enc.encodeToString(connectCluster.getBytes()) +
-                '.' +
+                ',' +
                 enc.encodeToString(connectorName.getBytes());
 
         whenRequesting(req -> req.get(connectorID))
@@ -258,7 +258,7 @@ class KafkaConnectorsResourceIT implements ClientRequestFilter {
     void testDescribeConnectorWithAllIncluded(String connectCluster, String connectorName, int taskCount) {
         var enc = Base64.getUrlEncoder();
         String connectorID = enc.encodeToString(connectCluster.getBytes()) +
-                '.' +
+                ',' +
                 enc.encodeToString(connectorName.getBytes());
 
         whenRequesting(req -> req


### PR DESCRIPTION
Next.js seems to treat the period/decimal point `.` as a special character, causing trouble with routing. This PR updates the Kafka Connect delimiters to use a comma instead.