### PR TITLE
Revert "build(deps): bump @patternfly/react-styles (#2057)"

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,7 @@
         "@patternfly/react-core": "^6.1.0",
         "@patternfly/react-drag-drop": "^6.1.0",
         "@patternfly/react-icons": "^6.1.0",
-        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-styles": "^6.3.1",
         "@patternfly/react-table": "^6.1.0",
         "@patternfly/react-tokens": "^6.1.0",
         "@patternfly/react-user-feedback": "^6.0.0",
@@ -3663,9 +3663,9 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.4.0.tgz",
-      "integrity": "sha512-EXmHA67s5sy+Wy/0uxWoUQ52jr9lsH2wV3QcgtvVc5zxpyBX89gShpqv4jfVqaowznHGDoL6fVBBrSe9BYOliQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.3.1.tgz",
+      "integrity": "sha512-hyb+PlO8YITjKh2wBvjdeZhX6FyB3hlf4r6yG4rPOHk4SgneXHjNSdGwQ3szAxgGqtbENCYtOqwD/8ai72GrxQ==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "@patternfly/react-core": "^6.1.0",
     "@patternfly/react-drag-drop": "^6.1.0",
     "@patternfly/react-icons": "^6.1.0",
-    "@patternfly/react-styles": "^6.4.0",
+    "@patternfly/react-styles": "^6.3.1",
     "@patternfly/react-table": "^6.1.0",
     "@patternfly/react-tokens": "^6.1.0",
     "@patternfly/react-user-feedback": "^6.0.0",


### PR DESCRIPTION
This reverts commit ccd07a40a15b6a9a63503301ed6d759d41006b3d.

The update breaks the padding around content panels, as seen below.
<img width="542" height="352" alt="image" src="https://github.com/user-attachments/assets/e54b28ad-5581-46f0-aae7-bc59c9bfad22" />

They should appear like this:
<img width="341" height="256" alt="image" src="https://github.com/user-attachments/assets/0c39e734-120e-45ca-a0e9-681dbbe640a7" />
