### PR TITLE
Fix several concurrency issues

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -151,27 +150,26 @@ public class ClientFactory {
 
     @Produces
     @ApplicationScoped
-    Map<String, KafkaContext> produceKafkaContexts(Function<Map<String, Object>, Admin> adminBuilder) {
-
-        final Map<String, KafkaContext> contexts = new ConcurrentHashMap<>();
+    KafkaContext.Manager produceKafkaContextManager(Function<Map<String, Object>, Admin> adminBuilder) {
+        final KafkaContext.Manager manager = new KafkaContext.Manager();
 
         if (kafkaInformer.isPresent()) {
-            addKafkaEventHandler(contexts, adminBuilder);
+            addKafkaEventHandler(manager, adminBuilder);
         }
 
         // Configure clusters that will not be configured by events
         consoleConfig.getKafka().getClusters()
             .stream()
             .filter(c -> cachedKafkaResource(c).isEmpty())
-            .forEach(clusterConfig -> putKafkaContext(contexts,
+            .forEach(clusterConfig -> putKafkaContext(manager,
                         clusterConfig,
                         Optional.empty(),
                         adminBuilder));
 
-        return Collections.unmodifiableMap(contexts);
+        return manager;
     }
 
-    void addKafkaEventHandler(Map<String, KafkaContext> contexts,
+    void addKafkaEventHandler(KafkaContext.Manager manager,
             Function<Map<String, Object>, Admin> adminBuilder) {
 
         kafkaInformer.get().addEventHandlerWithResyncPeriod(new ResourceEventHandler<Kafka>() {
@@ -185,7 +183,7 @@ public class ClientFactory {
                                 log.debugf("Ignoring added Kafka resource %s, cluster ID not yet available and not provided via configuration",
                                         Cache.metaNamespaceKeyFunc(kafka));
                             } else {
-                                putKafkaContext(contexts,
+                                putKafkaContext(manager,
                                         clusterConfig,
                                         Optional.of(kafka),
                                         adminBuilder);
@@ -199,7 +197,7 @@ public class ClientFactory {
                     log.debugf("Kafka resource %s updated", Cache.metaNamespaceKeyFunc(oldKafka));
                 }
                 findConfig(newKafka).ifPresentOrElse(
-                        clusterConfig -> putKafkaContext(contexts,
+                        clusterConfig -> putKafkaContext(manager,
                             clusterConfig,
                             Optional.of(newKafka),
                             adminBuilder),
@@ -215,9 +213,8 @@ public class ClientFactory {
                             String clusterKey = clusterConfig.clusterKey();
                             String clusterId = KafkaContext.clusterId(clusterConfig, Optional.of(kafka));
                             log.infof("Removing KafkaContext for cluster %s, id=%s", clusterKey, clusterId);
-                            log.debugf("Known KafkaContext identifiers: %s", contexts.keySet());
-                            KafkaContext previous = contexts.remove(clusterId);
-                            Optional.ofNullable(previous).ifPresent(KafkaContext::close);
+                            log.debugf("Known KafkaContext identifiers: %s", manager.contexts().keySet());
+                            manager.remove(clusterId);
                         },
                         () -> log.debugf("Ignoring deleted Kafka resource %s, not found in configuration", Cache.metaNamespaceKeyFunc(kafka)));
             }
@@ -229,7 +226,7 @@ public class ClientFactory {
         }, TimeUnit.MINUTES.toMillis(1));
     }
 
-    void putKafkaContext(Map<String, KafkaContext> contexts,
+    void putKafkaContext(KafkaContext.Manager manager,
             KafkaClusterConfig clusterConfig,
             Optional<Kafka> kafkaResource,
             Function<Map<String, Object>, Admin> adminBuilder) {
@@ -297,14 +294,7 @@ public class ClientFactory {
                 log.infof("Skipping setup of metrics client for cluster %s. Reason: namespace is required for metrics retrieval but none was provided", clusterKey);
             }
 
-            KafkaContext previous = contexts.put(clusterId, ctx);
-
-            if (previous == null) {
-                log.infof("Added KafkaContext for cluster %s, id=%s, global=%s", clusterKey, clusterId, globalConnection);
-            } else {
-                log.infof("Replaced KafkaContext for cluster %s, id=%s, global=%s", clusterKey, clusterId, previous.admin() != null);
-                previous.close();
-            }
+            manager.replace(clusterId, clusterKey, ctx);
         }
     }
 
@@ -445,6 +435,12 @@ public class ClientFactory {
         });
     }
 
+    @Produces
+    @ApplicationScoped
+    Map<String, KafkaContext> produceKafkaContexts(KafkaContext.Manager contextManager) {
+        return contextManager.contexts();
+    }
+
     /**
      * Provides the Strimzi Kafka custom resource addressed by the current request
      * URL as an injectable bean. This allows for the Kafka to be obtained by
@@ -460,7 +456,7 @@ public class ClientFactory {
      */
     @Produces
     @RequestScoped
-    public KafkaContext produceKafkaContext(Map<String, KafkaContext> contexts,
+    public KafkaContext produceKafkaContext(KafkaContext.Manager manager,
             SecurityIdentity identity,
             UnaryOperator<Admin> filter,
             Function<Map<String, Object>, Admin> adminBuilder) {
@@ -471,7 +467,7 @@ public class ClientFactory {
             return KafkaContext.EMPTY;
         }
 
-        KafkaContext ctx = contexts.get(clusterId);
+        KafkaContext ctx = manager.acquire(clusterId);
 
         if (ctx == null) {
             throw NO_SUCH_KAFKA.apply(clusterId);
@@ -496,16 +492,8 @@ public class ClientFactory {
         return ctx;
     }
 
-    public void disposeKafkaContext(@Disposes KafkaContext context, Map<String, KafkaContext> contexts) {
-        if (!contexts.values().contains(context)) {
-            var clusterKey = context.clusterConfig().clusterKey();
-            if (context.applicationScoped()) {
-                log.infof("Closing out-of-date KafkaContext: %s", clusterKey);
-            } else {
-                log.debugf("Closing request-scoped KafkaContext: %s", clusterKey);
-            }
-            context.close();
-        }
+    public void disposeKafkaContext(@Disposes KafkaContext context, KafkaContext.Manager manager) {
+        manager.release(context);
     }
 
     @Produces

--- a/api/src/main/java/com/github/streamshub/console/api/service/GroupService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/GroupService.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -552,7 +553,7 @@ public class GroupService {
             Collection<Group> groups,
             List<String> fields) {
 
-        Map<String, Either<Group, Throwable>> result = LinkedHashMap.newLinkedHashMap(groups.size());
+        Map<String, Either<Group, Throwable>> result = new ConcurrentHashMap<>(groups.size());
 
         var pendingTopicsIds = fetchTopicIdMap();
         var pendingDescribes = groups.stream()

--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -41,6 +43,100 @@ public class KafkaContext implements Closeable {
     private static final Pattern OAUTH_TOKEN_URI_PATTERN = Pattern.compile(
             Pattern.quote(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI) + "=\"([^\"]+)\"");
 
+    /**
+     * Container type to manager Kafka contexts (cluster configurations and
+     * connections) created and used for API requests. This class synchronizes
+     * access to ensure connections are only closed when no longer used to service
+     * requests.
+     */
+    public static class Manager {
+        private static final Logger LOGGER = Logger.getLogger(Manager.class);
+        private final Map<String, KafkaContext> contexts = new ConcurrentHashMap<>();
+
+        public Map<String, KafkaContext> contexts() {
+            return Collections.unmodifiableMap(contexts);
+        }
+
+        /**
+         * Obtains a context by ID and marks it as "in use".
+         */
+        public synchronized KafkaContext acquire(String clusterId) {
+            KafkaContext ctx = contexts.get(clusterId);
+
+            if (ctx != null) {
+                ctx.users.incrementAndGet();
+            }
+
+            return ctx;
+        }
+
+        /**
+         * Removes a context by ID. Underlying connections will be closed if the context
+         * is not in use. Used contexts will be closed later when they are no longer
+         * needed by a request and they are {@link #release(KafkaContext) released}.
+         */
+        public synchronized void remove(String clusterId) {
+            KafkaContext previous = contexts.remove(clusterId);
+
+            if (previous != null && !previous.hasUsers()) {
+                previous.close();
+            }
+        }
+
+        /**
+         * Replaces a context, typically in response to changes in configuration due to
+         * updates in the associated Strimzi Kafka CR. Underlying connections will be
+         * closed if the context is not in use. Used contexts will be closed later when
+         * they are no longer needed by a request and they are
+         * {@link #release(KafkaContext) released}.
+         */
+        public synchronized void replace(String clusterId, String clusterKey, KafkaContext ctx) {
+            KafkaContext previous = contexts.put(clusterId, ctx);
+
+            if (previous == null) {
+                LOGGER.infof("Added KafkaContext for cluster %s, id=%s, global=%s", clusterKey, clusterId, ctx.admin != null);
+            } else {
+                var closed = false;
+                var users = previous.userCount();
+
+                if (!previous.hasUsers()) {
+                    previous.close();
+                    closed = true;
+                }
+
+                LOGGER.infof("Replaced KafkaContext for cluster %s, id=%s, global=%s, users=%d, closed=%s",
+                        clusterKey, clusterId, previous.admin() != null, users, closed);
+            }
+        }
+
+        /**
+         * Release the provided context (decrement its user count) and close it if not
+         * in use by any other requests.
+         */
+        public synchronized void release(KafkaContext ctx) {
+            if (ctx.applicationScoped()) {
+                ctx.users.decrementAndGet();
+            }
+
+            if (!contexts.values().contains(ctx)) {
+                var clusterKey = ctx.clusterConfig().clusterKey();
+
+                if (ctx.hasUsers()) {
+                    LOGGER.infof("Out-of-date KafkaContext still has %d users: %s", ctx.userCount(), clusterKey);
+                } else {
+                    if (ctx.applicationScoped()) {
+                        LOGGER.infof("Closing out-of-date KafkaContext: %s", clusterKey);
+                    } else {
+                        LOGGER.debugf("Closing request-scoped KafkaContext: %s", clusterKey);
+                    }
+
+                    ctx.close();
+                }
+            }
+        }
+    }
+
+    final AtomicInteger users = new AtomicInteger(0);
     final KafkaClusterConfig clusterConfig;
     final Kafka resource;
     final Map<Class<?>, Map<String, Object>> configs;
@@ -68,6 +164,14 @@ public class KafkaContext implements Closeable {
         return Optional.ofNullable(clusterConfig.getId())
                 .or(() -> kafkaResource.map(Kafka::getStatus).map(KafkaStatus::getClusterId))
                 .orElseGet(clusterConfig::clusterKeyEncoded);
+    }
+
+    public boolean hasUsers() {
+        return users.get() > 0;
+    }
+
+    public int userCount() {
+        return users.get();
     }
 
     @Override


### PR DESCRIPTION
- use ConcurrentHashMap in GroupService for map populated from potentially multiple threads (relates to #2475)
- improve concurrency handling of Kafka contexts to ensure in-use connections are not closed when an update to the Kafka CR replaces the connection configurations.