### PR TITLE
Update node version used by frontend-maven-plugin to match container

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -23,7 +23,7 @@
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>1.15.1</version>
                     <configuration>
-                        <nodeVersion>v18.20.4</nodeVersion>
+                        <nodeVersion>v22.19.0</nodeVersion>
                         <installDirectory>${project.build.directory}</installDirectory>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This should have been included in #1751 