### PR TITLE
[GHA] Enable running STs in parallel

### DIFF
--- a/.github/actions/systemtests/generate-test-matrix.sh
+++ b/.github/actions/systemtests/generate-test-matrix.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Use env variables (set in workflow)
+TESTCASE="${TESTCASE:-}"
+PROFILE="${PROFILE:-}"
+
+# --- CASE 1: specific testcase provided ---
+if [[ -n "$TESTCASE" ]]; then
+  echo "Single testcase detected: $TESTCASE"
+  echo "matrix={\"include\":[{\"testcase\":\"$TESTCASE\",\"profile\":\"$PROFILE\"}]}" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# --- CASE 2: specific profile provided ---
+echo "No specific testcase provided, generating matrix..."
+FILES=$(find systemtests/src/test/java -type f -name '*ST.java' ! -name 'AbstractST.java')
+
+MATRIX="["
+SEP=""
+for f in $FILES; do
+  NAME=$(basename "$f" .java)
+  if [[ -n "$PROFILE" ]]; then
+    MATRIX+="${SEP}{\"testcase\":\"$NAME\",\"profile\":\"$PROFILE\"}"
+  else
+    MATRIX+="${SEP}{\"testcase\":\"$NAME\"}"
+  fi
+  SEP=","
+done
+MATRIX+="]"
+
+echo "Matrix: $MATRIX"
+echo "matrix={\"include\":$MATRIX}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/systemtests/parse-pr-comment-params.sh
+++ b/.github/actions/systemtests/parse-pr-comment-params.sh
@@ -23,12 +23,12 @@ if [[ ! "$retry_count" =~ ^[0-9]+$ ]]; then
 fi
 
 # Export as step outputs
-echo "testcase=$testcase" >> $GITHUB_OUTPUT
-echo "profile=$profile" >> $GITHUB_OUTPUT
-echo "env_str=$env_str" >> $GITHUB_OUTPUT
-echo "install_type=$install_type" >> $GITHUB_OUTPUT
-echo "retry_count=$retry_count" >> $GITHUB_OUTPUT
+echo "TESTCASE=$testcase" >> $GITHUB_ENV
+echo "PROFILE=$profile" >> $GITHUB_ENV
+echo "ENVS=$env_str" >> $GITHUB_ENV
+echo "INSTALL_TYPE=$install_type" >> $GITHUB_ENV
+echo "RETRY_COUNT=$retry_count" >> $GITHUB_ENV
 
 # Export current PR branch latest commit sha
 commit_sha=$(gh pr view $PR_NUMBER --json headRefOid -q '.headRefOid')
-echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
+echo "COMMIT_SHA=$commit_sha" >> $GITHUB_ENV

--- a/.github/actions/systemtests/update-pr-systemtests-started.sh
+++ b/.github/actions/systemtests/update-pr-systemtests-started.sh
@@ -25,7 +25,7 @@ PARAMS
 
 # Set status check
 gh api repos/$REPO/statuses/$COMMIT_SHA \
-  -f state="pending" -f context="System Tests" -f description="System tests are running..." -f target_url="$RUN_URL"
+  -f state="pending" -f context="System Tests" -f description="System tests are running..."
 
 # Update PR comment
 deleteLastStatusComment

--- a/.github/workflows/pre-systemtest.yml
+++ b/.github/workflows/pre-systemtest.yml
@@ -37,6 +37,9 @@ jobs:
         id: parse_env
         run: ./.github/actions/systemtests/parse-pr-comment-params.sh
 
+      - name: Comment start of the build
+        run: ./.github/actions/systemtests/update-pr-systemtests-started.sh
+
       - name: Invoke workflow in another repo with inputs
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc
         with:
@@ -44,10 +47,10 @@ jobs:
           workflow: systemtests.yml
           inputs: >
             {
-              "commit_sha": "${{ steps.parse_env.outputs.commit_sha }}",
-              "testcase": "${{ steps.parse_env.outputs.testcase }}",
-              "profile": "${{ steps.parse_env.outputs.profile }}",
-              "install_type": "${{ steps.parse_env.outputs.install_type }}",
-              "retry_count": "${{ steps.parse_env.outputs.retry_count }}",
-              "env_str": "${{ steps.parse_env.outputs.env_str }}"
+              "commit_sha": "${{ env.COMMIT_SHA }}",
+              "testcase": "${{ env.TESTCASE }}",
+              "profile": "${{ env.PROFILE }}",
+              "install_type": "${{ env.INSTALL_TYPE }}",
+              "retry_count": "${{ env.RETRY_COUNT }}",
+              "envs": "${{ env.ENVS }}"
             }

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -18,24 +18,60 @@ on:
       retry_count:
         description: 'Retry count to use'
         required: false
-      env_str:
+      envs:
         description: 'Envs to use for tests'
         required: false
 
 jobs:
-  run-systemtests:
+  generate-matrix:
     permissions:
       contents: read
       statuses: write
       pull-requests: write
     runs-on: ubuntu-24.04
     env:
