### PR TITLE
fix: use ISO format for all dates, limit UTC to message table

### DIFF
--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/rebalances/RebalanceTable.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/nodes/rebalances/RebalanceTable.tsx
@@ -269,9 +269,6 @@ export function RebalanceTable({
                       .map((c) => c.lastTransitionTime!)
                       .find(() => true) ?? row.attributes.creationTimestamp
                   }
-                  tz={"UTC"}
-                  dateStyle={"short"}
-                  timeStyle={"medium"}
                 />
               </Td>
             );

--- a/ui/components/AppHeader.tsx
+++ b/ui/components/AppHeader.tsx
@@ -47,12 +47,7 @@ export function AppHeader({
                 className={"pf-v6-u-font-size-sm"}
               >
                 Last updated{" "}
-                <DateTime
-                  value={lastRefresh}
-                  dateStyle={"short"}
-                  timeStyle={"medium"}
-                  tz={"local"}
-                />
+                <DateTime value={lastRefresh} />
                 <RefreshButton />
               </FlexItem>
             )}

--- a/ui/components/ClusterOverview/ClusterCard.tsx
+++ b/ui/components/ClusterOverview/ClusterCard.tsx
@@ -342,12 +342,7 @@ export function ClusterCard({
                                     width={1}
                                     className={"pf-v6-u-text-nowrap"}
                                   >
-                                    <DateTime
-                                      value={m.date}
-                                      tz={"UTC"}
-                                      dateStyle={"short"}
-                                      timeStyle={"short"}
-                                    />
+                                    <DateTime value={m.date} />
                                   </DataListCell>,
                                 ]}
                               />

