### PR TITLE
[GHA] Avoid NodeJS unpacking limit in workflow

### DIFF
--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -101,7 +101,6 @@ jobs:
       - name: Extract images
         run: |
           unzip streamshub-images.zip
-          tar -xzf streamshub-images.tgz
 
       - name: Setup Minikube
         id: setup_minikube


### PR DESCRIPTION
There is an issue with systemtest workflow. During the unpacking console images step the action-download-artifact fails to handle buffer > 2 GiB, so this PR splits downloading and unpacking into two steps.


Known Issue: https://github.com/dawidd6/action-download-artifact/issues/201