### PR TITLE
[GHA] Change download-artifacts action step due to 2GiB limit

### DIFF
--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -86,8 +86,11 @@ jobs:
           ref: ${{ env.COMMIT_SHA }}
 
       - name: Download Image Artifacts
-        run: |
-          gh run download ${{ env.ARTIFACTS_RUN_ID }} --repo ${{ env.REPO }} --name streamshub-images
+        uses: actions/download-artifact@v7
+        with:
+          name: streamshub-images
+          run-id: ${{ env.ARTIFACTS_RUN_ID }}
+          repository: ${{ env.REPO }}
 
       - name: Extract Images
         run: |


### PR DESCRIPTION
Due to NodeJs buffer limitations being put not only on the unzip action, but the whole download-artifacts action, this PR replaces it with a parametrized GH CLI `run download` command. That should solve the issue appearing in the recent systemtest workflow runs.

Note: Reason why the standard gha download-artifacts is not used is that this enables sourcing the last image build from a specified workflow.