### PR TITLE
Disable log warnings about unstable custom resources in prod profile

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -51,6 +51,9 @@ quarkus.log.category."org.apache.kafka".level=ERROR
 # Apicurio cache logger is noisy for "not found" scenarios. We log the error
 # in our own handler instead.
 quarkus.log.category."io.apicurio.registry.resolver.ERCache".level=OFF
+# The console is known to use "unstable" custom resource versions. Warnings in
+# the logs are not useful in production
+%prod.quarkus.log.category."io.fabric8.kubernetes.client.dsl.internal.VersionUsageUtils".level=ERROR
 
 %build.quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
 %build.quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -22,6 +22,10 @@ quarkus.kubernetes.env.fields."CONSOLE_DEPLOYMENT_DEFAULT_IMAGE_TAG"=metadata.la
 quarkus.vertx.caching=false
 quarkus.vertx.classpath-resolving=false
 
+# The console is known to use "unstable" custom resource versions. Warnings in
+# the logs are not useful in production
+%prod.quarkus.log.category."io.fabric8.kubernetes.client.dsl.internal.VersionUsageUtils".level=ERROR
+
 %build.quarkus.container-image.labels."org.opencontainers.image.version"=${quarkus.application.version}
 %build.quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revision}
 


### PR DESCRIPTION
Suppress warnings about unstable CR versions. We use these versions intentionally and there is no need to log warnings in prod mode.

```
2025-09-11 10:45:12,464 WARN [io.fab.kub.cli.dsl.int.VersionUsageUtils] (InformerWrapper [consoles.console.streamshub.github.com/v1alpha1] 34) The client is using resource type 'consoles' with unstable version 'v1alpha1'
...
2025-09-11 10:45:13,448 WARN [io.fab.kub.cli.dsl.int.VersionUsageUtils] (pool-13-thread-1) The client is using resource type 'kafkas' with unstable version 'v1beta2'
2025-09-11 10:45:13,582 WARN [io.fab.kub.cli.dsl.int.VersionUsageUtils] (pool-13-thread-1) The client is using resource type 'kafkausers' with unstable version 'v1beta2'
```