### PR TITLE
Filter out consumer group partitions for topics not visible to user

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/model/MemberDescription.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/MemberDescription.java
@@ -43,6 +43,11 @@ public class MemberDescription {
         result.assignments = description.assignment()
                 .topicPartitions()
                 .stream()
+                /*
+                 * Filter out assigned partitions not visible to the client
+                 * configured to connect to Kafka cluster.
+                 */
+                .filter(partition -> topicIds.containsKey(partition.topic()))
                 .map(partition -> new PartitionId(
                         topicIds.get(partition.topic()),
                         partition.topic(),


### PR DESCRIPTION
Prevents NullPointerException in the `PartitionId` constructor in the subsequent map step of the same stream.