### PR TITLE
Fix: use consistent Kafka ID in API response, show Kafka name in navbar

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
@@ -164,8 +164,12 @@ public class KafkaClusterService {
                 clusterResult.authorizedOperations().toCompletionStage().toCompletableFuture(),
                 clusterResult.clusterId().toCompletionStage().toCompletableFuture(),
                 quorumResult)
-            .thenApply(nothing -> new KafkaCluster(get(clusterResult::clusterId), enumNames(get(clusterResult::authorizedOperations))))
-            .thenComposeAsync(cluster -> addNodes(cluster, clusterResult, quorumResult), threadContext.currentContextExecutor())
+            .thenApplyAsync(
+                    nothing -> new KafkaCluster(kafkaContext.clusterId(), enumNames(get(clusterResult::authorizedOperations))),
+                    threadContext.currentContextExecutor())
+            .thenComposeAsync(
+                    cluster -> addNodes(cluster, clusterResult, quorumResult),
+                    threadContext.currentContextExecutor())
             .thenApplyAsync(this::addKafkaContextData, threadContext.currentContextExecutor())
             .thenApply(this::addKafkaResourceData)
             .thenCompose(cluster -> addMetrics(cluster, fields))

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/ClusterLinks.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/ClusterLinks.tsx
@@ -1,18 +1,20 @@
-import { getKafkaCluster } from "@/api/kafka/actions";
+import { ClusterDetail } from "@/api/kafka/schema";
 import { NavItemLink } from "@/components/Navigation/NavItemLink";
 import { NavGroup, NavList } from "@/libs/patternfly/react-core";
 import { useTranslations } from "next-intl";
 import { Suspense } from "react";
 
-export function ClusterLinks({ kafkaId }: { kafkaId: string }) {
+export function ClusterLinks({ kafkaDetail }: { kafkaDetail: ClusterDetail }) {
   const t = useTranslations();
+  const kafkaId = kafkaDetail.id;
+
   return (
     <NavList>
       <NavGroup
         title={
           (
             <Suspense>
-              <ClusterName kafkaId={kafkaId} />
+              <ClusterName kafkaName={kafkaDetail.attributes.name} />
             </Suspense>
           ) as unknown as string
         }
@@ -42,7 +44,6 @@ export function ClusterLinks({ kafkaId }: { kafkaId: string }) {
   );
 }
 
-async function ClusterName({ kafkaId }: { kafkaId: string }) {
-  const cluster = (await getKafkaCluster(kafkaId))?.payload;
-  return cluster?.attributes.name ?? `Cluster ${kafkaId}`;
+function ClusterName({ kafkaName }: { kafkaName: string }) {
+  return `Cluster ${kafkaName}`;
 }

--- a/ui/app/[locale]/(authorized)/kafka/[kafkaId]/layout.tsx
+++ b/ui/app/[locale]/(authorized)/kafka/[kafkaId]/layout.tsx
@@ -104,7 +104,7 @@ function Layout({
         username={username}
         kafkaDetail={kafkaDetail}
         metadata={metadata}
-        sidebar={<ClusterLinks kafkaId={kafkaDetail.id} />}
+        sidebar={<ClusterLinks kafkaDetail={kafkaDetail} />}
         clusterInfoList={clusterInfoList}
         isOidcEnabled={isOidcEnabled}
       >


### PR DESCRIPTION
There is currently a difference in how the Kafka `id` is set between a list fetch and a single Kafka fetch. In a single fetch, we use the Kafka cluster Id reported by Kafka itself, which may disagree from the identifier established in the API server at startup. This would be the case for connections without a Strimzi Kafka CR where we do not know the cluster's Id ahead of time and it is derived from the namespace + name. This PR fixes this discordance and will use the API server's cluster Id always.

Additionally, the UI displays the Kafka ID in the side navbar whereas it should be the name. This is corrected as well.