### PR TITLE
Derive Kafka version from feature metadata for unmanaged clusters

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -105,6 +105,17 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/api/src/test/java/com/github/streamshub/console/api/service/ClusterServiceTest.java
+++ b/api/src/test/java/com/github/streamshub/console/api/service/ClusterServiceTest.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -31,5 +33,15 @@ class ClusterServiceTest {
     void testEnumNamesNull() {
         List<String> result = KafkaClusterService.enumNames(null);
         assertNull(result);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "  1, 'Unknown (<3.3)'", // Below range, metadata.version 1 - 6 are not in enum as of Kafka 4.2. Earliest is 3.3
+        "999,  ",                // Above range (null), metadata.version 29 is the highest as of Kafka 4.2
+        " 28, '4.2'"             // Within range, 28 & 29 indicate Kafka 4.2
+    })
+    void testMetadataLevelToVersionString(short level, String expectedVersion) {
+        assertEquals(expectedVersion, KafkaClusterService.metadataLevelToVersionString(level));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <strimzi-api.version>0.50.0</strimzi-api.version>
         <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
         <apicurio-registry.version>3.1.4</apicurio-registry.version>
+        <kafka.version>4.1.1</kafka.version>
 
         <!-- Test Dependencies -->
         <strimzi-test-container.version>0.114.0</strimzi-test-container.version>
@@ -97,7 +98,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.1.1</version>
+                <version>${kafka.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>

--- a/ui/api/kafka/schema.ts
+++ b/ui/api/kafka/schema.ts
@@ -11,6 +11,7 @@ export const ClusterListSchema = z.object({
   type: z.literal("kafkas"),
   meta: z.object({
     configured: z.boolean(),
+    managed: z.boolean(),
     kind: KafkaClusterKindSchema,
     authentication: z
       .union([

--- a/ui/components/ClusterOverview/ClusterCard.tsx
+++ b/ui/components/ClusterOverview/ClusterCard.tsx
@@ -19,12 +19,14 @@ import {
   Skeleton,
   Content,
   Title,
+  Tooltip,
   Truncate,
 } from "@/libs/patternfly/react-core";
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  HelpIcon,
 } from "@/libs/patternfly/react-icons";
 import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
@@ -220,7 +222,22 @@ export function ClusterCard({
                   </GridItem>
                   <GridItem span={12} xl={4}>
                     <div className="pf-v6-u-font-size-xl">
-                      {isLoading ? <Skeleton /> : kafkaDetail?.attributes.kafkaVersion ?? "Not Available"}
+                      {isLoading ? <Skeleton /> : <>
+                        { kafkaDetail?.attributes.kafkaVersion ?
+                            <>
+                                { kafkaDetail?.attributes.kafkaVersion }
+                                {!kafkaDetail?.meta?.managed && <>
+                                    {" "}
+                                    <Tooltip content={t("ClustersTable.version_derived")}>
+                                        <HelpIcon />
+                                    </Tooltip>
+                                    </>
+                                }
+                            </>
+                            : t("ClustersTable.not_available")
+                        }
+                        </>
+                      }
                     </div>
                     <Content>
                       <Content component={"small"}>

--- a/ui/components/ClustersTable.tsx
+++ b/ui/components/ClustersTable.tsx
@@ -4,7 +4,8 @@ import { ClusterList } from "@/api/kafka/schema";
 import { useTranslations } from "next-intl";
 import { ButtonLink } from "./Navigation/ButtonLink";
 import { Link } from "@/i18n/routing";
-import { Truncate } from "@/libs/patternfly/react-core";
+import { Tooltip, Truncate } from "@/libs/patternfly/react-core";
+import { HelpIcon } from "@/libs/patternfly/react-icons";
 import { EmptyStateNoMatchFound } from "./Table/EmptyStateNoMatchFound";
 import { KroxyliciousClusterLabel } from "@/app/[locale]/(authorized)/kafka/[kafkaId]/KroxyliciousClusterLabel";
 
@@ -117,8 +118,19 @@ export function ClustersTable({
           case "version":
             return (
               <Td key={key}>
-                {row.attributes.kafkaVersion ??
-                  t("ClustersTable.not_available")}
+                { row.attributes.kafkaVersion ?
+                    <>
+                        { row.attributes.kafkaVersion }
+                        {!row.meta.managed && <>
+                            {" "}
+                            <Tooltip content={t("ClustersTable.version_derived")}>
+                                <HelpIcon />
+                            </Tooltip>
+                            </>
+                        }
+                    </>
+                    : t("ClustersTable.not_available")
+                }
               </Td>
             );
           case "namespace":

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -414,7 +414,8 @@
     "connection_details": "Connection details",
     "view_openshift_console": "View in OpenShift console",
     "no_data": "No clusters available.",
-    "not_available": "n/a"
+    "not_available": "n/a",
+    "version_derived": "Version derived from Kafka metadata"
   },
   "metrics": {
      "all_brokers": "All Nodes",


### PR DESCRIPTION
Without a Strimzi Kafka resource associated with a Kafka cluster, the console is currently missing version information. However, the `metadata.version` feature information available from the Admin interface provides a means to derive the version, at least the major and minor components. This PR adds that version information to the UI for non-managed clusters and provides a tooltip regarding the information source.

Cluster list
<img width="846" height="640" alt="image" src="https://github.com/user-attachments/assets/9c61580e-070a-4853-a117-8baf0355f499" />

Cluster detail
<img width="836" height="416" alt="image" src="https://github.com/user-attachments/assets/781b8892-3ae4-4904-9c63-2edfbe84f537" />
