### PR TITLE
[ST] Remove clusterroles,rolebindings and service accounts from log collecting of failed test

### DIFF
--- a/systemtests/src/main/java/com/github/streamshub/systemtests/logs/TestLogCollector.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/logs/TestLogCollector.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroup;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.ClusterServiceVersion;
@@ -60,7 +59,6 @@ public class TestLogCollector {
         List<String> resources = new ArrayList<>(List.of(
             HasMetadata.getKind(Service.class),
             HasMetadata.getKind(ConfigMap.class),
-            HasMetadata.getKind(ServiceAccount.class),
             HasMetadata.getKind(Secret.class),
             HasMetadata.getKind(Deployment.class),
             HasMetadata.getKind(Console.class),


### PR DESCRIPTION
As debugging showed, they were not really necessary to collect. Keeping services and configmaps there as they may contain important info for debugging failed tests.