### PR TITLE
Include MirrorMaker type in connector type, add filter

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/model/connect/ConnectClusterFilterParams.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/connect/ConnectClusterFilterParams.java
@@ -41,7 +41,7 @@ public class ConnectClusterFilterParams extends FilterParams {
 
     @QueryParam("filter[kafkaClusters]")
     @Parameter(
-        description = "Retrieve only connect clusters associated with the identified Kafka clusters",
+        description = "Retrieve only Kafka Connect clusters associated with the identified Kafka clusters",
         schema = @Schema(implementation = String[].class, minItems = 2),
         explode = Explode.FALSE)
     @Expression(

--- a/api/src/main/java/com/github/streamshub/console/api/model/connect/Connector.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/connect/Connector.java
@@ -173,6 +173,13 @@ public class Connector extends KubeApiResource<Connector.Attributes, Connector.R
     @JsonFilter(FIELDS_PARAM)
     static class Attributes extends KubeAttributes {
         @JsonProperty
+        @Schema(enumeration = {
+                "sink",
+                "source",
+                "source:mm",
+                "source:mm-checkpoint",
+                "source:mm-heartbeat"
+        })
         String type;
 
         @JsonProperty
@@ -239,6 +246,10 @@ public class Connector extends KubeApiResource<Connector.Attributes, Connector.R
 
     public void metrics(Metrics metrics) {
         attributes.metrics = metrics;
+    }
+
+    public String type() {
+        return attributes.type;
     }
 
     public void type(String type) {

--- a/api/src/main/java/com/github/streamshub/console/api/model/connect/Connector.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/connect/Connector.java
@@ -174,11 +174,11 @@ public class Connector extends KubeApiResource<Connector.Attributes, Connector.R
     static class Attributes extends KubeAttributes {
         @JsonProperty
         @Schema(enumeration = {
-                "sink",
-                "source",
-                "source:mm",
-                "source:mm-checkpoint",
-                "source:mm-heartbeat"
+            "sink",
+            "source",
+            "source:mm",
+            "source:mm-checkpoint",
+            "source:mm-heartbeat"
         })
         String type;
 

--- a/api/src/main/java/com/github/streamshub/console/api/model/connect/ConnectorFilterParams.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/connect/ConnectorFilterParams.java
@@ -39,6 +39,25 @@ public class ConnectorFilterParams extends FilterParams {
         node = "filter[name]")
     FetchFilter nameFilter;
 
+    @QueryParam("filter[type]")
+    @Parameter(
+        description = "Retrieve only connectors with a type matching this parameter",
+        schema = @Schema(implementation = String[].class, minItems = 2),
+        explode = Explode.FALSE)
+    @Expression(
+        when = "self != null",
+        value = "self.operator == 'eq' || self.operator == 'in'",
+        message = "unsupported filter operator, supported values: [ 'eq', 'in' ]",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[type]")
+    @Expression(
+        when = "self != null",
+        value = "self.operands.size() >= 1",
+        message = "at least 1 operand is required",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[type]")
+    FetchFilter typeFilter;
+
     @QueryParam("filter[connectCluster.kafkaClusters]")
     @Parameter(
         description = "Retrieve only connectors associated with the identified Kafka clusters",
@@ -61,6 +80,7 @@ public class ConnectorFilterParams extends FilterParams {
     @Override
     protected void buildPredicates() {
         maybeAddPredicate(nameFilter, Connector.class, Connector::name);
+        maybeAddPredicate(typeFilter, Connector.class, Connector::type);
         maybeAddPredicate(kafkaClusterFilter, KafkaConnectConfig.class, connectService::mapKafkaIdentifiers);
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/model/connect/ConnectorPlugin.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/connect/ConnectorPlugin.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.streamshub.console.api.support.KafkaConnectAPI;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ConnectorPlugin(
@@ -16,8 +15,8 @@ public record ConnectorPlugin(
         List<ConfigInfo> config
 ) {
 
-    public ConnectorPlugin(KafkaConnectAPI.PluginInfo info) {
-        this(info.className(), info.type(), info.version(), new ArrayList<>());
+    public ConnectorPlugin(String className, String type, String version) {
+        this(className, type, version, new ArrayList<>());
     }
 
     static record ConfigInfo(

--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaConnectService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaConnectService.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -19,6 +20,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
@@ -82,6 +84,18 @@ public class KafkaConnectService {
     @Inject
     PermissionService permissionService;
 
+    @Inject
+    @ConfigProperty(name = "console.connect.mirror.classes.checkpoints")
+    List<String> mmCheckpoints;
+
+    @Inject
+    @ConfigProperty(name = "console.connect.mirror.classes.heartbeats")
+    List<String> mmHeartbeats;
+
+    @Inject
+    @ConfigProperty(name = "console.connect.mirror.classes.sources")
+    List<String> mmSources;
+
     public CompletionStage<List<ConnectCluster>> listClusters(FieldFilter fields, ListRequestContext<ConnectCluster> listSupport) {
         var pendingServerInfo = consoleConfig.getKafkaConnectClusters()
                 .stream()
@@ -112,7 +126,7 @@ public class KafkaConnectService {
         var clusterKey = clusterConfig.clusterKey();
         var includePlugins = fields.isIncluded(ConnectCluster.FIELDS_PARAM, ConnectCluster.Fields.PLUGINS.toString());
         var pluginPromise = includePlugins
-            ? connectClient.getConnectorPlugins(clusterKey).thenApply(plugins -> plugins.stream().map(ConnectorPlugin::new).toList())
+            ? describeConnectorPlugins(clusterConfig)
             : PROMISE_NULL_PLUGINS;
 
         var includeConnectors = fetchParams.includes(ConnectCluster.Fields.CONNECTORS.toString());
@@ -250,7 +264,7 @@ public class KafkaConnectService {
                     Connector connector = new Connector(encode("", clusterConfig.clusterKey(), connectorName));
                     connector.name(connectorName);
                     connector.namespace(clusterConfig.getNamespace());
-                    connector.type(info.type());
+                    connector.type(mapType(info));
                     connector.config(info.config());
                     connector.state(state.connector().state());
                     connector.trace(state.connector().trace());
@@ -290,6 +304,24 @@ public class KafkaConnectService {
             });
     }
 
+    private String mapType(KafkaConnectAPI.ConnectorInfo info) {
+        var config = Optional.ofNullable(info.config()).orElseGet(Collections::emptyMap);
+        var className = config.getOrDefault("connector.class", "");
+        return mapType(info.type(), className);
+    }
+
+    private String mapType(String type, String className) {
+        if (mmCheckpoints.contains(className)) {
+            type += ":mm-checkpoint";
+        } else if (mmHeartbeats.contains(className)) {
+            type += ":mm-heartbeat";
+        } else if (mmSources.contains(className)) {
+            type += ":mm";
+        }
+
+        return type;
+    }
+
     private void mapTasks(Connector connector, KafkaConnectAPI.ConnectorInfo info, KafkaConnectAPI.ConnectorStateInfo state, boolean include) {
         List<ConnectorTask> tasks = new ArrayList<>();
 
@@ -324,6 +356,16 @@ public class KafkaConnectService {
         }
 
         return connector;
+    }
+
+    private CompletionStage<List<ConnectorPlugin>> describeConnectorPlugins(KafkaConnectConfig clusterConfig) {
+        return connectClient.getConnectorPlugins(clusterConfig.clusterKey())
+                .thenApply(plugins -> plugins.stream()
+                        .map(plugin -> new ConnectorPlugin(
+                                plugin.className(),
+                                mapType(plugin.type(), plugin.className()),
+                                plugin.version()))
+                        .toList());
     }
 
     private CompletionStage<List<String>> describeConnectorTopics(KafkaConnectConfig clusterConfig, String connectorName) {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -76,6 +76,11 @@ quarkus.index-dependency.strimzi-api.artifact-id=api
 console.kafka.admin.request.timeout.ms=10000
 console.kafka.admin.default.api.timeout.ms=10000
 
+# These could be overridden via the environment in edge cases where they are customized by a plugin extension
+console.connect.mirror.classes.checkpoints=org.apache.kafka.connect.mirror.MirrorCheckpointConnector
+console.connect.mirror.classes.heartbeats=org.apache.kafka.connect.mirror.MirrorHeartbeatConnector
+console.connect.mirror.classes.sources=org.apache.kafka.connect.mirror.MirrorSourceConnector
+
 ########
 #%dev.quarkus.http.auth.proactive=false
 #%dev.quarkus.http.auth.permission."oidc".policy=permit

--- a/api/src/test/resources/com/github/streamshub/console/api/KafkaConnect-fixtures.yaml
+++ b/api/src/test/resources/com/github/streamshub/console/api/KafkaConnect-fixtures.yaml
@@ -21,7 +21,8 @@ test-connect1.example.com:
 
   "/connectors/connect1-connector1":
     name: connect1-connector1
-    config: {}
+    config:
+      connector.class: my.custom.Connector1
     tasks:
       - connector: connect1-connector1
         task: 0
@@ -75,7 +76,8 @@ test-connect1.example.com:
 
   "/connectors/connect1-connector2":
     name: connect1-connector2
-    config: {}
+    config:
+      connector.class: my.custom.Connector2
     tasks:
       - connector: connect1-connector2
         task: 0
@@ -138,7 +140,8 @@ test-connect2.example.com:
 
   "/connectors/connect2-connector1":
     name: connect2-connector1
-    config: {}
+    config:
+      connector.class: org.apache.kafka.connect.mirror.MirrorSourceConnector
     tasks:
       - connector: connect2-connector1
         task: 0
@@ -180,7 +183,8 @@ test-connect2.example.com:
 
   "/connectors/connect2-connector2":
     name: connect2-connector2
-    config: {}
+    config:
+      connector.class: org.apache.kafka.connect.mirror.MirrorCheckpointConnector
     tasks:
       - connector: connect2-connector2
         task: 0

--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -74,6 +74,17 @@ public class ConsoleConfig {
         return Named.uniqueNames(schemaRegistries);
     }
 
+    @JsonIgnore
+    @AssertTrue(message = "Kafka Connect name, namespace, and mirrorMaker combinations must be unique")
+    public boolean hasUniqueKafkaConnectClusters() {
+        return Optional.ofNullable(kafkaConnectClusters)
+                .map(clusters -> clusters.stream()
+                        .map(kc -> List.of(kc.clusterKey(), kc.isMirrorMaker()))
+                        .distinct()
+                        .count() == clusters.size())
+                .orElse(true);
+    }
+
     /**
      * Specifying security subjects local to a Kafka cluster is not allowed when global OIDC
      * security is enabled.


### PR DESCRIPTION
Add the MirrorMaker type to the connector and plugin types when the class of the connector or plugin indicates MirrorMaker (may be overridden via environment variable in cases where a customized class is used). The type may also be filtered so that only MM connectors or only non-MM connectors are returned.

Also validate Kafka Connect name/namespace/mirrorMaker flag combination is unique.