--- a/ui/components/ClusterOverview/PageLayout.tsx
+++ b/ui/components/ClusterOverview/PageLayout.tsx
@@ -1,4 +1,3 @@
-import { DateTime } from "@/components/Format/DateTime";
 import {
   Flex,
   FlexItem,
@@ -6,7 +5,6 @@ import {
   GridItem,
   PageSection,
 } from "@/libs/patternfly/react-core";
-import { Link } from "@/i18n/routing";
 import { ReactNode, Suspense } from "react";
 import { ClusterCard } from "./ClusterCard";
 import { ClusterChartsCard } from "./ClusterChartsCard";

--- a/ui/components/ClusterOverview/components/ChartCpuUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartCpuUsage.tsx
@@ -13,6 +13,7 @@ import { Alert } from "@/libs/patternfly/react-core";
 import { useFormatter, useTranslations } from "next-intl";
 import { getHeight, getPadding } from "./chartConsts";
 import { useChartWidth } from "./useChartWidth";
+import { formatDateTime } from "@/utils/dateTime";
 
 type ChartCpuUsageProps = {
   usages: Record<string, TimeSeriesMetrics>;
@@ -69,13 +70,8 @@ export function ChartCpuUsage({ usages }: ChartCpuUsageProps) {
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(args) =>
-                  format.dateTime(args?.x ?? 0, {
-                    timeZone: "UTC",
-                    timeStyle: "medium",
-                    dateStyle: "short",
-                  })
-                }
+                flyoutWidth={250}
+                title={(args) => formatDateTime(args?.x ?? 0)}
               />
             }
             labels={({ datum }: { datum: Datum }) =>
@@ -100,16 +96,7 @@ export function ChartCpuUsage({ usages }: ChartCpuUsageProps) {
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => {
-            const [_, ...time] = format
-              .dateTime(d, {
-                dateStyle: "short",
-                timeStyle: "short",
-                timeZone: "UTC",
-              })
-              .split(" ");
-            return time.join(" ");
-          }}
+          tickFormat={(d) => formatDateTime(d, "HH:mm")}
           tickCount={5}
         />
         <ChartAxis

--- a/ui/components/ClusterOverview/components/ChartDiskUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartDiskUsage.tsx
@@ -15,6 +15,7 @@ import { Alert } from "@/libs/patternfly/react-core";
 import { useFormatter, useTranslations } from "next-intl";
 import { getHeight, getPadding } from "./chartConsts";
 import { useChartWidth } from "./useChartWidth";
+import { formatDateTime } from "@/utils/dateTime";
 
 type ChartDiskUsageProps = {
   usages: Record<string, TimeSeriesMetrics>;
@@ -76,13 +77,7 @@ export function ChartDiskUsage({ usages, available }: ChartDiskUsageProps) {
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(args) =>
-                  format.dateTime(args?.x ?? 0, {
-                    timeZone: "UTC",
-                    timeStyle: "medium",
-                    dateStyle: "short",
-                  })
-                }
+                title={(args) => formatDateTime(args?.x ?? 0)}
               />
             }
             labels={({ datum }: { datum: Datum }) =>
@@ -107,16 +102,7 @@ export function ChartDiskUsage({ usages, available }: ChartDiskUsageProps) {
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => {
-            const [_, ...time] = format
-              .dateTime(d, {
-                dateStyle: "short",
-                timeStyle: "short",
-                timeZone: "UTC",
-              })
-              .split(" ");
-            return time.join(" ");
-          }}
+          tickFormat={(d) => formatDateTime(d, "HH:mm")}
           tickCount={5}
         />
         <ChartAxis

--- a/ui/components/ClusterOverview/components/ChartIncomingOutgoing.tsx
+++ b/ui/components/ClusterOverview/components/ChartIncomingOutgoing.tsx
@@ -14,6 +14,7 @@ import { Alert } from "@/libs/patternfly/react-core";
 import { useFormatter, useTranslations } from "next-intl";
 import { getHeight, getPadding } from "./chartConsts";
 import { useChartWidth } from "./useChartWidth";
+import { formatDateTime } from "@/utils/dateTime";
 
 type ChartIncomingOutgoingProps = {
   incoming: TimeSeriesMetrics;
@@ -76,13 +77,7 @@ export function ChartIncomingOutgoing({
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(args) =>
-                  format.dateTime(args?.x ?? 0, {
-                    timeZone: "UTC",
-                    timeStyle: "medium",
-                    dateStyle: "short",
-                  })
-                }
+                title={(args) => formatDateTime(args?.x ?? 0)}
               />
             }
             labels={({ datum }: { datum: Datum }) => {
@@ -109,16 +104,7 @@ export function ChartIncomingOutgoing({
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => {
-            const [_, ...time] = format
-              .dateTime(d, {
-                dateStyle: "short",
-                timeStyle: "short",
-                timeZone: "UTC",
-              })
-              .split(" ");
-            return time.join(" ");
-          }}
+          tickFormat={(d) => formatDateTime(d, "HH:mm")}
           tickCount={4}
           orientation={"bottom"}
           offsetY={padding.bottom}

--- a/ui/components/ClusterOverview/components/ChartMemoryUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartMemoryUsage.tsx
@@ -14,6 +14,7 @@ import { Alert } from "@/libs/patternfly/react-core";
 import { useFormatter, useTranslations } from "next-intl";
 import { getHeight, getPadding } from "./chartConsts";
 import { useChartWidth } from "./useChartWidth";
+import { formatDateTime } from "@/utils/dateTime";
 
 type ChartDiskUsageProps = {
   usages: Record<string, TimeSeriesMetrics>;
@@ -64,13 +65,8 @@ export function ChartMemoryUsage({ usages }: ChartDiskUsageProps) {
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(args) =>
-                  format.dateTime(args?.x ?? 0, {
-                    timeZone: "UTC",
-                    timeStyle: "medium",
-                    dateStyle: "short",
-                  })
-                }
+                flyoutWidth={250}
+                title={(args) => formatDateTime(args?.x ?? 0)}
               />
             }
             labels={({ datum }: { datum: Datum }) =>
@@ -95,16 +91,7 @@ export function ChartMemoryUsage({ usages }: ChartDiskUsageProps) {
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => {
-            const [_, ...time] = format
-              .dateTime(d, {
-                dateStyle: "short",
-                timeStyle: "short",
-                timeZone: "UTC",
-              })
-              .split(" ");
-            return time.join(" ");
-          }}
+          tickFormat={(d) => formatDateTime(d, "HH:mm")}
           tickCount={5}
         />
         <ChartAxis

--- a/ui/components/Format/DateTime.stories.tsx
+++ b/ui/components/Format/DateTime.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/nextjs";
 import { expect, waitFor, within } from "storybook/test";
 import { DateTime } from "./DateTime";
 
+const ORIGINAL_ENV = process.env;
+
 const meta: Meta<typeof DateTime> = {
   component: DateTime,
   args: {
@@ -32,27 +34,41 @@ export const Default: Story = {};
 
 export const DateTimeStringUTC: Story = {
   args: {
-    value: "2025-04-01T12:00:00-04:00", // A static date value
+    value: "2025-04-01T00:00:00-07:00", // A static date value
     utc: true,
+  },
+  beforeEach: () => {
+    // UTC-7 for daylight / UTC-8 for standard
+    process.env = { ...ORIGINAL_ENV, TZ: "America/Los_Angeles" }
+  },
+  afterEach: () => {
+    process.env = ORIGINAL_ENV;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await waitFor(() => {
       // Check that the date was adjusted to UTC
-      expect(canvas.getByText("2025-04-01 16:00:00Z")).toBeInTheDocument();
+      expect(canvas.getByText("2025-04-01 07:00:00Z")).toBeInTheDocument();
     });
   },
 };
 
 export const DateTimeStringLocal: Story = {
   args: {
-    value: "2025-04-01T16:00:00Z", // A static date value
+    value: "2025-04-01T14:00:00Z", // A static date value
+  },
+  beforeEach: () => {
+    // UTC-4 for daylight / UTC-5 for standard
+    process.env = { ...ORIGINAL_ENV, TZ: "America/New_York" }
+  },
+  afterEach: () => {
+    process.env = ORIGINAL_ENV;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await waitFor(() => {
       // Check that the date was adjusted to UTC
-      expect(canvas.getByText("2025-04-01 12:00:00-04:00")).toBeInTheDocument();
+      expect(canvas.getByText("2025-04-01 10:00:00-04:00")).toBeInTheDocument();
     });
   },
 };

--- a/ui/components/Format/DateTime.stories.tsx
+++ b/ui/components/Format/DateTime.stories.tsx
@@ -6,7 +6,6 @@ const meta: Meta<typeof DateTime> = {
   component: DateTime,
   args: {
     value: new Date(Date.UTC(2024, 11, 31, 23, 59, 59, 999)).toISOString(),
-    tz: "local",
     empty: "-",
   },
   argTypes: {
@@ -14,20 +13,10 @@ const meta: Meta<typeof DateTime> = {
       control: "text",
       description: "The date value to be displayed",
     },
-    dateStyle: {
-      options: ["full", "long", "medium", "short"],
-      control: { type: "select" },
-      description: "Controls the date format",
-    },
-    timeStyle: {
-      options: ["full", "long", "medium", "short"],
-      control: { type: "select" },
-      description: "Controls the time format",
-    },
-    tz: {
-      options: ["UTC", "local"],
+    utc: {
+      options: [ true, false ],
       control: { type: "radio" },
-      description: "The timezone to be used",
+      description: "Whether UTC or local timezone is used for display",
     },
     empty: {
       control: "text",
@@ -41,53 +30,29 @@ type Story = StoryObj<typeof DateTime>;
 
 export const Default: Story = {};
 
-export const FullDateLongTime: Story = {
+export const DateTimeStringUTC: Story = {
   args: {
-    dateStyle: "full",
-    timeStyle: "long",
-  },
-};
-
-export const MediumDateShortTime: Story = {
-  args: {
-    dateStyle: "medium",
-    timeStyle: "short",
-  },
-};
-
-export const ShortDateMediumTime: Story = {
-  args: {
-    dateStyle: "short",
-    timeStyle: "medium",
-  },
-};
-
-export const LongDateFullTime: Story = {
-  args: {
-    dateStyle: "long",
-    timeStyle: "full",
-  },
-};
-
-export const DateTimeString: Story = {
-  args: {
-    value: "2023-04-01T12:00:00Z", // A static date value
-    dateStyle: "full",
-    timeStyle: "long",
+    value: "2025-04-01T12:00:00-04:00", // A static date value
+    utc: true,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await waitFor(() => {
-      // Check for parts of the date and time that are likely to appear regardless of the locale.
-      // This is a more flexible approach that can accommodate different locales and time zones.
-      const expectedDateParts = ["2023", "April", "1"];
-      expectedDateParts.forEach((part) => {
-        expect(canvas.getByText(new RegExp(part, "i"))).toBeInTheDocument();
-      });
+      // Check that the date was adjusted to UTC
+      expect(canvas.getByText("2025-04-01 16:00:00Z")).toBeInTheDocument();
+    });
+  },
+};
 
-      // This looks for a pattern like "12:00" without specifying AM/PM or 24-hour format,
-      // which might vary by locale.
-      expect(canvas.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument();
+export const DateTimeStringLocal: Story = {
+  args: {
+    value: "2025-04-01T16:00:00Z", // A static date value
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      // Check that the date was adjusted to UTC
+      expect(canvas.getByText("2025-04-01 12:00:00-04:00")).toBeInTheDocument();
     });
   },
 };

--- a/ui/components/Format/DateTime.stories.tsx
+++ b/ui/components/Format/DateTime.stories.tsx
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from "@storybook/nextjs";
 import { expect, waitFor, within } from "storybook/test";
 import { DateTime } from "./DateTime";
 
-const ORIGINAL_ENV = process.env;
-
 const meta: Meta<typeof DateTime> = {
   component: DateTime,
   args: {
@@ -32,17 +30,11 @@ type Story = StoryObj<typeof DateTime>;
 
 export const Default: Story = {};
 
+// Tests assume the process is running with TZ='America/Los_Angeles'
 export const DateTimeStringUTC: Story = {
   args: {
     value: "2025-04-01T00:00:00-07:00", // A static date value
     utc: true,
-  },
-  beforeEach: () => {
-    // UTC-7 for daylight / UTC-8 for standard
-    process.env = { ...ORIGINAL_ENV, TZ: "America/Los_Angeles" }
-  },
-  afterEach: () => {
-    process.env = ORIGINAL_ENV;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -55,20 +47,13 @@ export const DateTimeStringUTC: Story = {
 
 export const DateTimeStringLocal: Story = {
   args: {
-    value: "2025-04-01T14:00:00Z", // A static date value
-  },
-  beforeEach: () => {
-    // UTC-4 for daylight / UTC-5 for standard
-    process.env = { ...ORIGINAL_ENV, TZ: "America/New_York" }
-  },
-  afterEach: () => {
-    process.env = ORIGINAL_ENV;
+    value: "2025-04-01T07:00:00Z", // A static date value
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await waitFor(() => {
       // Check that the date was adjusted to UTC
-      expect(canvas.getByText("2025-04-01 10:00:00-04:00")).toBeInTheDocument();
+      expect(canvas.getByText("2025-04-01 00:00:00-07:00")).toBeInTheDocument();
     });
   },
 };

--- a/ui/components/Format/DateTime.tsx
+++ b/ui/components/Format/DateTime.tsx
@@ -1,36 +1,41 @@
+"use client";
+
+import { formatDateTime } from "@/utils/dateTime";
 import { isDate, parseISO } from "date-fns";
-import { useFormatter } from "next-intl";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
+
+const FORMAT = "yyyy-MM-dd HH:mm:ssXXX";
 
 export function DateTime({
   value,
-  dateStyle = "long",
-  timeStyle = "long",
-  tz = "local",
+  utc = false,
   empty = "-",
 }: {
-  value: string | Date | undefined;
-  dateStyle?: "full" | "long" | "medium" | "short";
-  timeStyle?: "full" | "long" | "medium" | "short";
-  tz?: "UTC" | "local";
-  empty?: ReactNode;
+  readonly value: string | Date | undefined;
+  readonly utc?: boolean;
+  readonly empty?: ReactNode;
 }) {
-  const format = useFormatter();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    // Do not return any result unless mounted (i.e., running client side)
+    return null;
+  }
+
   if (!value) {
     return empty;
   }
-  const maybeDate = typeof value === "string" ? parseISO(value) : value;
-  if (!isDate(maybeDate)) {
+
+  const dateValue = typeof value === "string" ? parseISO(value) : value;
+
+  if (!isDate(dateValue)) {
     return empty;
   }
-  const formattedDt = format.dateTime(maybeDate, {
-    dateStyle,
-    timeStyle,
-    timeZone: tz === "local" ? undefined : "UTC",
-  });
+
   return (
-    <time dateTime={maybeDate.toISOString()} suppressHydrationWarning={true}>
-      {formattedDt}
+    <time dateTime={dateValue.toISOString()}>
+      {formatDateTime(value, FORMAT, utc)}
     </time>
   );
 }

--- a/ui/components/MessagesTable/MessagesTable.tsx
+++ b/ui/components/MessagesTable/MessagesTable.tsx
@@ -245,22 +245,13 @@ export function MessagesTable({
                       case "timestamp":
                         return (
                           <Cell>
-                            <DateTime
-                              value={row.attributes.timestamp}
-                              dateStyle={"short"}
-                              timeStyle={"medium"}
-                            />
+                            <DateTime value={row.attributes.timestamp} />
                           </Cell>
                         );
                       case "timestampUTC":
                         return (
                           <Cell>
-                            <DateTime
-                              value={row.attributes.timestamp}
-                              dateStyle={"short"}
-                              timeStyle={"medium"}
-                              tz={"UTC"}
-                            />
+                            <DateTime value={row.attributes.timestamp} utc={true} />
                           </Cell>
                         );
                       case "key":
@@ -394,11 +385,7 @@ export function MessagesTable({
               className={"pf-v6-u-px-md pf-v6-u-py-sm"}
             >
               Last updated:{" "}
-              <DateTime
-                value={lastUpdated}
-                timeStyle={"medium"}
-                dateStyle={"short"}
-              />
+              <DateTime value={lastUpdated} />
             </Content>
           </Content>
         </DrawerContent>

--- a/ui/components/MessagesTable/components/ColumnsModal.tsx
+++ b/ui/components/MessagesTable/components/ColumnsModal.tsx
@@ -1,11 +1,12 @@
-import { Button, Modal } from "@/libs/patternfly/react-core";
 import {
+  Button,
   Content,
   DataList,
   DataListCell,
   DataListCheck,
   DataListControl,
   DataListItemCells,
+  Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -27,14 +28,13 @@ export type Column = (typeof columns)[number];
 
 export function useColumnLabels() {
   const t = useTranslations();
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const columnLabels: Record<Column, string> = {
     key: t("useColumnLabels.key"),
     headers: t("useColumnLabels.headers"),
     "offset-partition": t("useColumnLabels.offset-partition"),
     value: t("useColumnLabels.value"),
     size: t("useColumnLabels.size"),
-    timestamp: t("useColumnLabels.timestamp", { timeZone }),
+    timestamp: t("useColumnLabels.timestamp"),
     timestampUTC: t("useColumnLabels.timestampUTC"),
   };
   return columnLabels;

--- a/ui/components/MessagesTable/components/MessageDetails.tsx
+++ b/ui/components/MessagesTable/components/MessageDetails.tsx
@@ -161,8 +161,8 @@ export function MessageDetailsBody({
             <DescriptionListDescription>
               <DateTime
                 value={message.attributes.timestamp}
+                utc={true}
                 empty={<NoData />}
-                tz={"UTC"}
               />
             </DescriptionListDescription>
           </DescriptionListGroup>

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -427,7 +427,7 @@
     "offset-partition": "Offset",
     "value": "Value",
     "size": "Size",
-    "timestamp": "Timestamp ({timeZone})",
+    "timestamp": "Timestamp (local)",
     "timestampUTC": "Timestamp (UTC)"
   },
   "ConfigTable": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test-storybook": "test-storybook",
+    "test-storybook": "TZ='America/Los_Angeles' test-storybook",
     "test": "npx playwright test --config ./tests/playwright/playwright.config.ts"
   },
   "dependencies": {

--- a/ui/utils/dateTime.ts
+++ b/ui/utils/dateTime.ts
@@ -1,0 +1,16 @@
+import { format as formatDate } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+
+const FORMAT = "yyyy-MM-dd HH:mm:ssXXX";
+
+export function formatDateTime(value: number | string | Date | undefined, format: string = FORMAT, utc?: boolean) {
+  if (value === undefined) {
+    return "-";
+  }
+
+  if (utc) {
+    return formatInTimeZone(value, "UTC", format);
+  } else {
+    return formatDate(value, format);
+  }
+}


### PR DESCRIPTION
Currently, the console displays dates in a few different ways:
- User's local time zone in US format (MM/dd/yy)
- UTC time zone in US format (MM/dd/yy)
- UTC time zone in ISO format

The PR standardizes all dates to ISO format and display most dates in the user's time zone. The exception is that the topic message table has the option to display the date/time in UTC.