### PR TITLE
test(playwright): handle empty states for consumer groups and consumer pages

### DIFF
--- a/ui/tests/playwright/ConsumerGroupsPage.test.tsx
+++ b/ui/tests/playwright/ConsumerGroupsPage.test.tsx
@@ -4,28 +4,37 @@ test.beforeEach(async ({ authenticatedPage }) => {
   await authenticatedPage.goToConsumerGroups();
 });
 
-test("Consumer groups page", async ({ page }) => {
-  await test.step("Consumer groups page should display table or empty state", async () => {
-    const tableRows = page.locator(
-      'table[aria-label="Consumer groups"] tbody tr'
-    );
-    const emptyState = page.getByText("No consumer groups");
+test("Consumer groups page: Check for Table or Empty State", async ({
+  page,
+}) => {
+  const emptyState = page.getByText("No consumer groups");
+  const tableHeader = page.getByRole("columnheader", {
+    name: "Consumer group name",
+  });
 
-    await Promise.race([
-      tableRows.first().waitFor({ state: "visible" }).catch(() => null),
-      emptyState.waitFor({ state: "visible" }).catch(() => null),
-    ]);
+  await test.step("Ensure either table or empty state is visible", async () => {
+    await expect(emptyState.or(tableHeader)).toBeVisible();
 
     if (await emptyState.isVisible()) {
       await expect(emptyState).toBeVisible();
-      return; 
+      console.log("Empty state detected: 'No consumer groups' is visible.");
+      return;
     }
+    console.log("Consumer groups table detected. Verifying headers and data.");
 
-    await expect(page.getByRole("columnheader", { name: "Consumer group name" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "State" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Overall lag" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Members" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Topics" })).toBeVisible();
+    await expect(tableHeader).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "State" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Overall lag" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Members" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Topics" }),
+    ).toBeVisible();
 
     const dataCells = await page
       .locator('table[aria-label="Consumer groups"] tbody tr td')

--- a/ui/tests/playwright/ConsumerPage.test.tsx
+++ b/ui/tests/playwright/ConsumerPage.test.tsx
@@ -4,57 +4,55 @@ test.beforeEach(async ({ authenticatedPage }) => {
   await authenticatedPage.goToConsumerGroups();
 });
 
-test("Consumer page", async ({ page, authenticatedPage }) => {
-  await test.step("Navigate to consumer page or show empty state", async () => {
-    const tableRows = page.locator(
-      'table[aria-label="Consumer groups"] tbody tr'
+test("Consumer page content check", async ({ page, authenticatedPage }) => {
+  const emptyStateMessage = page.getByText("No consumer groups");
+  const isNoGroupsVisible = await emptyStateMessage.isVisible();
+
+  if (isNoGroupsVisible) {
+    console.log(
+      "Empty state detected: 'No consumer groups' is visible. Skipping table checks.",
     );
-    const emptyState = page.getByText("No consumer groups");
+    await expect(emptyStateMessage).toBeVisible();
+  } else {
+    console.log(
+      "Consumer groups table expected. Proceeding with table content checks.",
+    );
 
-    // Wait for either a row OR empty state
-    await Promise.race([
-      tableRows.first().waitFor({ state: "visible" }).catch(() => null),
-      emptyState.waitFor({ state: "visible" }).catch(() => null)
-    ]);
+    await test.step("Navigate to consumer page", async () => {
+      await expect(
+        page.getByRole("columnheader", { name: "Consumer group name" }),
+      ).toBeVisible();
+      await authenticatedPage.clickFirstLinkInTheTable("Consumer groups");
+    });
 
-    // ----- EMPTY STATE -----
-    if (await emptyState.isVisible()) {
-      await expect(emptyState).toBeVisible();
-      test.skip(true, "No consumer groups exist, skipping navigation to consumer page");
-      return;
-    }
+    await test.step("Consumer page should display details table", async () => {
+      await expect(
+        page.getByRole("columnheader", { name: "Member ID" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: "Overall lag" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: "Assigned partitions" }),
+      ).toBeVisible();
 
-    // ----- TABLE EXISTS -----
-    await expect(page.getByRole("columnheader", { name: "Consumer group name" })).toBeVisible();
+      await page.getByRole("button", { name: "Details" }).click();
 
-    await authenticatedPage.clickFirstLinkInTheTable("Consumer groups");
-  });
-
-  await test.step("Consumer page should display table or empty state", async () => {
-    const memberRows = page.locator('table[aria-label="Consumer"] tbody tr');
-    const emptyState = page.getByText("No consumer");
-
-    await Promise.race([
-      memberRows.first().waitFor({ state: "visible" }).catch(() => null),
-      emptyState.waitFor({ state: "visible" }).catch(() => null)
-    ]);
-
-    // ----- EMPTY STATE -----
-    if (await emptyState.isVisible()) {
-      await expect(emptyState).toBeVisible();
-      return;
-    }
-
-    // ----- TABLE EXISTS -----
-    await expect(page.getByRole("columnheader", { name: "Member ID" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Overall lag" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Assigned partitions" })).toBeVisible();
-
-    await page.getByRole("button", { name: "Details" }).click();
-    await expect(page.getByRole("columnheader", { name: "Topic" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Partition", exact: true })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Lag", exact: true })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Committed offset" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "End offset" })).toBeVisible();
-  });
+      await expect(
+        page.getByRole("columnheader", { name: "Topic" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: "Partition", exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: "Lag", exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: "Committed offset" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: "End offset" }),
+      ).toBeVisible();
+    });
+  }
 });


### PR DESCRIPTION
test(playwright): handle empty states for consumer groups and consumer pages