### PR TITLE
[GHA] Add changes

### DIFF
--- a/.github/actions/systemtests/common.sh
+++ b/.github/actions/systemtests/common.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Returns empty edit mode if the last bot comment is the help message
+getEditModeOrSkipIfLastCommentIsHelp() {
+  local marker="ℹ️ Systemtests Help ℹ️"
+  local comment_author=$(gh api user --jq '.login')
+
+  local last_body=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+    --json comments \
+    --jq '.comments
+          | map(select(.author.login=="'"$comment_author"'"))
+          | sort_by(.updatedAt)
+          | last
+          | .body // empty')
+
+  if [[ -n $last_body && $last_body != *"$marker"* ]]; then
+    echo "--edit-last"
+  else
+    echo ""
+  fi
+}

--- a/.github/actions/systemtests/parse-results-update-pr.sh
+++ b/.github/actions/systemtests/parse-results-update-pr.sh
@@ -3,6 +3,9 @@ set -xeuo pipefail
 
 # Get directory of this script, regardless of where it was called from
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
+
+source $SCRIPT_DIR/common.sh
+
 ROOT_DIR="$SCRIPT_DIR/../../.."
 RESULT_DIR=${1:-"$ROOT_DIR/systemtests/target/failsafe-reports"}
 RESULT_MD=${2:-"$ROOT_DIR/test-results.md"}
@@ -129,5 +132,7 @@ echo "Results file $(cat $RESULT_MD)"
 # Set status check of the PR
 gh api repos/$REPO/statuses/$COMMIT_SHA -f state="$STATE" -f context="System Tests" -f description="$DESCRIPTION" -f target_url="$RUN_URL"
 
-# Comment PR with results markdown
-gh pr comment $PR_NUMBER --repo $REPO  --edit-last --create-if-none --body-file $RESULT_MD
+# Comment PR with results markdown - do not edit help comment
+COMMENT_MODE=$(getEditModeOrSkipIfLastCommentIsHelp)
+echo "Comment mode: $COMMENT_MODE"
+gh pr comment $PR_NUMBER --repo $REPO $COMMENT_MODE --body-file $RESULT_MD

--- a/.github/actions/systemtests/pr-help.sh
+++ b/.github/actions/systemtests/pr-help.sh
@@ -19,7 +19,7 @@ You can run system tests with the following parameters:
 * `--help`: Show this help message
 
 Note: Use either `--testcase` or `--profile` to select tests to run, setting both will result in
-github actions prioretizing testcase over profile. If neither is provided, no systemtest will start.
+github actions prioritizing testcase over profile. If neither is provided, no systemtest will start.
 
 ### Example usage:
 ```bash
@@ -30,7 +30,6 @@ MESSAGE
 
 # Comment help
 gh pr comment $PR_NUMBER --repo $REPO --body-file $HELP_MD
-
 
 echo "Stop further workflow execution. Exiting workflow"
 gh run cancel $RUN_ID --repo $REPO

--- a/.github/actions/systemtests/update-pr-systemtests-started.sh
+++ b/.github/actions/systemtests/update-pr-systemtests-started.sh
@@ -3,6 +3,9 @@ set -xeuo pipefail
 
 # Get directory of this script
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+source $SCRIPT_DIR/common.sh
+
 ROOT_DIR="$SCRIPT_DIR/../../.."
 PARAMS_MD=${1:-"$ROOT_DIR/params.md"}
 
@@ -24,5 +27,7 @@ PARAMS
 gh api repos/$REPO/statuses/$COMMIT_SHA \
   -f state="pending" -f context="System Tests" -f description="System tests are running..." -f target_url="$RUN_URL"
 
-# Update PR comment
-gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file "$PARAMS_MD"
+# Update PR comment - do not edit help comment
+COMMENT_MODE=$(getEditModeOrSkipIfLastCommentIsHelp)
+echo "Comment mode: $COMMENT_MODE"
+gh pr comment $PR_NUMBER --repo $REPO $COMMENT_MODE --body-file $PARAMS_MD

--- a/.github/workflows/pre-systemtest.yml
+++ b/.github/workflows/pre-systemtest.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Invoke workflow in another repo with inputs
         uses: benc-uk/workflow-dispatch@v1
         with:
-          token: ${{ secrets.GH_FULL_ORG_TOKEN }}
+          token: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
           workflow: systemtests.yml
           inputs: >
             {

--- a/.github/workflows/pre-systemtest.yml
+++ b/.github/workflows/pre-systemtest.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./.github/actions/systemtests/parse-pr-comment-params.sh
 
       - name: Invoke workflow in another repo with inputs
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc
         with:
           token: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
           workflow: systemtests.yml

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -32,7 +32,7 @@ jobs:
     env:
       RUN_URL: ${{ github.run_url }}
       COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
       REPO: ${{ github.repository }}
       TEST_CASE: ${{ github.event.inputs.testcase }}
       PROFILE: ${{ github.event.inputs.profile }}

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Download Images
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
         with:
           github_token: ${{ env.GH_TOKEN }}
           workflow: integration.yml


### PR DESCRIPTION
In order to have streamshub-bot comment all the messages related to systemtests actions it's necessary to use either the previous token or create a new one with comment permissions. This PR also fixes HELP comment being replaced by other comments like build started or cannot trigger systemtests, this makes it hard for user to see the help messages. `getEditModeOrSkipIfLastCommentIsHelp` solves this issue by looking at it's last bot comment and returning --edit-last flag if it's not a systemtests help comment.