### PR TITLE
Upgrade Java version from 17 to 21, use temurin throughout CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Fetch Operator Framework Utilities
         run: ./operator/bin/fetch-operator-utilities.sh
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Cache Maven Packages
         uses: actions/cache@v5
@@ -165,11 +165,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Cache Maven Packages
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Cache Maven Packages
         uses: actions/cache@v5

--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v5

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Build project

--- a/api/CONTRIBUTING.md
+++ b/api/CONTRIBUTING.md
@@ -11,7 +11,7 @@ One option to get started is to follow [Strimzi's Quick Starts](https://strimzi.
 
 You will also need a working installation of:
 
-- Java (v17)
+- Java (v21)
 - Maven (v3.8)
 
 ### Coding Guidelines

--- a/api/README.md
+++ b/api/README.md
@@ -13,7 +13,7 @@ well as endpoints to publish and browse messages.
 There are a few things you need to have installed to run this project:
 
 - [Maven](https://maven.apache.org/)
-- [JDK 17+](https://openjdk.java.net/projects/jdk/17/)
+- [JDK 21+](https://openjdk.java.net/projects/jdk/21/)
 - Kubernetes environment ([minikube](https://minikube.sigs.k8s.io/) recommended) with [Strimzi Cluster Operator](https://strimzi.io) installed and a Kafka cluster deployed
 - [Docker](https://www.docker.com/) or [Podman](https://podman.io)
 

--- a/api/src/main/docker/Dockerfile
+++ b/api/src/main/docker/Dockerfile
@@ -53,7 +53,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.24
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1767793527
 
 ENV LANGUAGE='en_US:en'
 LABEL org.opencontainers.image.source="https://github.com/streamshub/console"

--- a/operator/README.md
+++ b/operator/README.md
@@ -9,7 +9,7 @@ This repository contains the operator responsible for deploying the StreamsHub c
 There are a few things you need to have installed to run this project:
 
 - [Maven](https://maven.apache.org/)
-- [JDK 17+](https://openjdk.java.net/projects/jdk/17/)
+- [JDK 21+](https://openjdk.java.net/projects/jdk/21/)
 - Kubernetes environment ([minikube](https://minikube.sigs.k8s.io/) recommended) with [Strimzi Cluster Operator](https://strimzi.io) installed and a Kafka cluster deployed
 - [Docker](https://www.docker.com/) or [Podman](https://podman.io)
 

--- a/operator/src/main/docker/Dockerfile
+++ b/operator/src/main/docker/Dockerfile
@@ -53,7 +53,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.24
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1767793527
 
 ENV LANGUAGE='en_US:en'
 LABEL org.opencontainers.image.source="https://github.com/streamshub/console"

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <!-- Dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
Use Java 21 as the compiler level for the project and standardize on using the temurin JDK throughout the jobs in the GitHub actions.