-      RUN_URL: ${{ github.run_url }}
+      GH_TOKEN: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
+      REPO: ${{ github.repository }}
+      COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+      TESTCASE: ${{ github.event.inputs.testcase }}
+      PROFILE: ${{ github.event.inputs.profile }}
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.COMMIT_SHA }}
+
+      - name: Get previously built artifacts
+        run: |
+          ARTIFACTS_RUN_ID=$(gh run list --repo $REPO --commit $COMMIT_SHA --workflow integration.yml --status success --json databaseId --jq '.[0].databaseId')
+          echo "ARTIFACTS_RUN_ID=$ARTIFACTS_RUN_ID" >> $GITHUB_ENV
+
+      - name: Generate ST matrix
+        id: generate-matrix
+        run: ./.github/actions/systemtests/generate-test-matrix.sh
+
+
+  # Run single or matrix of ST jobs
+  run-systemtests:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+      max-parallel: 2
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    env:
+      # Need to use MATRIX TEST_CASE instead of the testcase from trigger job
+      TEST_CASE: ${{ matrix.testcase }}
+      PROFILE: ${{ matrix.profile }}
       COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
       GH_TOKEN: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
       REPO: ${{ github.repository }}
-      TEST_CASE: ${{ github.event.inputs.testcase }}
-      PROFILE: ${{ github.event.inputs.profile }}
       INSTALL_TYPE: ${{ github.event.inputs.install_type }}
       RETRY_COUNT: ${{ github.event.inputs.retry_count }}
       ENVS: ${{ github.event.inputs.env_str }}
@@ -48,18 +84,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ env.COMMIT_SHA }}
-
-      - name: Get the commit details
-        run: |
-          ARTIFACTS_RUN_ID=$(gh run list --repo $REPO --commit $COMMIT_SHA --workflow integration.yml --status success --status success --json databaseId --jq '.[0].databaseId')
-          PR_NUMBER=$(gh pr list --repo $REPO --state open --search $COMMIT_SHA --json number,createdAt -q "sort_by(.createdAt) | .[-1] | .number")
-        
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          echo "ARTIFACTS_RUN_ID=$ARTIFACTS_RUN_ID" >> $GITHUB_ENV
-
-      - name: Comment the build
-        run: ./.github/actions/systemtests/update-pr-systemtests-started.sh
-
       - name: Download Images
         id: download-artifact
         uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
@@ -113,10 +137,10 @@ jobs:
         if: ${{ env.INSTALL_TYPE == 'olm' }}
         run: |
           set -x
-          
+
           echo "CONSOLE_OLM_CATALOG_SOURCE_NAME=streamshub-console-catalog" >> $GITHUB_ENV
           echo "CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE=$OLM_MINIKUBE_NAMESPACE" >> $GITHUB_ENV
-          
+
           # Create the CatalogSource with the Console operator bundle
           yq ea '.spec.image = "localhost:5000/streamshub/console-operator-catalog:${{ env.PROJECT_VERSION }}"' \
             ./install/operator/olm/010-CatalogSource-console-operator-catalog.yaml \
@@ -155,13 +179,45 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: systemtests-artifacts
+          name: systemtests-artifacts-${{ matrix.testcase }}${{ matrix.profile && format('-{0}', matrix.profile) || '' }}
           if-no-files-found: warn
           path: |
             systemtests/target/**/TEST-*.xml
             systemtests/target/logs/**
             systemtests/screenshot/**
             systemtests/tracing/**
+
+  aggregate-results:
+    needs: run-systemtests
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    # Ensure this job runs even if tests failed
+    if: always()
+    env:
+      COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+      GH_TOKEN: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
+      REPO: ${{ github.repository }}
+      TEST_CASE: ${{ github.event.inputs.testcase }}
+      PROFILE: ${{ github.event.inputs.profile }}
+      INSTALL_TYPE: ${{ github.event.inputs.install_type }}
+      RETRY_COUNT: ${{ github.event.inputs.retry_count }}
+      ENVS: ${{ github.event.inputs.env_str }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download all systemtest artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: systemtests-artifacts-*
+          merge-multiple: true
+          path: ./all-systemtest-artifacts
+
+      - name: Get current PR number
+        run: |
+          PR_NUMBER=$(gh pr list --repo $REPO --state open --search $COMMIT_SHA --json number,createdAt -q "sort_by(.createdAt) | .[-1] | .number")
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
       - name: Parse results and update PR status
         if: always()


### PR DESCRIPTION
This PR introduces a new github workflow with a dynamic matrix generation and result scraping. With this PR tests are now executed in parallel with fixed 2 workers (seemed like a reasonable number per PR) - this should avoid errors on default github job timeout if a test fails and is executed again. It also allows for a bit faster execution since github default resources are not unlimited and maxed out minikube setup is a bit slower than openshift clusters when it comes to creating and waiting for resources. 

#### Execution: 

To run STs on a PR - a `console-developers` member uses either a `--profile` or specifies a `--test-case`. 

When using `profile` option, all of the systemtest files ending with `ST.java` are scraped (AbstractST is utility class and is ignored by the generator). Then for each of the files - maven command is executed with the selected profile. 

For `test-case` a single job is executed with maven `-Dit.test` option with provided test-case value.

### Key changes

* Added a generate-matrix job to dynamically detect and build a test matrix based on available *ST.java files.

* Updated system test execution to run each test class as a separate matrix job, improving parallelization and isolation.

* Modified PR results scraping — the workflow now merges XML reports, parses test outcomes, and updates PR status accordingly.


## Preview of the workflow
<img width="1138" height="780" alt="image" src="https://github.com/user-attachments/assets/5c15cb29-d485-4bab-b4d6-c7fdb0840895" />
