### PR TITLE
[GHA] Include profile parameter

### DIFF
--- a/.github/actions/systemtests/prepare-systemtests-env.sh
+++ b/.github/actions/systemtests/prepare-systemtests-env.sh
@@ -14,7 +14,9 @@ PARAMETERS="-Dfailsafe.rerunFailingTestsCount=${RETRY_COUNT}"
 
 if [[ -n "$TEST_CASE" ]]; then
   PARAMETERS="$PARAMETERS -Dit.test=${TEST_CASE} -DskipSTs=false"
-elif [[ -n "$PROFILE" ]]; then
+fi
+
+if [[ -n "$PROFILE" ]]; then
   PARAMETERS="$PARAMETERS -P $PROFILE"
 fi
 


### PR DESCRIPTION
Profile was previously ignored due to testcase parameter being generated for every matrix, but it did not matter since there was only one test profile, with new profiles this will be an issue however. This PR makes a quick fix for it.