### PR TITLE
[ST] Strimzi CRDs API v1

### DIFF
--- a/systemtests/src/main/java/com/github/streamshub/systemtests/constants/Constants.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/constants/Constants.java
@@ -3,6 +3,11 @@ package com.github.streamshub.systemtests.constants;
 public class Constants {
     public static final String NGINX_INGRESS_NAMESPACE = "ingress-nginx";
 
+    // As of now for strimzi operator 0.49.0, it is required to convert all resources to `apiVersion: v1`
+    // Best way is to hard-set this value when creating strimzi CRs to avoid long upgrading process described in:
+    // https://strimzi.io/docs/operators/0.49.0/deploying.html#proc-convert-custom-resources-cluster-str
+    public static final String STRIMZI_API_V1 = "v1";
+
     private Constants() {}
 
     // --------------------------------

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/setup/strimzi/KafkaSetup.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/setup/strimzi/KafkaSetup.java
@@ -109,6 +109,7 @@ public class KafkaSetup {
      */
     public static KafkaNodePool getDefaultBrokerNodePools(String namespaceName, String clusterName, int replicas) {
         return new KafkaNodePoolBuilder()
+            .withApiVersion(Constants.STRIMZI_API_V1)
             .withNewMetadata()
                 .withName(KafkaNamingUtils.brokerPoolName(clusterName))
                 .withNamespace(namespaceName)
@@ -141,6 +142,7 @@ public class KafkaSetup {
      */
     public static KafkaNodePool getDefaultControllerNodePools(String namespaceName, String clusterName, int replicas) {
         return new KafkaNodePoolBuilder()
+            .withApiVersion(Constants.STRIMZI_API_V1)
             .withNewMetadata()
                 .withName(KafkaNamingUtils.controllerPoolName(clusterName))
                 .withNamespace(namespaceName)
@@ -173,6 +175,7 @@ public class KafkaSetup {
      */
     public static KafkaUser getDefaultKafkaUser(String namespaceName, String clusterName) {
         return new KafkaUserBuilder()
+            .withApiVersion(Constants.STRIMZI_API_V1)
             .withNewMetadata()
                 .withName(KafkaNamingUtils.kafkaUserName(clusterName))
                 .withNamespace(namespaceName)
@@ -233,6 +236,7 @@ public class KafkaSetup {
         // This helps to avoid issues with same-name kafka in different namespace exposing the same hostname
         String hashedNamespace = Utils.hashStub(namespaceName);
         return new KafkaBuilder()
+            .withApiVersion(Constants.STRIMZI_API_V1)
             .editMetadata()
                 .withNamespace(namespaceName)
                 .withName(clusterName)

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/utils/resourceutils/KafkaTopicUtils.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/utils/resourceutils/KafkaTopicUtils.java
@@ -2,6 +2,7 @@ package com.github.streamshub.systemtests.utils.resourceutils;
 
 import com.github.streamshub.systemtests.clients.KafkaClients;
 import com.github.streamshub.systemtests.clients.KafkaClientsBuilder;
+import com.github.streamshub.systemtests.constants.Constants;
 import com.github.streamshub.systemtests.logs.LogWrapper;
 import com.github.streamshub.systemtests.utils.WaitUtils;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -197,6 +198,7 @@ public class KafkaTopicUtils {
 
     public static KafkaTopicBuilder defaultTopic(String topicNamespace, String clusterName, String topicName, int partitions, int replicas, int minIsr) {
         return new KafkaTopicBuilder()
+            .withApiVersion(Constants.STRIMZI_API_V1)
             .withNewMetadata()
                 .withName(topicName)
                 .withNamespace(topicNamespace)


### PR DESCRIPTION
Currently while running tests you may experience topic operator crashlooping (similar to https://github.com/orgs/strimzi/discussions/12173). This is because even though strimzi states parallel support for older api it does not account for kafkatopics and kafkausers - they are required to be v1 as described in (https://artifacthub.io/packages/helm/strimzi/strimzi-kafka-operator). 