### PR TITLE
fix: use base64-encoded identifiers for consumer group resources

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/ConsumerGroupsResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/ConsumerGroupsResource.java
@@ -82,6 +82,7 @@ public class ConsumerGroupsResource {
             @StringEnumeration(
                     source = ConsumerGroup.FIELDS_PARAM,
                     allowedValues = {
+                        ConsumerGroup.Fields.GROUP_ID,
                         ConsumerGroup.Fields.STATE,
                         ConsumerGroup.Fields.SIMPLE_CONSUMER_GROUP,
                         ConsumerGroup.Fields.MEMBERS,
@@ -98,6 +99,7 @@ public class ConsumerGroupsResource {
                             type = SchemaType.ARRAY,
                             implementation = String.class,
                             enumeration = {
+                                ConsumerGroup.Fields.GROUP_ID,
                                 ConsumerGroup.Fields.STATE,
                                 ConsumerGroup.Fields.SIMPLE_CONSUMER_GROUP,
                                 ConsumerGroup.Fields.MEMBERS,
@@ -153,6 +155,7 @@ public class ConsumerGroupsResource {
             @StringEnumeration(
                     source = ConsumerGroup.FIELDS_PARAM,
                     allowedValues = {
+                        ConsumerGroup.Fields.GROUP_ID,
                         ConsumerGroup.Fields.STATE,
                         ConsumerGroup.Fields.SIMPLE_CONSUMER_GROUP,
                         ConsumerGroup.Fields.MEMBERS,
@@ -169,6 +172,7 @@ public class ConsumerGroupsResource {
                             type = SchemaType.ARRAY,
                             implementation = String.class,
                             enumeration = {
+                                ConsumerGroup.Fields.GROUP_ID,
                                 ConsumerGroup.Fields.STATE,
                                 ConsumerGroup.Fields.SIMPLE_CONSUMER_GROUP,
                                 ConsumerGroup.Fields.MEMBERS,
@@ -235,13 +239,14 @@ public class ConsumerGroupsResource {
 
         if (dryRun) {
             requestedFields.accept(List.of(
+                ConsumerGroup.Fields.GROUP_ID,
                 ConsumerGroup.Fields.STATE,
                 ConsumerGroup.Fields.MEMBERS,
                 ConsumerGroup.Fields.OFFSETS
             ));
         }
 
-        return consumerGroupService.patchConsumerGroup(patch.getData().getAttributes(), dryRun)
+        return consumerGroupService.patchConsumerGroup(groupId, patch.getData().getAttributes(), dryRun)
                 .thenApply(optionalGroup -> optionalGroup
                         .map(ConsumerGroup.Data::new)
                         .map(Response::ok)

--- a/api/src/main/java/com/github/streamshub/console/api/TopicsResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/TopicsResource.java
@@ -319,6 +319,7 @@ public class TopicsResource {
             @StringEnumeration(
                     source = ConsumerGroup.FIELDS_PARAM,
                     allowedValues = {
+                        ConsumerGroup.Fields.GROUP_ID,
                         ConsumerGroup.Fields.STATE,
                         ConsumerGroup.Fields.SIMPLE_CONSUMER_GROUP,
                         ConsumerGroup.Fields.MEMBERS,
@@ -335,6 +336,7 @@ public class TopicsResource {
                             type = SchemaType.ARRAY,
                             implementation = String.class,
                             enumeration = {
+                                ConsumerGroup.Fields.GROUP_ID,
                                 ConsumerGroup.Fields.STATE,
                                 ConsumerGroup.Fields.SIMPLE_CONSUMER_GROUP,
                                 ConsumerGroup.Fields.MEMBERS,

--- a/api/src/main/java/com/github/streamshub/console/api/model/ConsumerGroup.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/ConsumerGroup.java
@@ -19,7 +19,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.streamshub.console.api.model.jsonapi.JsonApiError;
 import com.github.streamshub.console.api.model.jsonapi.JsonApiResource;
@@ -29,6 +28,7 @@ import com.github.streamshub.console.api.model.jsonapi.None;
 import com.github.streamshub.console.api.support.ComparatorBuilder;
 import com.github.streamshub.console.api.support.ErrorCategory;
 import com.github.streamshub.console.api.support.ListRequestContext;
+import com.github.streamshub.console.support.Identifiers;
 
 import io.xlate.validation.constraints.Expression;
 
@@ -43,6 +43,7 @@ public class ConsumerGroup {
     public static final String FIELDS_PARAM = "fields[" + API_TYPE + "]";
 
     public static final class Fields {
+        public static final String GROUP_ID = "groupId";
         public static final String STATE = "state";
         public static final String MEMBERS = "members";
         public static final String COORDINATOR = "coordinator";
@@ -56,14 +57,21 @@ public class ConsumerGroup {
 
         static final Map<String, Map<Boolean, Comparator<ConsumerGroup>>> COMPARATORS = ComparatorBuilder.bidirectional(
                 Map.of("id", ID_COMPARATOR,
+                        GROUP_ID, nullsLast(comparing(ConsumerGroup::getGroupId)),
                         STATE, nullsLast(comparing(ConsumerGroup::getState)),
                         SIMPLE_CONSUMER_GROUP, comparing(ConsumerGroup::isSimpleConsumerGroup)));
 
         public static final ComparatorBuilder<ConsumerGroup> COMPARATOR_BUILDER =
                 new ComparatorBuilder<>(ConsumerGroup.Fields::comparator, ConsumerGroup.Fields.defaultComparator());
 
-        public static final String LIST_DEFAULT = STATE + ", " + SIMPLE_CONSUMER_GROUP;
-        public static final String DESCRIBE_DEFAULT = STATE + ", " + MEMBERS + ", " + COORDINATOR + ", " + OFFSETS
+        public static final String LIST_DEFAULT = GROUP_ID +
+                ", " + STATE +
+                ", " + SIMPLE_CONSUMER_GROUP;
+        public static final String DESCRIBE_DEFAULT = GROUP_ID +
+                ", " + STATE +
+                ", " + MEMBERS +
+                ", " + COORDINATOR +
+                ", " + OFFSETS
                 + ", " + SIMPLE_CONSUMER_GROUP;
 
         private Fields() {
@@ -134,14 +142,16 @@ public class ConsumerGroup {
          */
         @JsonCreator
         public ConsumerGroupResource(String id, String type, ConsumerGroup attributes) {
-            super(id, type, new ConsumerGroup(id, attributes));
+            super(id, type, new ConsumerGroup(attributes));
         }
 
         /**
          * Used by list and describe
          */
         public ConsumerGroupResource(ConsumerGroup attributes) {
-            super(attributes.groupId, API_TYPE, attributes);
+            super(Identifiers.encode("".equals(attributes.groupId) ? "+" : attributes.groupId),
+                    API_TYPE,
+                    attributes);
 
             if (attributes.errors != null) {
                 addMeta("errors", attributes.errors);
@@ -150,7 +160,6 @@ public class ConsumerGroup {
     }
 
     // Available via list or describe operations
-    @JsonIgnore
     private final String groupId;
     private final boolean simpleConsumerGroup;
     private final String state;
@@ -169,10 +178,16 @@ public class ConsumerGroup {
     // When a describe error occurs
     private List<JsonApiError> errors;
 
-    private ConsumerGroup(String id, ConsumerGroup other) {
-        this(id,
-             other != null && other.simpleConsumerGroup,
-             other != null ? other.state : null);
+    private ConsumerGroup(ConsumerGroup other) {
+        if (other != null) {
+            this.groupId = other.groupId;
+            this.simpleConsumerGroup = other.simpleConsumerGroup;
+            this.state = other.state;
+        } else {
+            this.groupId = null;
+            this.simpleConsumerGroup = false;
+            this.state = null;
+        }
 
         Optional.ofNullable(other)
             .map(ConsumerGroup::getOffsets)

--- a/api/src/main/java/com/github/streamshub/console/api/model/ConsumerGroup.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/ConsumerGroup.java
@@ -308,7 +308,7 @@ public class ConsumerGroup {
 
         JsonObject attr = cursor.getJsonObject("attributes");
 
-        return new ConsumerGroup(cursor.getString("id"),
+        return new ConsumerGroup(attr.getString(Fields.GROUP_ID, null),
                 attr.getBoolean(Fields.SIMPLE_CONSUMER_GROUP, false),
                 attr.getString(Fields.STATE, null));
     }
@@ -320,6 +320,10 @@ public class ConsumerGroup {
 
         if (sortFields.contains(Fields.SIMPLE_CONSUMER_GROUP)) {
             attrBuilder.add(Fields.SIMPLE_CONSUMER_GROUP, simpleConsumerGroup);
+        }
+
+        if (sortFields.contains(Fields.GROUP_ID)) {
+            attrBuilder.add(Fields.GROUP_ID, groupId);
         }
 
         if (sortFields.contains(Fields.STATE)) {

--- a/api/src/main/java/com/github/streamshub/console/api/security/AuthorizationInterceptor.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/AuthorizationInterceptor.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.PathSegment;
@@ -25,6 +26,7 @@ import com.github.streamshub.console.api.ClientFactory;
 import com.github.streamshub.console.api.service.TopicDescribeService;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.config.security.ResourceTypes;
+import com.github.streamshub.console.support.Identifiers;
 
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -144,10 +146,18 @@ public class AuthorizationInterceptor {
                 resourceNames.add(converter.apply(segment));
             } else {
                 if (s == 3) {
-                    if (ResourceTypes.Kafka.TOPICS.value().equals(segment)) {
-                        converter = this::topicName;
-                    } else if (ResourceTypes.Kafka.REBALANCES.value().equals(segment)) {
-                        converter = this::rebalanceName;
+                    switch (ResourceTypes.Kafka.fromValue(segment)) {
+                        case CONSUMER_GROUPS:
+                            converter = this::consumerGroupId;
+                            break;
+                        case REBALANCES:
+                            converter = this::rebalanceName;
+                            break;
+                        case TOPICS:
+                            converter = this::topicName;
+                            break;
+                        default:
+                            break;
                     }
                 }
                 if (!resource.isEmpty()) {
@@ -165,6 +175,17 @@ public class AuthorizationInterceptor {
     private String topicName(String topicId) {
         return topicDescribe.topicNameForId(topicId).toCompletableFuture().join()
             .orElseThrow(() -> new UnknownTopicIdException("No such topic: " + topicId));
+    }
+
+    /**
+     * Decode the base64-encoded consumer groupId.
+     */
+    private String consumerGroupId(String groupId) {
+        String[] decoded = Identifiers.decode(groupId);
+        if (decoded.length != 1) {
+            throw new BadRequestException("Malformed consumer group URI");
+        }
+        return decoded[0];
     }
 
     /**

--- a/api/src/main/java/com/github/streamshub/console/api/service/ConsumerGroupService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/ConsumerGroupService.java
@@ -60,7 +60,6 @@ import com.github.streamshub.console.api.support.Promises;
 import com.github.streamshub.console.api.support.UnknownTopicIdPatch;
 import com.github.streamshub.console.api.support.ValidationProxy;
 import com.github.streamshub.console.config.security.Privilege;
-import com.github.streamshub.console.support.Identifiers;
 
 @ApplicationScoped
 public class ConsumerGroupService {
@@ -173,7 +172,7 @@ public class ConsumerGroupService {
 
     public CompletionStage<ConsumerGroup> describeConsumerGroup(String requestGroupId, List<String> includes) {
         Admin adminClient = kafkaContext.admin();
-        String groupId = preprocessGroupId(requestGroupId);
+        String groupId = ConsumerGroup.decodeGroupId(requestGroupId);
 
         return assertConsumerGroupExists(adminClient, groupId)
             .thenComposeAsync(
@@ -232,7 +231,7 @@ public class ConsumerGroupService {
 
     public CompletionStage<Optional<ConsumerGroup>> patchConsumerGroup(String requestGroupId, ConsumerGroup patch, boolean dryRun) {
         Admin adminClient = kafkaContext.admin();
-        String groupId = preprocessGroupId(requestGroupId);
+        String groupId = ConsumerGroup.decodeGroupId(requestGroupId);
 
         return assertConsumerGroupExists(adminClient, groupId)
             .thenComposeAsync(nothing -> Optional.ofNullable(patch.getOffsets())
@@ -426,7 +425,7 @@ public class ConsumerGroupService {
 
     public CompletionStage<Void> deleteConsumerGroup(String requestGroupId) {
         Admin adminClient = kafkaContext.admin();
-        String groupId = preprocessGroupId(requestGroupId);
+        String groupId = ConsumerGroup.decodeGroupId(requestGroupId);
 
         return adminClient.deleteConsumerGroups(List.of(groupId))
                 .deletedGroups()
@@ -618,13 +617,5 @@ public class ConsumerGroupService {
 
             group.setOffsets(offsets);
         }
-    }
-
-    private static String preprocessGroupId(String groupId) {
-        String[] decoded = Identifiers.decode(groupId);
-        if (decoded.length == 1) {
-            return "+".equals(decoded[0]) ? "" : decoded[0];
-        }
-        throw new GroupIdNotFoundException("Invalid groupId");
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/service/TopicDescribeService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/TopicDescribeService.java
@@ -53,6 +53,7 @@ import com.github.streamshub.console.api.support.KafkaOffsetSpec;
 import com.github.streamshub.console.api.support.ListRequestContext;
 import com.github.streamshub.console.api.support.UnknownTopicIdPatch;
 import com.github.streamshub.console.config.security.Privilege;
+import com.github.streamshub.console.support.Identifiers;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -311,7 +312,10 @@ public class TopicDescribeService {
 
                         if (searchTopics.contains(idString)) {
                             var topicGroups = consumerGroups.getOrDefault(idString, Collections.emptyList());
-                            var identifiers = topicGroups.stream().map(g -> new Identifier("consumerGroups", g)).toList();
+                            var identifiers = topicGroups.stream()
+                                    .map(Identifiers::encode)
+                                    .map(g -> new Identifier("consumerGroups", g))
+                                    .toList();
                             topic.consumerGroups().getData().addAll(identifiers);
                             topic.consumerGroups().addMeta("count", identifiers.size());
                         } else {

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaConnectorsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaConnectorsResourceIT.java
@@ -253,7 +253,7 @@ class KafkaConnectorsResourceIT implements ClientRequestFilter {
         "default/test-connect2, connect2-connector2"
     })
     void testDescribeConnector(String connectCluster, String connectorName) {
-        var enc = Base64.getUrlEncoder();
+        var enc = Base64.getUrlEncoder().withoutPadding();
         String connectorID = enc.encodeToString(connectCluster.getBytes()) +
                 ',' +
                 enc.encodeToString(connectorName.getBytes());
@@ -272,7 +272,7 @@ class KafkaConnectorsResourceIT implements ClientRequestFilter {
         "default/test-connect2, connect2-connector2, 2"
     })
     void testDescribeConnectorWithAllIncluded(String connectCluster, String connectorName, int taskCount) {
-        var enc = Base64.getUrlEncoder();
+        var enc = Base64.getUrlEncoder().withoutPadding();
         String connectorID = enc.encodeToString(connectCluster.getBytes()) +
                 ',' +
                 enc.encodeToString(connectorName.getBytes());

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaConnectsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaConnectsResourceIT.java
@@ -192,22 +192,23 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
 
     @Test
     void testListConnectClustersSortedByVersion() {
+        var enc = Base64.getUrlEncoder().withoutPadding();
         whenRequesting(req -> req.param("sort", "version").get())
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(3))
             .body("data.meta.managed", contains(true, true, false))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString("default/test-connect1".getBytes())))
+            .body("data[0].id", is(enc.encodeToString("default/test-connect1".getBytes())))
             .body("data[0].attributes.commit", is("abc123d"))
             .body("data[0].attributes.kafkaClusterId", is(consoleConfig.getKafka().getCluster("default/test-kafka1").get().getId()))
             .body("data[0].attributes.version", is("4.0.0"))
             .body("data[0].attributes.replicas", is(2))
-            .body("data[1].id", is(Base64.getUrlEncoder().encodeToString("default/test-connect2".getBytes())))
+            .body("data[1].id", is(enc.encodeToString("default/test-connect2".getBytes())))
             .body("data[1].attributes.commit", is("zyx987w"))
             .body("data[1].attributes.kafkaClusterId", is("k2-id"))
             .body("data[1].attributes.version", is("4.0.1"))
             .body("data[1].attributes.replicas", is(4))
-            .body("data[2].id", is(Base64.getUrlEncoder().encodeToString("test-connect3".getBytes())))
+            .body("data[2].id", is(enc.encodeToString("test-connect3".getBytes())))
             .body("data[2].attributes.commit", is("yyy777x"))
             .body("data[2].attributes.kafkaClusterId", is("test-kafkaY"))
             .body("data[2].attributes.version", is("4.0.2"))
@@ -226,7 +227,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString(("default/" + expectedName).getBytes())))
+            .body("data[0].id", is(Base64.getUrlEncoder().withoutPadding().encodeToString(("default/" + expectedName).getBytes())))
             .body("data[0].attributes.namespace", is("default"))
             .body("data[0].attributes.name", is(expectedName))
             .body("data[0].attributes.commit", is(expectedCommit))
@@ -249,7 +250,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString(("default/" + expectedName).getBytes())))
+            .body("data[0].id", is(Base64.getUrlEncoder().withoutPadding().encodeToString(("default/" + expectedName).getBytes())))
             .body("data[0].attributes.namespace", is("default"))
             .body("data[0].attributes.commit", is(expectedCommit))
             .body("data[0].attributes.kafkaClusterId", is(expectedKafkaId))
@@ -271,7 +272,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString(("default/" + expectedName).getBytes())))
+            .body("data[0].id", is(Base64.getUrlEncoder().withoutPadding().encodeToString(("default/" + expectedName).getBytes())))
             .body("data[0].relationships.connectors.data.size()", is(2))
             .body("included.size()", is(2));
     }
@@ -289,7 +290,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString(("default/" + expectedName).getBytes())))
+            .body("data[0].id", is(Base64.getUrlEncoder().withoutPadding().encodeToString(("default/" + expectedName).getBytes())))
             .body("data[0].relationships.connectors.data.size()", is(2))
             .body("included", anyOf(nullValue(), hasSize(0))); // included is either missing or empty
     }
@@ -309,7 +310,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString(("default/" + expectedName).getBytes())))
+            .body("data[0].id", is(Base64.getUrlEncoder().withoutPadding().encodeToString(("default/" + expectedName).getBytes())))
             .body("included.size()", is(5)) // 2 connectors + 3 tasks
             .body("included.findAll { it.type == 'connectors' }.size()", is(2))
             .body("included.findAll { it.type == 'connectors' }.relationships.tasks.data", containsInAnyOrder(hasSize(1), hasSize(2)))
@@ -334,7 +335,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data[0].id", is(Base64.getUrlEncoder().encodeToString(("default/" + expectedName).getBytes())))
+            .body("data[0].id", is(Base64.getUrlEncoder().withoutPadding().encodeToString(("default/" + expectedName).getBytes())))
             .body("included.size()", is(2)) // 2 connectors + no tasks
             .body("included.type", everyItem(is("connectors")))
             .body("included.relationships.tasks.data", containsInAnyOrder(hasSize(1), hasSize(2)))
@@ -347,7 +348,7 @@ class KafkaConnectsResourceIT implements ClientRequestFilter {
         "default/test-connect2, default/test-kafka2",
     })
     void testDescribeConnectCluster(String connectClusterKey, String kafkaClusterKey) {
-        String connectClusterID = Base64.getUrlEncoder().encodeToString(connectClusterKey.getBytes());
+        String connectClusterID = Base64.getUrlEncoder().withoutPadding().encodeToString(connectClusterKey.getBytes());
         // Tests that the connectorTasks relationships are returned, but the resources themselves are not included
         whenRequesting(req -> req
                 .param("fields[connects]", "name,kafkaClusters")

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -92,6 +92,7 @@ import com.github.streamshub.console.config.security.ResourceTypes;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.deployment.DeploymentManager;
 import com.github.streamshub.console.kafka.systemtest.utils.ConsumerUtils;
+import com.github.streamshub.console.support.Identifiers;
 import com.github.streamshub.console.test.AdminClientSpy;
 import com.github.streamshub.console.test.LogCapture;
 import com.github.streamshub.console.test.TestHelper;
@@ -808,7 +809,9 @@ class TopicsResourceIT {
         String topic2 = "t2-" + UUID.randomUUID().toString();
 
         String group1 = "g1-" + UUID.randomUUID().toString();
+        String group1Id = Identifiers.encode(group1);
         String group2 = "g2-" + UUID.randomUUID().toString();
+        String group2Id = Identifiers.encode(group2);
 
         String client1 = "c1-" + UUID.randomUUID().toString();
         String client2 = "c2-" + UUID.randomUUID().toString();
@@ -824,11 +827,11 @@ class TopicsResourceIT {
                 .body("data.find { it.attributes.name == '%s' }.relationships.consumerGroups.data[0]".formatted(topic1),
                     allOf(
                         hasEntry(equalTo("type"), equalTo("consumerGroups")),
-                        hasEntry(equalTo("id"), equalTo(group1))))
+                        hasEntry(equalTo("id"), equalTo(group1Id))))
                 .body("data.find { it.attributes.name == '%s' }.relationships.consumerGroups.data[0]".formatted(topic2),
                     allOf(
                         hasEntry(equalTo("type"), equalTo("consumerGroups")),
-                        hasEntry(equalTo("id"), equalTo(group2))));
+                        hasEntry(equalTo("id"), equalTo(group2Id))));
         }
     }
 
@@ -2291,7 +2294,9 @@ class TopicsResourceIT {
         String topic1Id = topicUtils.createTopics(List.of(topic1), 2).get(topic1);
 
         String group1 = "g1-" + UUID.randomUUID().toString();
+        String group1Id = Identifiers.encode(group1);
         String group2 = "g2-" + UUID.randomUUID().toString();
+        String group2Id = Identifiers.encode(group2);
 
         String client1 = "c1-" + UUID.randomUUID().toString();
         String client2 = "c2-" + UUID.randomUUID().toString();
@@ -2306,13 +2311,14 @@ class TopicsResourceIT {
                 .body("data.size()", is(1))
                 .body("data[0].relationships.consumerGroups.data.size()", is(2))
                 .body("data[0].relationships.consumerGroups.data.type", contains("consumerGroups", "consumerGroups"))
-                .body("data[0].relationships.consumerGroups.data.id", containsInAnyOrder(group1, group2));
+                .body("data[0].relationships.consumerGroups.data.id", containsInAnyOrder(group1Id, group2Id));
 
             whenRequesting(req -> req.get("{topicId}/consumerGroups", clusterId1, topic1Id))
                 .assertThat()
                 .statusCode(is(Status.OK.getStatusCode()))
                 .body("data.size()", is(2))
-                .body("data.id", containsInAnyOrder(group1, group2));
+                .body("data.id", containsInAnyOrder(group1Id, group2Id))
+                .body("data.attributes.groupId", containsInAnyOrder(group1, group2));
         }
     }
 

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceOidcIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceOidcIT.java
@@ -36,6 +36,7 @@ import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.deployment.DeploymentManager;
 import com.github.streamshub.console.kafka.systemtest.utils.ConsumerUtils;
 import com.github.streamshub.console.kafka.systemtest.utils.TokenUtils;
+import com.github.streamshub.console.support.Identifiers;
 import com.github.streamshub.console.test.LogCapture;
 import com.github.streamshub.console.test.TestHelper;
 import com.github.streamshub.console.test.TopicHelper;
@@ -228,11 +229,11 @@ class TopicsResourceOidcIT {
 
         if ("a".equals(team)) {
             allowedTopic = topicA;
-            allowedGroup = groupA;
+            allowedGroup = Identifiers.encode(groupA);
             forbiddenTopic = topicB;
         } else {
             allowedTopic = topicB;
-            allowedGroup = groupB;
+            allowedGroup = Identifiers.encode(groupB);
             forbiddenTopic = topicA;
         }
 

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -1,6 +1,5 @@
 package com.github.streamshub.console.config;
 
-import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -13,14 +12,13 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.github.streamshub.console.config.security.KafkaSecurityConfig;
 import com.github.streamshub.console.config.security.ResourceTypes;
 import com.github.streamshub.console.config.security.ResourceTypes.ValidResourceTypes;
+import com.github.streamshub.console.support.Identifiers;
 
 import io.sundr.builder.annotations.Buildable;
 
 @JsonInclude(Include.NON_NULL)
 @Buildable(editableEnabled = false)
 public class KafkaClusterConfig implements Named {
-
-    private static final Base64.Encoder ID_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     private String id;
     @NotBlank(message = "Kafka cluster `name` is required")
@@ -51,7 +49,7 @@ public class KafkaClusterConfig implements Named {
 
     @JsonIgnore
     public String clusterKeyEncoded() {
-        return ID_ENCODER.encodeToString(clusterKey().getBytes());
+        return Identifiers.encode(clusterKey());
     }
 
     @JsonIgnore

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaConnectConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaConnectConfig.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.github.streamshub.console.config.authentication.Authenticated;
 import com.github.streamshub.console.config.authentication.AuthenticationConfig;
+import com.github.streamshub.console.support.Identifiers;
 
 import io.sundr.builder.annotations.Buildable;
 
@@ -50,7 +51,7 @@ public class KafkaConnectConfig implements Authenticated, Trustable {
 
     @JsonIgnore
     public String clusterKeyEncoded() {
-        return ID_ENCODER.encodeToString(clusterKey().getBytes());
+        return Identifiers.encode(clusterKey());
     }
 
     @JsonIgnore

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaConnectConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaConnectConfig.java
@@ -1,7 +1,6 @@
 package com.github.streamshub.console.config;
 
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 import jakarta.validation.Valid;
@@ -14,15 +13,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.github.streamshub.console.config.authentication.Authenticated;
 import com.github.streamshub.console.config.authentication.AuthenticationConfig;
-import com.github.streamshub.console.support.Identifiers;
 
 import io.sundr.builder.annotations.Buildable;
 
 @JsonInclude(Include.NON_NULL)
 @Buildable(editableEnabled = false)
 public class KafkaConnectConfig implements Authenticated, Trustable {
-
-    private static final Base64.Encoder ID_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     @NotBlank(message = "Kafka Connect `name` is required")
     private String name;
@@ -47,11 +43,6 @@ public class KafkaConnectConfig implements Authenticated, Trustable {
     @JsonIgnore
     public String clusterKey() {
         return hasNamespace() ? "%s/%s".formatted(namespace, name) : name;
-    }
-
-    @JsonIgnore
-    public String clusterKeyEncoded() {
-        return Identifiers.encode(clusterKey());
     }
 
     @JsonIgnore

--- a/common/src/main/java/com/github/streamshub/console/config/security/ResourceTypes.java
+++ b/common/src/main/java/com/github/streamshub/console/config/security/ResourceTypes.java
@@ -90,6 +90,15 @@ public class ResourceTypes {
         public String value() {
             return value;
         }
+
+        public static Kafka fromValue(String value) {
+            for (Kafka v : values()) {
+                if (v.value.equals(value)) {
+                    return v;
+                }
+            }
+            throw new IllegalArgumentException("Unknown Kafka resource value: " + value);
+        }
     }
 
     @Target(ElementType.FIELD)

--- a/common/src/main/java/com/github/streamshub/console/config/security/ResourceTypes.java
+++ b/common/src/main/java/com/github/streamshub/console/config/security/ResourceTypes.java
@@ -90,15 +90,6 @@ public class ResourceTypes {
         public String value() {
             return value;
         }
-
-        public static Kafka fromValue(String value) {
-            for (Kafka v : values()) {
-                if (v.value.equals(value)) {
-                    return v;
-                }
-            }
-            throw new IllegalArgumentException("Unknown Kafka resource value: " + value);
-        }
     }
 
     @Target(ElementType.FIELD)

--- a/common/src/main/java/com/github/streamshub/console/support/Identifiers.java
+++ b/common/src/main/java/com/github/streamshub/console/support/Identifiers.java
@@ -1,0 +1,43 @@
+package com.github.streamshub.console.support;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public final class Identifiers {
+
+    public static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+    public static final Base64.Decoder DECODER = Base64.getUrlDecoder();
+
+    private Identifiers() {
+    }
+
+    public static String encode(String value) {
+        return encode("", value);
+    }
+
+    /**
+     * id values must be URL-safe, so we encode the unknown/variable values of object
+     * names from Kafka Connect and.
+     */
+    public static String encode(String base, String... values) {
+        StringBuilder encoded = new StringBuilder(base);
+        for (String v : values) {
+            if (!encoded.isEmpty()) {
+                encoded.append(',');
+            }
+            encoded.append(ENCODER.encodeToString(v.getBytes(StandardCharsets.UTF_8)));
+        }
+        return encoded.toString();
+    }
+
+    public static String[] decode(String value) {
+        List<String> decoded = new ArrayList<>();
+        for (String v : value.split(Pattern.quote(","))) {
+            decoded.add(new String(DECODER.decode(v), StandardCharsets.UTF_8));
+        }
+        return decoded.toArray(String[]::new);
+    }
+}

--- a/ui/api/consumerGroups/actions.ts
+++ b/ui/api/consumerGroups/actions.ts
@@ -42,7 +42,7 @@ export async function getConsumerGroups(
   const sp = new URLSearchParams(
     filterUndefinedFromObj({
       "fields[consumerGroups]":
-        params.fields ?? "state,simpleConsumerGroup,members,offsets",
+        params.fields ?? "groupId,state,simpleConsumerGroup,members,offsets",
       "filter[id]": filterLike(params.id),
       "filter[state]": filterIn(params.consumerGroupState),
       "page[size]": params.pageSize,
@@ -74,7 +74,7 @@ export async function getTopicConsumerGroups(
   const sp = new URLSearchParams(
     filterUndefinedFromObj({
       "fields[consumerGroups]":
-        "state,simpleConsumerGroup,members,offsets,coordinator,partitionAssignor",
+        "groupId,state,simpleConsumerGroup,members,offsets,coordinator,partitionAssignor",
       "page[size]": params.pageSize,
       "page[after]": params.pageCursor,
       sort: sortParam(params.sort, params.sortDir),

--- a/ui/api/consumerGroups/schema.ts
+++ b/ui/api/consumerGroups/schema.ts
@@ -44,6 +44,7 @@ export const ConsumerGroupSchema = z.object({
   id: z.string(),
   type: z.literal("consumerGroups"),
   attributes: z.object({
+    groupId: z.string(),
     simpleConsumerGroup: z.boolean().optional(),
     state: ConsumerGroupStateSchema,
     members: z.array(MemberDescriptionSchema).nullable().optional(),

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/page.tsx
@@ -1,20 +1,31 @@
+import { getConsumerGroup } from "@/api/consumerGroups/actions";
 import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
 import { BreadcrumbLink } from "@/components/Navigation/BreadcrumbLink";
 import RichText from "@/components/RichText";
+import { NoDataErrorState } from "@/components/NoDataErrorState";
+
 import {
   Breadcrumb,
   BreadcrumbItem,
   Tooltip,
 } from "@/libs/patternfly/react-core";
 import { HomeIcon } from "@/libs/patternfly/react-icons";
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
-export default function ConsumerGroupsActiveBreadcrumb({
+export default async function ConsumerGroupsActiveBreadcrumb({
   params: { groupId, kafkaId },
 }: {
   params: KafkaConsumerGroupMembersParams;
 }) {
-  const t = useTranslations();
+  const t = await getTranslations();
+  const consumerGroup = (await getConsumerGroup(kafkaId, groupId));
+
+  if (consumerGroup.errors) {
+    return <NoDataErrorState errors={consumerGroup.errors} />;
+  }
+
+  const groupIdDisplay = consumerGroup.payload?.attributes.groupId!;
+
   return (
     <Breadcrumb>
       <BreadcrumbItem key="home" to="/" showDivider>
@@ -37,10 +48,10 @@ export default function ConsumerGroupsActiveBreadcrumb({
         {t("breadcrumbs.consumer_groups")}
       </BreadcrumbLink>
       <BreadcrumbItem key={"cgm"} showDivider={true} isActive={true}>
-        {decodeURIComponent(groupId) === "+" ? (
+        {groupIdDisplay === "" ? (
           <RichText>{(tags) => t.rich("common.empty_name", tags)}</RichText>
         ) : (
-          groupId
+          groupIdDisplay
         )}
       </BreadcrumbItem>
     </Breadcrumb>

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/reset-offset/dryrun/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/reset-offset/dryrun/page.tsx
@@ -1,19 +1,30 @@
+import { getConsumerGroup } from "@/api/consumerGroups/actions";
 import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
 import { BreadcrumbLink } from "@/components/Navigation/BreadcrumbLink";
+import RichText from "@/components/RichText";
+import { NoDataErrorState } from "@/components/NoDataErrorState";
+
 import {
   Breadcrumb,
   BreadcrumbItem,
   Tooltip,
 } from "@/libs/patternfly/react-core";
 import { HomeIcon } from "@/libs/patternfly/react-icons";
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
-export default function DryrunActiveBreadcrumb({
+export default async function DryrunActiveBreadcrumb({
   params: { groupId, kafkaId },
 }: {
   params: KafkaConsumerGroupMembersParams;
 }) {
-  const t = useTranslations();
+  const t = await getTranslations();
+  const consumerGroup = (await getConsumerGroup(kafkaId, groupId));
+
+  if (consumerGroup.errors) {
+    return <NoDataErrorState errors={consumerGroup.errors} />;
+  }
+
+  const groupIdDisplay = consumerGroup.payload?.attributes.groupId!;
 
   return (
     <Breadcrumb>
@@ -29,6 +40,22 @@ export default function DryrunActiveBreadcrumb({
       >
         {t("breadcrumbs.overview")}
       </BreadcrumbItem>
+
+      <BreadcrumbLink
+        key={"cg"}
+        href={`/kafka/${kafkaId}/consumer-groups`}
+        showDivider={true}
+      >
+        {t("breadcrumbs.consumer_groups")}
+      </BreadcrumbLink>
+      <BreadcrumbItem key={"cgm"} showDivider={true} isActive={true}>
+        {groupIdDisplay === "" ? (
+          <RichText>{(tags) => t.rich("common.empty_name", tags)}</RichText>
+        ) : (
+          groupIdDisplay
+        )}
+      </BreadcrumbItem>
+
       <BreadcrumbLink
         key={"cg"}
         href={`/kafka/${kafkaId}/consumer-groups/${groupId}/reset-offset`}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@activeBreadcrumb/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -1,20 +1,31 @@
+import { getConsumerGroup } from "@/api/consumerGroups/actions";
 import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
 import { BreadcrumbLink } from "@/components/Navigation/BreadcrumbLink";
 import RichText from "@/components/RichText";
+import { NoDataErrorState } from "@/components/NoDataErrorState";
+
 import {
   Breadcrumb,
   BreadcrumbItem,
   Tooltip,
 } from "@/libs/patternfly/react-core";
 import { HomeIcon } from "@/libs/patternfly/react-icons";
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
-export default function ConsumerGroupsActiveBreadcrumb({
+export default async function ConsumerGroupsActiveBreadcrumb({
   params: { groupId, kafkaId },
 }: {
   params: KafkaConsumerGroupMembersParams;
 }) {
-  const t = useTranslations();
+  const t = await getTranslations();
+  const consumerGroup = (await getConsumerGroup(kafkaId, groupId));
+
+  if (consumerGroup.errors) {
+    return <NoDataErrorState errors={consumerGroup.errors} />;
+  }
+
+  const groupIdDisplay = consumerGroup.payload?.attributes.groupId!;
+
   return (
     <Breadcrumb>
       <BreadcrumbItem key="home" to="/" showDivider>
@@ -37,10 +48,10 @@ export default function ConsumerGroupsActiveBreadcrumb({
         {t("breadcrumbs.consumer_groups")}
       </BreadcrumbLink>
       <BreadcrumbItem key={"cgm"} showDivider={true} isActive={true}>
-        {decodeURIComponent(groupId) === "+" ? (
+        {groupIdDisplay === "" ? (
           <RichText>{(tags) => t.rich("common.empty_name", tags)}</RichText>
         ) : (
-          groupId
+          groupIdDisplay
         )}
       </BreadcrumbItem>
     </Breadcrumb>

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/ConsumerGroupActionButton.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/ConsumerGroupActionButton.tsx
@@ -7,18 +7,18 @@ import { useRouter } from "next/navigation";
 export function ConsumerGroupActionButton({
   disabled,
   kafkaId,
-  consumerGroupName,
+  groupId,
 }: {
   disabled: boolean;
   kafkaId: string;
-  consumerGroupName: string;
+  groupId: string;
 }) {
   const t = useTranslations();
   const router = useRouter();
 
   const onClickResetOffset = () => {
     router.push(
-      `/kafka/${kafkaId}/consumer-groups/${consumerGroupName}/reset-offset`,
+      `/kafka/${kafkaId}/consumer-groups/${groupId}/reset-offset`,
     );
   };
 

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/reset-offset/dryrun/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/reset-offset/dryrun/page.tsx
@@ -17,7 +17,7 @@ export default function Page({
   searchParams: { data?: string };
 }) {
   return (
-    <Suspense fallback={<Header params={{ kafkaId, groupId }} offsets={[]} />}>
+    <Suspense fallback={<Header groupIdDisplay={""} offsets={[]} />}>
       <ConnectedAppHeader
         params={{ kafkaId, groupId }}
         searchParams={searchParams}
@@ -87,17 +87,17 @@ async function ConnectedAppHeader({
       offset: o.offset,
     }),
   );
-  return <Header params={{ kafkaId, groupId }} offsets={offsets} />;
+  return <Header groupIdDisplay={res.attributes.groupId} offsets={offsets} />;
 }
 
 function Header({
-  params: { kafkaId, groupId },
+  groupIdDisplay,
   offsets,
 }: {
-  params: KafkaConsumerGroupMembersParams;
+  groupIdDisplay: string;
   offsets: Offset[];
 }) {
-  const t = useTranslations("ConsumerGroupsTable");
+  const t = useTranslations();
 
   return (
     <AppHeader
@@ -106,21 +106,21 @@ function Header({
           <FlexItem>
             <Content>
               <Content>
-                <RichText>{(tags) => t.rich("dry_run_result", tags)}</RichText>
+                <RichText>{(tags) => t.rich("ConsumerGroupsTable.dry_run_result", tags)}</RichText>
               </Content>
             </Content>
           </FlexItem>
           <FlexItem>
-            <DryrunDownloadButton groupId={groupId} offsets={offsets} />
+            <DryrunDownloadButton groupId={groupIdDisplay} offsets={offsets} />
           </FlexItem>
         </Flex>
       }
       subTitle={
-        decodeURIComponent(groupId) === "+" ? (
+        groupIdDisplay === "" ? (
           <RichText>{(tags) => t.rich("common.empty_name", tags)}</RichText>
         ) : (
           <RichText>
-            {(tags) => t.rich("consumer_name", { ...tags, groupId })}
+            {(tags) => t.rich("ConsumerGroupsTable.consumer_name", { ...tags, groupId: groupIdDisplay })}
           </RichText>
         )
       }

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/@header/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -1,3 +1,4 @@
+import { getConsumerGroup } from "@/api/consumerGroups/actions";
 import { KafkaConsumerGroupMembersParams } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/KafkaConsumerGroupMembers.params";
 import { AppHeader } from "@/components/AppHeader";
 import { Suspense } from "react";
@@ -10,7 +11,7 @@ export default function Page({
   params: KafkaConsumerGroupMembersParams;
 }) {
   return (
-    <Suspense fallback={<Header params={{ kafkaId, groupId }} />}>
+    <Suspense fallback={<Header groupIdDisplay={""} />}>
       <ConnectedAppHeader params={{ kafkaId, groupId }} />
     </Suspense>
   );
@@ -21,25 +22,32 @@ async function ConnectedAppHeader({
 }: {
   params: KafkaConsumerGroupMembersParams;
 }) {
-  return <Header params={{ kafkaId, groupId }} />;
+  const consumerGroup = (await getConsumerGroup(kafkaId, groupId)).payload;
+  let groupIdDisplay = "";
+
+  if (consumerGroup) {
+    groupIdDisplay = consumerGroup.attributes.groupId;
+  }
+
+  return <Header groupIdDisplay={groupIdDisplay} />;
 }
 
 function Header({
-  params: { kafkaId, groupId },
+  groupIdDisplay,
 }: {
-  params: KafkaConsumerGroupMembersParams;
+  groupIdDisplay: string;
 }) {
-  const t = useTranslations("ConsumerGroupsTable");
+  const t = useTranslations();
 
   return (
     <AppHeader
-      title={t("reset_consumer_offset")}
+      title={t("ConsumerGroupsTable.reset_consumer_offset")}
       subTitle={
-        decodeURIComponent(groupId) === "+" ? (
+        groupIdDisplay === "" ? (
           <RichText>{(tags) => t.rich("common.empty_name", tags)}</RichText>
         ) : (
           <RichText>
-            {(tags) => t.rich("consumer_name", { ...tags, groupId })}
+            {(tags) => t.rich("ConsumerGroupsTable.consumer_name", { ...tags, groupId: groupIdDisplay })}
           </RichText>
         )
       }

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/ConnectedConsumerGroupTable.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/ConnectedConsumerGroupTable.tsx
@@ -90,7 +90,7 @@ export function ConnectedConsumerGroupTable({
   const [consumerGroupMembers, setConsumerGroupMembers] = useState<string[]>(
     [],
   );
-  const [consumerGroupName, setConsumerGroupName] = useState<string>("");
+  const [consumerGroupId, setConsumerGroupId] = useState<string>("");
 
   const closeResetOffsetModal = () => {
     setResetOffsetModalOpen(false);
@@ -177,7 +177,7 @@ export function ConnectedConsumerGroupTable({
               setConsumerGroupMembers(
                 row.attributes.members?.map((member) => member.memberId) || [],
               );
-              setConsumerGroupName(row.id);
+              setConsumerGroupId(row.id);
             } else if (row.attributes.state === "EMPTY") {
               router.push(`${baseurl}/${row.id}/reset-offset`);
             }
@@ -189,7 +189,7 @@ export function ConnectedConsumerGroupTable({
           members={consumerGroupMembers}
           isResetOffsetModalOpen={isResetOffsetModalOpen}
           onClickClose={closeResetOffsetModal}
-          consumerGroupName={consumerGroupName}
+          consumerGroupId={consumerGroupId}
           kafkaId={kafkaId}
         />
       )}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
@@ -175,14 +175,14 @@ export function ConsumerGroupsTable({
                 dataLabel={t("ConsumerGroupsTable.consumer_group_name")}
               >
                 <Link
-                  href={`/kafka/${kafkaId}/consumer-groups/${row.id === "" ? "+" : encodeURIComponent(row.id)}`}
+                  href={`/kafka/${kafkaId}/consumer-groups/${row.id}`}
                 >
-                  {row.id === "" ? (
+                  {row.attributes.groupId === "" ? (
                     <RichText>
                       {(tags) => t.rich("ConsumerGroupsTable.empty_name", tags)}
                     </RichText>
                   ) : (
-                    row.id
+                    row.attributes.groupId
                   )}
                 </Link>
               </Td>

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/ResetOffsetModal.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/ResetOffsetModal.tsx
@@ -20,13 +20,13 @@ export function ResetOffsetModal({
   isResetOffsetModalOpen,
   onClickClose,
   kafkaId,
-  consumerGroupName,
+  consumerGroupId,
 }: {
   members: string[];
   isResetOffsetModalOpen: boolean;
   onClickClose: () => void;
   kafkaId: string;
-  consumerGroupName: string;
+  consumerGroupId: string;
 }) {
   const t = useTranslations("ConsumerGroupsTable");
   const router = useRouter();
@@ -34,7 +34,7 @@ export function ResetOffsetModal({
   const refresh = () => {
     if (members.length === 0) {
       router.push(
-        `/kafka/${kafkaId}/consumer-groups/${consumerGroupName}/reset-offset`,
+        `/kafka/${kafkaId}/consumer-groups/${consumerGroupId}/reset-offset`,
       );
     }
   };

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/DryrunSelect.stories.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/DryrunSelect.stories.tsx
@@ -11,6 +11,6 @@ type Story = StoryObj<typeof DryrunSelect>;
 export const Default: Story = {
   args: {
     cliCommand:
-      "$kafka-consumer-groups --bootstrap-server localhost:9092 --group my-consumer-group --reset-offsets --topic mytopic --to-earliest --dry-run",
+      "$kafka-consumer-groups --bootstrap-server localhost:9092 --group 'my-consumer-group' --reset-offsets --topic mytopic --to-earliest --dry-run",
   },
 };

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.stories.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.stories.tsx
@@ -9,7 +9,6 @@ type Story = StoryObj<typeof ResetOffset>;
 
 export const Default: Story = {
   args: {
-    consumerGroupName: "console-consumer-01",
     topics: [
       { topicId: "123", topicName: "console_datagen_002-a" },
       { topicId: "456", topicName: "console_datagen_002-b" },
@@ -21,6 +20,6 @@ export const Default: Story = {
     selectOffset: "latest",
     isLoading: false,
     cliCommand:
-      "$ kafka-consumer-groups --bootstrap-server localhost:9092 --group my-consumer-group --reset-offsets --topic mytopic --to-earliest --dry-run",
+      "$ kafka-consumer-groups --bootstrap-server localhost:9092 --group 'my-consumer-group' --reset-offsets --topic mytopic --to-earliest --dry-run",
   },
 };

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/ResetOffset.tsx
@@ -59,7 +59,6 @@ export function ResetOffset({
   onOffsetSelect,
 }: {
   cliCommand: string;
-  consumerGroupName: string;
   topics: { topicId: string; topicName: string }[];
   partitions: number[];
   selectTopic: TopicSelection;

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -80,7 +80,7 @@ async function ConnectedResetOffset({
 
   return (
     <ResetConsumerOffset
-      consumerGroupName={consumerGroup.id}
+      consumerGroup={consumerGroup}
       topics={topicDetails}
       partitions={partitions}
       baseurl={`/kafka/${kafkaId}/consumer-groups`}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/consumer-groups/[groupId]/reset-offset/page.tsx
@@ -26,7 +26,14 @@ export default function ResetOffsetPage({
         fallback={
           <ResetConsumerOffset
             kafkaId={kafkaId}
-            consumerGroupName={groupId}
+            consumerGroup={{
+              id: groupId,
+              type: "consumerGroups",
+              attributes: {
+                groupId: "-",
+                state: "UNKNOWN",
+              }
+            }}
             topics={[]}
             partitions={[]}
             baseurl={`/kafka/${kafkaId}/consumer-groups`}

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/overview/page.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/overview/page.tsx
@@ -24,7 +24,7 @@ export default async function OverviewPage({ params }: { params: KafkaParams }) 
   }).then(r => r.payload ?? null);
 
   const topics = getTopics(params.kafkaId, { fields: "status", pageSize: 1 });
-  const consumerGroups = getConsumerGroups(params.kafkaId, { fields: "state" });
+  const consumerGroups = getConsumerGroups(params.kafkaId, { fields: "groupId,state" });
   const viewedTopics = getViewedTopics().then((topics) =>
     topics.filter((t) => t.kafkaId === params.kafkaId),
   );

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/consumer-groups/ConsumerGroupsTable.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/topics/[topicId]/consumer-groups/ConsumerGroupsTable.tsx
@@ -125,14 +125,14 @@ export function ConsumerGroupsTable({
                 dataLabel={t("ConsumerGroupsTable.consumer_group_name")}
               >
                 <Link
-                  href={`/kafka/${kafkaId}/consumer-groups/${row.id === "" ? "+" : encodeURIComponent(row.id)}`}
+                  href={`/kafka/${kafkaId}/consumer-groups/${row.id}`}
                 >
-                  {row.id === "" ? (
+                  {row.attributes.groupId === "" ? (
                     <RichText>
                       {(tags) => t.rich("ConsumerGroupsTable.empty_name", tags)}
                     </RichText>
                   ) : (
-                    row.id
+                    row.attributes.groupId
                   )}
                 </Link>
               </Td>


### PR DESCRIPTION
Fixes #1891 

The consumer group ID is user-provided and may contain characters that are either not safe in URLs or that somehow conflict with Next.js. To account for that, this PR will instead use the base64-encoded group ID as the consumer group resource's `id`, placing the real group ID in a new `groupId` attribute. All knowledge about the encoding of the `id` is removed from the UI and the UI will now rely entirely on the new `groupId` in `attributes` for display and the `id` only for referencing in the API.