### PR TITLE
[0.8.x] build(deps): bump quarkus.platform.version from 3.20.2 to 3.20.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- Dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.20.2</quarkus.platform.version>
+        <quarkus.platform.version>3.20.2.1</quarkus.platform.version>
         <strimzi-api.version>0.46.1</strimzi-api.version>
         <strimzi-oauth.version>0.16.2</strimzi-oauth.version>
         <apicurio-registry.version>2.6.13.Final</apicurio-registry.version>


### PR DESCRIPTION
Bumps `quarkus.platform.version` from 3.20.2 to 3.20.2.1.

Updates `io.quarkus.platform:quarkus-bom` from 3.20.2 to 3.20.2.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.20.2...3.20.2.1)

Updates `io.quarkus.platform:quarkus-operator-sdk-bom` from 3.20.2 to 3.20.2.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.20.2...3.20.2.1)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.20.2 to 3.20.2.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.20.2...3.20.2.1)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-version: 3.20.2.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-operator-sdk-bom dependency-version: 3.20.2.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-version: 3.20.2.1 dependency-type: direct:production update-type: version-update:semver-patch ...