### PR TITLE
Remove the local image files after they have been loaded to minikube

### DIFF
--- a/.github/actions/setup-minikube/action.yml
+++ b/.github/actions/setup-minikube/action.yml
@@ -49,6 +49,11 @@ runs:
 
         kill ${SOCAT_PID}
 
+    - name: Remove local image files
+      shell: bash
+      run: |
+        rm -rvf streamshub-images.tgz streamshub-images
+
     - name: Set Nginx ingres passthrough
       shell: bash
       run: |


### PR DESCRIPTION
Frees up disk space to avoid lack of space failures later in the job.