### PR TITLE
Avoid deadlocks using thread pool with context to run async futures

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/service/GroupService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/GroupService.java
@@ -50,7 +50,6 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
-import org.eclipse.microprofile.context.ThreadContext;
 
 import com.github.streamshub.console.api.model.Either;
 import com.github.streamshub.console.api.model.Group;
@@ -61,6 +60,7 @@ import com.github.streamshub.console.api.model.PartitionInfo;
 import com.github.streamshub.console.api.model.Topic;
 import com.github.streamshub.console.api.model.jsonapi.JsonApiError;
 import com.github.streamshub.console.api.security.PermissionService;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.FetchFilterPredicate;
 import com.github.streamshub.console.api.support.GroupValidation;
 import com.github.streamshub.console.api.support.KafkaContext;
@@ -94,7 +94,7 @@ public class GroupService {
      * {@linkplain Admin Admin client}
      */
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     KafkaContext kafkaContext;

--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.admin.FeatureMetadata;
 import org.apache.kafka.clients.admin.FinalizedVersionRange;
 import org.apache.kafka.clients.admin.QuorumInfo;
 import org.apache.kafka.server.common.MetadataVersion;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.Annotations;
@@ -38,6 +37,7 @@ import com.github.streamshub.console.api.model.KafkaCluster;
 import com.github.streamshub.console.api.model.KafkaListener;
 import com.github.streamshub.console.api.model.jsonapi.Identifier;
 import com.github.streamshub.console.api.security.PermissionService;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.ListRequestContext;
@@ -82,7 +82,7 @@ public class KafkaClusterService {
      * tasks to allow access to request-scoped beans.
      */
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider executorProvider;
 
     @Inject
     Holder<SharedIndexInformer<Kafka>> kafkaInformer;
@@ -170,17 +170,17 @@ public class KafkaClusterService {
                 quorumResult)
             .thenApplyAsync(
                     nothing -> new KafkaCluster(kafkaContext.clusterId(), enumNames(get(clusterResult::authorizedOperations))),
-                    threadContext.currentContextExecutor())
+                    executorProvider.currentContextExecutor())
             .thenComposeAsync(
                     cluster -> addNodes(cluster, clusterResult, quorumResult),
-                    threadContext.currentContextExecutor())
-            .thenApplyAsync(this::addKafkaContextData, threadContext.currentContextExecutor())
+                    executorProvider.currentContextExecutor())
+            .thenApplyAsync(this::addKafkaContextData, executorProvider.currentContextExecutor())
             .thenApply(this::addKafkaResourceData)
             .thenCompose(cluster -> addMetrics(cluster, fields, durationMinutes))
             .thenApply(this::setManaged)
             .thenApplyAsync(
                     permissionService.addPrivileges(ResourceTypes.Global.KAFKAS, KafkaCluster::getId),
-                    threadContext.currentContextExecutor());
+                    executorProvider.currentContextExecutor());
     }
 
     private CompletionStage<KafkaCluster> addNodes(KafkaCluster cluster, DescribeClusterResult clusterResult, CompletableFuture<QuorumInfo> quorumResult) {
@@ -416,11 +416,11 @@ public class KafkaClusterService {
 
         try (var rangesStream = getClass().getResourceAsStream("/metrics/queries/kafkaCluster_ranges.promql");
             var valuesStream = getClass().getResourceAsStream("/metrics/queries/kafkaCluster_values.promql")) {
-        
-       
+
+
             rangeQuery = new String(rangesStream.readAllBytes(), StandardCharsets.UTF_8)
                     .formatted(namespace, name, promInterval);
-        
+
             valueQuery = new String(valuesStream.readAllBytes(), StandardCharsets.UTF_8)
                     .formatted(namespace, name);
         } catch (IOException e) {

--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaConnectService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaConnectService.java
@@ -17,7 +17,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.FetchParams;
@@ -25,6 +24,7 @@ import com.github.streamshub.console.api.model.connect.ConnectCluster;
 import com.github.streamshub.console.api.model.connect.Connector;
 import com.github.streamshub.console.api.model.connect.ConnectorPlugin;
 import com.github.streamshub.console.api.model.connect.ConnectorTask;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.FieldFilter;
 import com.github.streamshub.console.api.support.KafkaConnectAPI;
 import com.github.streamshub.console.api.support.KafkaConnectAPI.ConnectorOffsets;
@@ -59,7 +59,7 @@ public class KafkaConnectService {
     Logger logger;
 
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     ConsoleConfig consoleConfig;

--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaUserService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaUserService.java
@@ -13,11 +13,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.KafkaUser;
 import com.github.streamshub.console.api.security.PermissionService;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.ListRequestContext;
 import com.github.streamshub.console.config.ConsoleConfig;
@@ -46,7 +46,7 @@ public class KafkaUserService {
     Logger logger;
 
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     ConsoleConfig consoleConfig;

--- a/api/src/main/java/com/github/streamshub/console/api/service/NodeService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/NodeService.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.QuorumInfo;
 import org.apache.kafka.common.config.ConfigResource;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.ConfigEntry;
@@ -41,6 +40,7 @@ import com.github.streamshub.console.api.model.Node.ControllerStatus;
 import com.github.streamshub.console.api.model.Node.MetadataStatus;
 import com.github.streamshub.console.api.model.NodeSummary;
 import com.github.streamshub.console.api.security.PermissionService;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.ListRequestContext;
 import com.github.streamshub.console.api.support.MetadataQuorumSupport;
@@ -90,7 +90,7 @@ public class NodeService {
     PermissionService permissionService;
 
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     @Named("KafkaNodePools")
@@ -523,7 +523,7 @@ public class NodeService {
             }
         });
     }
-    
+
     public CompletionStage<Metrics> getNodeMetrics(String nodeId, int durationMinutes) {
         if (kafkaContext.prometheus() == null) {
             logger.warnf("Metrics requested for node %s, but Prometheus is not configured", nodeId);
@@ -536,10 +536,10 @@ public class NodeService {
 
         String promInterval = "5m";
         if (durationMinutes >= 1440) {
-            promInterval = "30m"; 
+            promInterval = "30m";
         }
         if (durationMinutes >= 10080) {
-            promInterval = "2h"; 
+            promInterval = "2h";
         }
         String rangeQuery;
         String valueQuery;
@@ -550,7 +550,7 @@ public class NodeService {
         ) {
             rangeQuery = new String(rangesStream.readAllBytes(), StandardCharsets.UTF_8)
                 .formatted(namespace, name, promInterval);
-        
+
             valueQuery = new String(valuesStream.readAllBytes(), StandardCharsets.UTF_8)
                 .formatted(namespace, name);
         } catch (IOException e) {

--- a/api/src/main/java/com/github/streamshub/console/api/service/RecordService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/RecordService.java
@@ -37,12 +37,12 @@ import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.KafkaRecord;
 import com.github.streamshub.console.api.model.jsonapi.Identifier;
 import com.github.streamshub.console.api.model.jsonapi.JsonApiRelationshipToOne;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.SizeLimitedSortedSet;
 import com.github.streamshub.console.api.support.serdes.RecordData;
@@ -69,7 +69,7 @@ public class RecordService {
     Producer<RecordData, RecordData> producer;
 
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     TopicDescribeService topicService;

--- a/api/src/main/java/com/github/streamshub/console/api/service/TopicDescribeService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/TopicDescribeService.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +14,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -37,7 +37,6 @@ import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.common.TopicCollection;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.Either;
@@ -48,6 +47,7 @@ import com.github.streamshub.console.api.model.ReplicaLocalStorage;
 import com.github.streamshub.console.api.model.Topic;
 import com.github.streamshub.console.api.model.jsonapi.Identifier;
 import com.github.streamshub.console.api.security.PermissionService;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.KafkaOffsetSpec;
 import com.github.streamshub.console.api.support.ListRequestContext;
@@ -88,7 +88,7 @@ public class TopicDescribeService {
      * {@linkplain Admin Admin client}
      */
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     KafkaContext kafkaContext;
@@ -336,10 +336,11 @@ public class TopicDescribeService {
             List<String> fields,
             String offsetSpec) {
 
-        Map<Uuid, Either<Topic, Throwable>> result = new LinkedHashMap<>(topicIds.size());
+        Map<Uuid, Either<Topic, Throwable>> result = new ConcurrentHashMap<>(topicIds.size());
         TopicCollection request = TopicCollection.ofTopicIds(topicIds);
         DescribeTopicsOptions options = new DescribeTopicsOptions()
                 .includeAuthorizedOperations(fields.contains(Topic.Fields.AUTHORIZED_OPERATIONS));
+        var contextualExecutor = threadContext.currentContextExecutor();
 
         var pendingDescribes = adminClient.describeTopics(request, options)
                 .topicIdValues()
@@ -358,7 +359,7 @@ public class TopicDescribeService {
                                         UnknownTopicIdPatch.apply(error, Function.identity()),
                                         Topic::fromTopicDescription));
                             return null;
-                        }, threadContext.currentContextExecutor()))
+                        }, contextualExecutor))
                 .map(CompletionStage::toCompletableFuture)
                 .toArray(CompletableFuture[]::new);
 
@@ -371,7 +372,7 @@ public class TopicDescribeService {
     }
 
     private CompletionStage<Void> listOffsets(Admin adminClient, Map<Uuid, Either<Topic, Throwable>> topics, String offsetSpec) {
-        Map<String, Uuid> topicIds = new HashMap<>(topics.size());
+        Map<String, Uuid> topicIds = HashMap.newHashMap(topics.size());
         var onlineTopics = topics.entrySet()
                 .stream()
                 .filter(topic -> topic.getValue()
@@ -501,7 +502,7 @@ public class TopicDescribeService {
     }
 
     private CompletionStage<Void> describeLogDirs(Admin adminClient, Map<Uuid, Either<Topic, Throwable>> topics) {
-        Map<String, Uuid> topicIds = new HashMap<>(topics.size());
+        Map<String, Uuid> topicIds = HashMap.newHashMap(topics.size());
 
         var topicPartitionReplicas = topicPartitionLeaders(topics, topicIds);
         var nodeIds = topicPartitionReplicas.values().stream().distinct().toList();

--- a/api/src/main/java/com/github/streamshub/console/api/service/TopicService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/TopicService.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.UnknownTopicIdException;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.model.ConfigEntry;
@@ -42,6 +41,7 @@ import com.github.streamshub.console.api.model.NewTopic;
 import com.github.streamshub.console.api.model.Topic;
 import com.github.streamshub.console.api.model.TopicPatch;
 import com.github.streamshub.console.api.security.PermissionService;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.api.support.KafkaOffsetSpec;
 import com.github.streamshub.console.api.support.ListRequestContext;
@@ -78,7 +78,7 @@ public class TopicService {
      * {@linkplain Admin Admin client}
      */
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     ValidationProxy validationService;
@@ -579,7 +579,7 @@ public class TopicService {
         private final Instant limit = Instant.now().plusSeconds(TOPIC_OPERATION_LIMIT);
         protected final CompletableFuture<T> promise = new CompletableFuture<>();
 
-        TopicCheck(ThreadContext threadContext, ScheduledExecutorService scheduler) {
+        TopicCheck(ContextualExecutorProvider threadContext, ScheduledExecutorService scheduler) {
             this.scheduler = scheduler;
             this.task = threadContext.contextualRunnable(this);
         }

--- a/api/src/main/java/com/github/streamshub/console/api/support/ContextualExecutorProvider.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/ContextualExecutorProvider.java
@@ -1,0 +1,38 @@
+package com.github.streamshub.console.api.support;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.context.ThreadContext;
+
+@ApplicationScoped
+public class ContextualExecutorProvider {
+
+    @Inject
+    ExecutorService executor;
+
+    @Inject
+    ThreadContext threadContext;
+
+    /**
+     * Provide an executor that will run using the server's thread pool, but with
+     * the context of the thread calling this method. This allows us to provide
+     * request context to the task even though it will run on a thread-pool thread.
+     *
+     * @return an executor with propagation of the calling thread's context
+     */
+    public Executor currentContextExecutor() {
+        var context = threadContext.currentContextExecutor();
+        return task -> executor.execute(() -> context.execute(task));
+    }
+
+    /**
+     * @see {@link ThreadContext#contextualRunnable(Runnable)}
+     */
+    public Runnable contextualRunnable(Runnable runnable) {
+        return threadContext.contextualRunnable(runnable);
+    }
+}

--- a/api/src/test/java/com/github/streamshub/console/api/GroupsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/GroupsResourceIT.java
@@ -39,7 +39,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.context.ThreadContext;
 import org.hamcrest.Description;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
@@ -55,6 +54,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.github.streamshub.console.api.model.Group;
+import com.github.streamshub.console.api.support.ContextualExecutorProvider;
 import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.api.support.Promises;
 import com.github.streamshub.console.config.ConsoleConfig;
@@ -112,7 +112,7 @@ class GroupsResourceIT {
     Config config;
 
     @Inject
-    ThreadContext threadContext;
+    ContextualExecutorProvider threadContext;
 
     @Inject
     KubernetesClient client;


### PR DESCRIPTION
Currently, when `CompletionStage` *Async methods are invoked with the executor provided by a `ThreadContext`, the thread that runs the task may be a Kafka Admin client thread. Additional use of the Admin client by another thread may result in a deadlock when there is a blocking task that is waiting for a result from the cluster. 

This PR adds a new `ContextualExecutorProvider` that instead runs the async tasks with the Quarkus executor thread pool, freeing the original thread to do additional work and avoiding a deadlock.