### PR TITLE
[0.6.x] build(deps): bump quarkus.platform.version from 3.15.6 to 3.15.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- Dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.15.6</quarkus.platform.version>
+        <quarkus.platform.version>3.15.7</quarkus.platform.version>
         <strimzi-api.version>0.45.1</strimzi-api.version>
         <strimzi-oauth.version>0.15.1</strimzi-oauth.version>
         <apicurio-registry.version>2.6.13.Final</apicurio-registry.version>


### PR DESCRIPTION
Release notes: https://github.com/quarkusio/quarkus/releases/tag/3.15.7