### PR TITLE
fix: correct Storybook test failure by parameterizing time zone

### DIFF
--- a/ui/components/ClusterOverview/components/ChartCpuUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartCpuUsage.tsx
@@ -71,7 +71,7 @@ export function ChartCpuUsage({ usages }: ChartCpuUsageProps) {
               <ChartLegendTooltip
                 legendData={legendData}
                 flyoutWidth={250}
-                title={(args) => formatDateTime(args?.x ?? 0)}
+                title={(args) => formatDateTime({ value: args?.x ?? 0})}
               />
             }
             labels={({ datum }: { datum: Datum }) =>
@@ -96,7 +96,7 @@ export function ChartCpuUsage({ usages }: ChartCpuUsageProps) {
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => formatDateTime(d, "HH:mm")}
+          tickFormat={(d) => formatDateTime({ value: d, format: "HH:mm" })}
           tickCount={5}
         />
         <ChartAxis

--- a/ui/components/ClusterOverview/components/ChartDiskUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartDiskUsage.tsx
@@ -77,7 +77,7 @@ export function ChartDiskUsage({ usages, available }: ChartDiskUsageProps) {
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(args) => formatDateTime(args?.x ?? 0)}
+                title={(args) => formatDateTime({ value: args?.x ?? 0 })}
               />
             }
             labels={({ datum }: { datum: Datum }) =>
@@ -102,7 +102,7 @@ export function ChartDiskUsage({ usages, available }: ChartDiskUsageProps) {
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => formatDateTime(d, "HH:mm")}
+          tickFormat={(d) => formatDateTime({ value: d, format: "HH:mm" })}
           tickCount={5}
         />
         <ChartAxis

--- a/ui/components/ClusterOverview/components/ChartIncomingOutgoing.tsx
+++ b/ui/components/ClusterOverview/components/ChartIncomingOutgoing.tsx
@@ -77,7 +77,7 @@ export function ChartIncomingOutgoing({
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(args) => formatDateTime(args?.x ?? 0)}
+                title={(args) => formatDateTime({ value: args?.x ?? 0 })}
               />
             }
             labels={({ datum }: { datum: Datum }) => {
@@ -104,7 +104,7 @@ export function ChartIncomingOutgoing({
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => formatDateTime(d, "HH:mm")}
+          tickFormat={(d) => formatDateTime({ value: d, format: "HH:mm" })}
           tickCount={4}
           orientation={"bottom"}
           offsetY={padding.bottom}

--- a/ui/components/ClusterOverview/components/ChartMemoryUsage.tsx
+++ b/ui/components/ClusterOverview/components/ChartMemoryUsage.tsx
@@ -66,7 +66,7 @@ export function ChartMemoryUsage({ usages }: ChartDiskUsageProps) {
               <ChartLegendTooltip
                 legendData={legendData}
                 flyoutWidth={250}
-                title={(args) => formatDateTime(args?.x ?? 0)}
+                title={(args) => formatDateTime({ value: args?.x ?? 0 })}
               />
             }
             labels={({ datum }: { datum: Datum }) =>
@@ -91,7 +91,7 @@ export function ChartMemoryUsage({ usages }: ChartDiskUsageProps) {
       >
         <ChartAxis
           scale={"time"}
-          tickFormat={(d) => formatDateTime(d, "HH:mm")}
+          tickFormat={(d) => formatDateTime({ value: d, format: "HH:mm" })}
           tickCount={5}
         />
         <ChartAxis

--- a/ui/components/Format/DateTime.stories.tsx
+++ b/ui/components/Format/DateTime.stories.tsx
@@ -13,10 +13,9 @@ const meta: Meta<typeof DateTime> = {
       control: "text",
       description: "The date value to be displayed",
     },
-    utc: {
-      options: [ true, false ],
-      control: { type: "radio" },
-      description: "Whether UTC or local timezone is used for display",
+    timeZone: {
+      control: "text",
+      description: "Timezone used for display",
     },
     empty: {
       control: "text",
@@ -34,7 +33,7 @@ export const Default: Story = {};
 export const DateTimeStringUTC: Story = {
   args: {
     value: "2025-04-01T00:00:00-07:00", // A static date value
-    utc: true,
+    timeZone: "UTC",
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -48,6 +47,7 @@ export const DateTimeStringUTC: Story = {
 export const DateTimeStringLocal: Story = {
   args: {
     value: "2025-04-01T07:00:00Z", // A static date value
+    timeZone: "US/Pacific",
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/ui/components/Format/DateTime.tsx
+++ b/ui/components/Format/DateTime.tsx
@@ -4,15 +4,13 @@ import { formatDateTime } from "@/utils/dateTime";
 import { isDate, parseISO } from "date-fns";
 import { ReactNode, useEffect, useState } from "react";
 
-const FORMAT = "yyyy-MM-dd HH:mm:ssXXX";
-
 export function DateTime({
   value,
-  utc = false,
+  timeZone,
   empty = "-",
 }: {
   readonly value: string | Date | undefined;
-  readonly utc?: boolean;
+  readonly timeZone?: string;
   readonly empty?: ReactNode;
 }) {
   const [mounted, setMounted] = useState(false);
@@ -35,7 +33,7 @@ export function DateTime({
 
   return (
     <time dateTime={dateValue.toISOString()}>
-      {formatDateTime(value, FORMAT, utc)}
+      {formatDateTime({ value, timeZone })}
     </time>
   );
 }

--- a/ui/components/MessagesTable/MessagesTable.tsx
+++ b/ui/components/MessagesTable/MessagesTable.tsx
@@ -251,7 +251,7 @@ export function MessagesTable({
                       case "timestampUTC":
                         return (
                           <Cell>
-                            <DateTime value={row.attributes.timestamp} utc={true} />
+                            <DateTime value={row.attributes.timestamp} timeZone="UTC" />
                           </Cell>
                         );
                       case "key":

--- a/ui/components/MessagesTable/components/MessageDetails.tsx
+++ b/ui/components/MessagesTable/components/MessageDetails.tsx
@@ -161,7 +161,7 @@ export function MessageDetailsBody({
             <DescriptionListDescription>
               <DateTime
                 value={message.attributes.timestamp}
-                utc={true}
+                timeZone="UTC"
                 empty={<NoData />}
               />
             </DescriptionListDescription>

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test-storybook": "TZ='America/Los_Angeles' test-storybook",
+    "test-storybook": "test-storybook",
     "test": "npx playwright test --config ./tests/playwright/playwright.config.ts"
   },
   "dependencies": {
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
+    "@storybook/addon-docs": "^9.1.3",
     "@storybook/addon-links": "^9.1.3",
     "@storybook/nextjs": "^9.1.3",
     "@storybook/test-runner": "^0.23.0",
@@ -67,8 +68,7 @@
     "playwright": "^1.45.2",
     "prettier": "^3.6.2",
     "storybook": "^9.0.16",
-    "tsconfig-paths-webpack-plugin": "^4.2.0",
-    "@storybook/addon-docs": "^9.1.3"
+    "tsconfig-paths-webpack-plugin": "^4.2.0"
   },
   "overrides": {
     "eslint-plugin-storybook": {

--- a/ui/utils/dateTime.ts
+++ b/ui/utils/dateTime.ts
@@ -1,16 +1,19 @@
-import { format as formatDate } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 
-const FORMAT = "yyyy-MM-dd HH:mm:ssXXX";
-
-export function formatDateTime(value: number | string | Date | undefined, format: string = FORMAT, utc?: boolean) {
+export function formatDateTime({
+  value,
+  timeZone,
+  format = "yyyy-MM-dd HH:mm:ssXXX",
+} : {
+  value: number | string | Date | undefined,
+  timeZone?: string,
+  format?: string,
+}) {
   if (value === undefined) {
     return "-";
   }
 
-  if (utc) {
-    return formatInTimeZone(value, "UTC", format);
-  } else {
-    return formatDate(value, format);
-  }
+  timeZone ??= Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  return formatInTimeZone(value, timeZone, format);
 }


### PR DESCRIPTION
PR #1900 relies on the browser's time zone when not using UTC. This results in unpredictable results in the Storybook test running in CI where the system's zone may not be known. That PR attempted to solve it by setting the `TZ` environment variable on the storybook test script, but it failed after merging to `main` when running the test deployed to Chromatic.

This update will instead allow for a timezone to be provided to the `DateTime` component and `formatDateTime` function, allowing the storybook test to provide it and giving determinate results.