### PR TITLE
Fix several issues/differences in new React client-side application

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/MetadataResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/MetadataResource.java
@@ -67,13 +67,16 @@ public class MetadataResource {
     }
 
     private Map<String, Object> initializeMetadata() {
-        Map<String, String>  meta = new LinkedHashMap<>();
+        Map<String, Object> meta = new LinkedHashMap<>();
 
         meta.put(VERSION, config
                 .getValue("console.meta.version", String.class));
         meta.put("platform", config
                 .getOptionalValue("console.meta.platform", String.class)
                 .orElseGet(this::determinePlatform));
+        meta.put("options", Map.of(
+                "showLearning", consoleConfig.getOptions().isShowLearning()
+        ));
 
         var replacementMetadata = Optional.<Map<String, Object>>of(Map.of(
             "data", Map.of(

--- a/api/src/main/webui/src/api/hooks/useKafkaClusters.ts
+++ b/api/src/main/webui/src/api/hooks/useKafkaClusters.ts
@@ -81,7 +81,7 @@ export function useKafkaCluster(kafkaId: string | undefined, params?: {
       return apiClient.get<{ data: KafkaCluster }>(path);
     },
     enabled: !!kafkaId,
-    refetchInterval: 10000,
+    refetchInterval: 30000,
   });
 }
 

--- a/api/src/main/webui/src/api/types.ts
+++ b/api/src/main/webui/src/api/types.ts
@@ -352,6 +352,9 @@ export interface Metadata {
   attributes: {
     version: string;
     platform: string;
+    options: {
+      showLearning: boolean;
+    };
   };
 }
 

--- a/api/src/main/webui/src/components/EmptyStates/NoDataEmptyState.tsx
+++ b/api/src/main/webui/src/components/EmptyStates/NoDataEmptyState.tsx
@@ -7,26 +7,33 @@ import { useTranslation } from 'react-i18next';
 import {
   EmptyState,
   EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
   Title,
 } from '@patternfly/react-core';
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 interface NoDataEmptyStateProps {
   entityName?: string;
   title?: string;
   message?: string;
   icon?: React.ComponentType;
+  learningLink?: {
+    href: string;
+    label: string;
+  };
 }
 
-export function NoDataEmptyState({ 
-  entityName, 
-  title, 
+export function NoDataEmptyState({
+  entityName,
+  title,
   message,
-  icon: IconComponent = CubesIcon 
+  icon: IconComponent = CubesIcon,
+  learningLink,
 }: NoDataEmptyStateProps = {}) {
   const { t } = useTranslation();
 
-  const defaultTitle = entityName 
+  const defaultTitle = entityName
     ? t('common.noEntityAvailable', { entity: entityName })
     : t('common.noData');
 
@@ -43,6 +50,19 @@ export function NoDataEmptyState({
       <EmptyStateBody>
         {message || defaultMessage}
       </EmptyStateBody>
+      {learningLink && (
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <a
+              href={learningLink.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {learningLink.label} <ExternalLinkAltIcon />
+            </a>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      )}
     </EmptyState>
   );
 }

--- a/api/src/main/webui/src/components/app/AppMasthead.tsx
+++ b/api/src/main/webui/src/components/app/AppMasthead.tsx
@@ -27,17 +27,20 @@ import { ClusterSwitcher } from '@/components/kafka/ClusterSwitcher';
 import { KafkaCluster } from '@/api/types';
 import { useMetadata } from '@/api/hooks/useMetadata';
 import { UserDropdown } from './UserDropdown';
+import { RefreshAllButton } from './RefreshAllButton';
 
 export interface AppMastheadProps {
   readonly showSidebarToggle?: boolean;
   readonly clusters?: KafkaCluster[];
   readonly currentClusterId?: string;
+  readonly staticRefresh?: Date; // allows fixed value to be provided for storybook testing
 }
 
 export function AppMasthead({
   showSidebarToggle = false,
   clusters,
   currentClusterId,
+  staticRefresh,
 }: AppMastheadProps) {
   const { t } = useTranslation();
   const { toggleSidebar } = useAppLayout();
@@ -107,6 +110,9 @@ export function AppMasthead({
               >
                 <ToolbarItem>
                   <ThemeSwitcher />
+                </ToolbarItem>
+                <ToolbarItem>
+                  <RefreshAllButton staticRefresh={staticRefresh} />
                 </ToolbarItem>
                 <ToolbarItem>
                   <Button

--- a/api/src/main/webui/src/components/app/RefreshAllButton.tsx
+++ b/api/src/main/webui/src/components/app/RefreshAllButton.tsx
@@ -1,0 +1,43 @@
+// In a toolbar or header component
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, ButtonProps, Tooltip } from '@patternfly/react-core';
+import { SyncIcon } from '@patternfly/react-icons';
+import { useState, useTransition } from 'react';
+import { formatDateTime } from '@/utils/dateTime';
+import { Trans } from 'react-i18next';
+
+export function RefreshAllButton({ staticRefresh} : { staticRefresh?: Date; }) {
+  const queryClient = useQueryClient();
+  const [isRefreshing, startTransition] = useTransition();
+  const now = new Date();
+  const [lastRefresh, setLastRefresh] = useState(staticRefresh ?? now);
+
+  const handleRefresh: ButtonProps["onClick"] = async (e) => {
+    e.preventDefault();
+    startTransition(async () => {
+      await queryClient.refetchQueries({ type: 'active' });
+      setLastRefresh(new Date());
+    });
+  };
+
+  return (
+    <Tooltip content={
+      <Trans 
+        i18nKey="common.refreshDataTooltip"
+        components={{
+          br: <br/>,
+        }}
+        values={{
+          lastRefresh: formatDateTime({ value: lastRefresh })
+        }}
+        />
+    }>
+      <Button
+        variant="plain"
+        onClick={handleRefresh}
+        isLoading={isRefreshing}
+        icon={<SyncIcon />}
+      />
+    </Tooltip>
+  );
+}

--- a/api/src/main/webui/src/components/home/ClustersTable.tsx
+++ b/api/src/main/webui/src/components/home/ClustersTable.tsx
@@ -19,7 +19,9 @@ import {
   ToolbarContent,
   ToolbarItem,
   SearchInput,
+  Tooltip,
 } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 import { KafkaCluster } from '@/api/types';
 import { NoDataEmptyState, NoResultsEmptyState } from '@/components/EmptyStates';
 
@@ -141,11 +143,16 @@ export function ClustersTable({
       <Table aria-label={t('kafka.clusterList', 'Kafka clusters')} variant="compact">
         <Thead>
           <Tr>
-            <Th width={25} sort={getSortParams('name')}>{t('kafka.name', 'Name')}</Th>
-            <Th>{t('kafka.namespace', 'Namespace')}</Th>
-            <Th>{t('kafka.version', 'Kafka Version')}</Th>
-            <Th>{t('kafka.status', 'Status')}</Th>
-            <Th modifier="fitContent">{t('common.actions', 'Actions')}</Th>
+            <Th width={25} sort={getSortParams('name')}>{t('kafka.name')}</Th>
+            <Th>{t('kafka.namespace')}</Th>
+            <Th>{t('kafka.version')}</Th>
+            <Th>
+              {t('kafka.status')}{' '}
+              <Tooltip content={t('kafka.statusTooltip')}>
+                <HelpIcon />
+              </Tooltip>
+            </Th>
+            <Th modifier="fitContent">{t('common.actions')}</Th>
           </Tr>
         </Thead>
         <Tbody>

--- a/api/src/main/webui/src/components/kafka/overview/ClusterChartsCard.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/ClusterChartsCard.tsx
@@ -91,7 +91,7 @@ export function ClusterChartsCard({
     if (metricsData) {
       // Extract disk usage metrics
       const usageSeries = timeSeriesMetrics(metricsData.ranges, 'volume_stats_used_bytes');
-      const availableSeries = timeSeriesMetrics(metricsData.ranges, 'volume_stats_available_bytes');
+      const availableSeries = timeSeriesMetrics(metricsData.ranges, 'volume_stats_capacity_bytes');
       
       Object.assign(usages, usageSeries);
       Object.assign(available, availableSeries);

--- a/api/src/main/webui/src/components/kafka/overview/RecentTopicsCard.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/RecentTopicsCard.tsx
@@ -17,14 +17,17 @@ import {
   Divider,
   EmptyState,
   EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
   Title,
   List,
   ListItem,
   Content,
   Tooltip,
 } from '@patternfly/react-core';
-import { CubesIcon, HelpIcon } from '@patternfly/react-icons';
+import { CubesIcon, HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { ViewedTopic } from '@/api/hooks/useViewedTopics';
+import { useShowLearning } from '@/hooks/useShowLearning';
 
 export interface RecentTopicsCardProps {
   viewedTopics: ViewedTopic[];
@@ -37,6 +40,7 @@ export function RecentTopicsCard({
 }: RecentTopicsCardProps) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(true);
+  const showLearning = useShowLearning();
 
   return (
     <Card component="div" isFullHeight isExpanded={isExpanded} isCompact>
@@ -74,6 +78,20 @@ export function RecentTopicsCard({
               <EmptyStateBody>
                 {t('RecentTopicsCard.no_recent_topics_description')}
               </EmptyStateBody>
+              {showLearning && (
+                <EmptyStateFooter>
+                  <EmptyStateActions>
+                    <a
+                      href={t('learning.links.topicOperatorUse')}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ fontSize: 'var(--pf-v6-global--FontSize--sm)' }}
+                    >
+                      {t('learning.labels.topicOperatorUse')} <ExternalLinkAltIcon />
+                    </a>
+                  </EmptyStateActions>
+                </EmptyStateFooter>
+              )}
             </EmptyState>
           ) : (
             <>

--- a/api/src/main/webui/src/components/kafka/overview/filters/FilterByBroker.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/filters/FilterByBroker.tsx
@@ -17,7 +17,7 @@ import {
 
 interface FilterByBrokerProps {
   brokerIds: string[];
-  value: string | null; // null means "All Brokers"
+  value: string | null; // null means "All Nodes"
   onChange: (brokerId: string | null) => void;
   isDisabled?: boolean;
 }
@@ -33,7 +33,7 @@ export function FilterByBroker({
 
   const selectedLabel = value
     ? `Node ${value}`
-    : t('metrics.all_brokers') || 'All brokers';
+    : t('metrics.all_nodes');
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
@@ -69,7 +69,7 @@ export function FilterByBroker({
     >
       <SelectList>
         <SelectOption key="all" value="all">
-          {t('metrics.all_brokers') || 'All brokers'}
+          {t('metrics.all_nodes')}
         </SelectOption>
         {brokerIds.map((brokerId) => (
           <SelectOption key={brokerId} value={brokerId}>

--- a/api/src/main/webui/src/components/kafka/overview/utils/chartConsts.ts
+++ b/api/src/main/webui/src/components/kafka/overview/utils/chartConsts.ts
@@ -10,6 +10,6 @@ export const getHeight = (legendEntriesCount: number) => {
 export const getPadding = (legendEntriesCount: number) => ({
   bottom: 50 + 32 * legendEntriesCount,
   top: 5,
-  left: 70,
+  left: 90,
   right: 30,
 });

--- a/api/src/main/webui/src/hooks/useShowLearning.ts
+++ b/api/src/main/webui/src/hooks/useShowLearning.ts
@@ -1,0 +1,16 @@
+/**
+ * Hook to access the showLearning configuration option
+ * 
+ * This hook fetches the showLearning setting from the metadata API endpoint.
+ * The setting controls whether learning/documentation links are displayed
+ * throughout the application.
+ * 
+ * @returns boolean - Whether to show learning links (defaults to true if not set)
+ */
+
+import { useMetadata } from '@/api/hooks/useMetadata';
+
+export function useShowLearning(): boolean {
+  const { data: metadata } = useMetadata();
+  return metadata?.data?.attributes?.options?.showLearning ?? true;
+}

--- a/api/src/main/webui/src/i18n/messages/en.json
+++ b/api/src/main/webui/src/i18n/messages/en.json
@@ -31,7 +31,8 @@
     "noEntityDescription": "There are currently no {{entity}} to display.",
     "noResultsFound": "No results found",
     "noResultsFoundDescription": "No results match the filter criteria. Clear all filters and try again.",
-    "clearAllFilters": "Clear all filters"
+    "clearAllFilters": "Clear all filters",
+    "refreshDataTooltip": "Refresh data<br/>Last update: {{lastRefresh}}"
   },
   "about": {
     "buttonLabel": "About",
@@ -58,6 +59,12 @@
     "dark": "Dark",
     "darkDescription": "Always use dark mode"
   },
+  "home": {
+    "title": "Home",
+    "recommendedLearningResources": "Recommended learning resources",
+    "documentation": "Documentation",
+    "viewDocumentation": "View documentation"
+  },
   "kafka": {
     "clusters": "Kafka Clusters",
     "selectCluster": "Kafka Clusters",
@@ -68,6 +75,7 @@
     "name": "Name",
     "version": "Kafka Version",
     "status": "Status",
+    "statusTooltip": "Status is only available for Kafka clusters managed by a Strimzi Kafka resource.",
     "namespace": "Namespace",
     "connectedClusters": "Connected Kafka clusters",
     "filterByName": "Filter by name",
@@ -80,7 +88,7 @@
     "topics": "Topics",
     "consumerGroups": "Consumer Groups",
     "groups": "Groups",
-    "nodes": "Nodes",
+    "nodes": "Kafka Nodes",
     "users": "Kafka Users",
     "schemaRegistry": "Schema Registry",
     "connect": {
@@ -132,11 +140,12 @@
     "tableLabel": "Topics table",
     "columnName": "Name",
     "columnStatus": "Status",
+    "columnStatusTooltip": "Indicates the replication status of the partitions in the Kafka topic. A partition is fully replicated when its replicas (followers) are 'in-sync' with the designated partition leader. A partition is under-replicated if partition replicas (followers) are not 'in-sync' with their designated partition leader. If the status shows unavailable, some or all partitions are currently unavailable due to underlying issues.",
     "columnPartitions": "Partitions",
     "columnGroups": "Groups",
     "columnStorage": "Storage",
     "hideInternalTopics": "Hide internal topics",
-    "hideInternalTopicsTooltip": "Internal topics are used by Kafka for internal operations and are typically hidden from users",
+    "hideInternalTopicsTooltip": "By convention internal topics are prefixed with __. These topics are usually created and managed by Kafka.",
     "filter": {
       "name": "Name",
       "topicId": "Topic ID",
@@ -300,6 +309,9 @@
     "state": "State",
     "members": "Members",
     "noGroups": "No groups found",
+    "alert": "Group types identify how Kafka client applications coordinate work. Types include Classic, Consumer, Share, and Streams. Consumer groups use a newer protocol than Classic groups.",
+    "learnMore": "Learn more",
+    "learnMoreLink": "https://www.streamshub.io/docs/StreamsHub-Console/main/#con-groups-page-str",
     "type": "Type",
     "typeTooltip": "The Kafka group type, such as Classic, Consumer, Streams, or Share.",
     "protocol": "Protocol",
@@ -404,7 +416,7 @@
     }
   },
   "nodes": {
-    "title": "Nodes",
+    "title": "Kafka Nodes",
     "brokerTitle": "Broker {{nodeId}}",
     "nodeId": "Node ID",
     "brokerId": "Broker ID",
@@ -412,14 +424,14 @@
     "hostName": "Host name",
     "port": "Port",
     "rack": "Rack",
-    "rackTooltip": "The rack ID for this node, used for rack-aware replica assignment",
+    "rackTooltip": "Represents the ID of the rack or datacenter in which the broker resides.",
     "nodePool": "Node Pool",
     "allNodePoolsPlaceholder": "All node pools",
     "roles": "Roles",
     "status": "Status",
     "statusPlaceholder": "All statuses",
     "replicas": "Total Replicas",
-    "replicasTooltip": "Total number of partition replicas (leaders + followers) on this broker",
+    "replicasTooltip": "The overall count of partition replicas hosted by the broker. Replicas provide fault tolerance and data availability.",
     "diskUsage": "Disk usage",
     "kafkaVersion": "Kafka version",
     "leadController": "Lead controller",
@@ -476,14 +488,14 @@
     "distribution": {
       "title": "Partition distribution",
       "totalNodes": "Total nodes",
-      "totalNodesTooltip": "Total number of nodes in the cluster (brokers + controllers)",
+      "totalNodesTooltip": "Total number of Kafka nodes across all roles (broker, controller, or combined).",
       "controllerRole": "Controller role",
       "brokerRole": "Broker role",
       "leadController": "Lead controller",
-      "leadControllerTooltip": "The node that is currently the active controller",
+      "leadControllerTooltip": "The Lead Controller (also known as the Active Controller) is the primary metadata manager in a KRaft-based Kafka cluster. It maintains a global view of the cluster, processes metadata updates, and distributes them to all other nodes.",
       "leadControllerValue": "Node {{leadController}}",
       "partitionsDistributionOfTotal": "Node Partition Distribution",
-      "partitionsDistributionOfTotalTooltip": "Distribution of partition replicas across broker nodes",
+      "partitionsDistributionOfTotalTooltip": "The percentage distribution of partitions across brokers in the cluster. Consider rebalancing if the distribution is uneven to ensure efficient resource utilization.",
       "distributionToggles": "Distribution filter toggles",
       "allLabel": "All ({{count}})",
       "leadersLabel": "Leaders ({{count}})",
@@ -529,6 +541,9 @@
     "addBrokersModeDescription": "Moves replicas to newly added brokers. Brokers must be specified",
     "removeBrokersMode": "Remove",
     "removeBrokersModeDescription": "Moves replicas off brokers to be removed. Brokers must be specified",
+    "alert": "Cruise Control is enabled",
+    "learnMore": "Learn more about Cruise Control enablement",
+    "learnMoreLink": "https://strimzi.io/docs/operators/latest/deploying#cruise-control-concepts-str",
     "noRebalances": "No Kafka cluster rebalances found",
     "noRebalancesDescription": "Configure a KafkaRebalance resource to generate optimization proposals and initiate rebalances for your Kafka cluster.",
     "noRebalancesAction": "Learn more about Kafka rebalancing",
@@ -657,7 +672,7 @@
   "ClusterCard": {
     "Kafka_cluster_details": "Kafka cluster details",
     "online_brokers": "Online brokers",
-    "consumer_groups": "Consumer groups",
+    "consumer_groups": "Groups",
     "kafka_version": "Kafka version",
     "cluster_errors_and_warnings": "Cluster errors and warnings",
     "no_messages": "No errors or warnings"
@@ -681,15 +696,15 @@
     "header": "Cluster overview",
     "description": "Key performance indicators and important information regarding the Kafka cluster.",
     "topic_header": "Topics",
-    "total_topics": "Total topics",
-    "total_partitions": "Total partitions",
+    "total_topics": "topics",
+    "total_partitions": "partitions",
     "fully_replicated_partition": "Fully replicated",
-    "fully_replicated_partition_tooltip": "Partitions that have all replicas in sync with the leader",
+    "fully_replicated_partition_tooltip": "All partitions are fully replicated. A partition is fully-replicated when its replicas (followers) are 'in sync' with the designated partition leader. Replicas are 'in sync' if they have fetched records up to the log end offset of the leader partition within an allowable lag time, as determined by replica.lag.time.max.ms.",
     "under_replicated_partition": "Under-replicated",
-    "under_replicated_partition_tooltip": "Partitions with one or more replicas that are not in sync with the leader",
-    "unavailable_partition": "Offline",
-    "unavailable_partition_tooltip": "Partitions that have no available replicas",
-    "view_all_topics": "View all topics",
+    "under_replicated_partition_tooltip": "Some partitions are not fully replicated. A partition is fully replicated when its replicas (followers) are 'in sync' with the designated partition leader. Replicas are 'in sync' if they have fetched records up to the log end offset of the leader partition within an allowable lag time, as determined by replica.lag.time.max.ms.",
+    "unavailable_partition": "Unavailable",
+    "unavailable_partition_tooltip": "Some or all partitions are currently unavailable. This may be due to issues such as broker failures or network problems. Investigate and address the underlying issues to restore normal functionality.",
+    "view_all_topics": "View all",
     "ErrorsAndWarnings": {
       "tooltip": "Issues encountered in the Kafka cluster. Investigate and address these issues to ensure continued operation of the cluster."
     }
@@ -712,17 +727,21 @@
   "learning": {
     "labels": {
       "overview": "Strimzi Overview",
-      "connecting": "Connect to a Kafka cluster from an application"
+      "gettingStarted": "Getting Started with StreamsHub",
+      "connecting": "Connect to a Kafka cluster from an application",
+      "topicOperatorUse": "Using the Topic Operator to manage Kafka topics"
     },
     "links": {
       "overview": "https://strimzi.io/docs/operators/latest/overview",
-      "connecting": ""
+      "gettingStarted": "",
+      "connecting": "",
+      "topicOperatorUse": "https://strimzi.io/docs/operators/latest/overview#overview-concepts-topic-operator-str"
     }
   },
   "topicMetricsCard": {
     "topic_metric": "Topic metrics",
     "topics_bytes_incoming_and_outgoing": "Topics bytes incoming and outgoing",
-    "topics_bytes_incoming_and_outgoing_tooltip": "Rate of data being produced to and consumed from topics",
+    "topics_bytes_incoming_and_outgoing_tooltip": "Bytes incoming and outgoing are the total bytes for all topics or total bytes for a selected topic in the Kafka cluster. This metric enables you to assess data transfer in and out of your Kafka cluster. To modify incoming and outgoing bytes, you can adjust topic message size or other topic properties as needed.",
     "charts_coming_soon": "Charts coming soon",
     "charts_implementation_pending": "Chart visualization will be implemented in a future update",
     "no_topics": "No topics available",
@@ -740,8 +759,8 @@
     "not_available": "N/A"
   },
   "metrics": {
-    "all_topics": "All topics",
-    "all_brokers": "All brokers"
+    "all_topics": "All Topics",
+    "all_nodes": "All Nodes"
   },
   "ChartDiskUsage": {
     "data_unavailable": "Disk usage data unavailable"

--- a/api/src/main/webui/src/pages/HomePage.tsx
+++ b/api/src/main/webui/src/pages/HomePage.tsx
@@ -11,9 +11,24 @@ import {
   EmptyState,
   EmptyStateBody,
   Spinner,
+  Card,
+  CardTitle,
+  CardBody,
+  CardHeader,
+  CardExpandableContent,
+  DataList,
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  Label,
+  Content,
+  Divider,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useKafkaClusters } from '../api/hooks/useKafkaClusters';
 import { useMetadata } from '../api/hooks/useMetadata';
+import { useShowLearning } from '../hooks/useShowLearning';
 import { AppLayout } from '@/components/app/AppLayout';
 import { ClustersTable } from '@/components/home/ClustersTable';
 
@@ -65,6 +80,9 @@ export function HomePage() {
     setFilterName(name);
     setPage(1); // Reset to first page when filter changes
   };
+
+  const showLearning = useShowLearning();
+  const [isLearningExpanded, setIsLearningExpanded] = useState(false);
 
   if (isLoading) {
     return (
@@ -125,6 +143,153 @@ export function HomePage() {
           onFilterNameChange={handleFilterNameChange}
         />
       </PageSection>
+      {showLearning && (
+        <PageSection>
+          <Card
+            component="div"
+            isFullHeight
+            isExpanded={isLearningExpanded}
+            isCompact
+          >
+            <CardHeader onExpand={() => setIsLearningExpanded(!isLearningExpanded)}>
+              <Content>
+                <CardTitle>
+                  {t('home.recommendedLearningResources')}
+                </CardTitle>
+                {!isLearningExpanded && (
+                  <Content component="small">
+                    <Label color="orange" isCompact>
+                      {t('home.documentation')}
+                    </Label>
+                  </Content>
+                )}
+              </Content>
+            </CardHeader>
+            <CardExpandableContent>
+              <CardBody>
+                <Divider />
+                <DataList
+                  aria-label={t('home.recommendedLearningResources')}
+                  isCompact
+                  style={{ paddingTop: '1rem' }}
+                >
+                  <DataListItem aria-labelledby="learning-overview">
+                    <DataListItemRow style={{ alignItems: 'center', minHeight: '3rem' }}>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="overview-label" width={2} style={{ display: 'flex', alignItems: 'center' }}>
+                            <span id="learning-overview">{t('learning.labels.overview')}</span>
+                          </DataListCell>,
+                          <DataListCell key="overview-type" style={{ display: 'flex', alignItems: 'center' }}>
+                            <Label color="orange" isCompact>
+                              {t('home.documentation')}
+                            </Label>
+                          </DataListCell>,
+                          <DataListCell key="overview-link" style={{ display: 'flex', alignItems: 'center' }}>
+                            <a
+                              href={t('learning.links.overview')}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {t('home.viewDocumentation')} <ExternalLinkAltIcon />
+                            </a>
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+
+                  {t('learning.links.gettingStarted') && (
+                    <DataListItem aria-labelledby="learning-getting-started">
+                      <DataListItemRow style={{ alignItems: 'center', minHeight: '3rem' }}>
+                        <DataListItemCells
+                          dataListCells={[
+                            <DataListCell key="getting-started-label" width={2} style={{ display: 'flex', alignItems: 'center' }}>
+                              <span id="learning-getting-started">
+                                {t('learning.labels.gettingStarted')}
+                              </span>
+                            </DataListCell>,
+                            <DataListCell key="getting-started-type" style={{ display: 'flex', alignItems: 'center' }}>
+                              <Label color="orange" isCompact>
+                                {t('home.documentation')}
+                              </Label>
+                            </DataListCell>,
+                            <DataListCell key="getting-started-link" style={{ display: 'flex', alignItems: 'center' }}>
+                              <a
+                                href={t('learning.links.gettingStarted')}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {t('home.viewDocumentation')} <ExternalLinkAltIcon />
+                              </a>
+                            </DataListCell>,
+                          ]}
+                        />
+                      </DataListItemRow>
+                    </DataListItem>
+                  )}
+
+                  {t('learning.links.connecting') && (
+                    <DataListItem aria-labelledby="learning-connecting">
+                      <DataListItemRow style={{ alignItems: 'center', minHeight: '3rem' }}>
+                        <DataListItemCells
+                          dataListCells={[
+                            <DataListCell key="connecting-label" width={2} style={{ display: 'flex', alignItems: 'center' }}>
+                              <span id="learning-connecting">{t('learning.labels.connecting')}</span>
+                            </DataListCell>,
+                            <DataListCell key="connecting-type" style={{ display: 'flex', alignItems: 'center' }}>
+                              <Label color="orange" isCompact>
+                                {t('home.documentation')}
+                              </Label>
+                            </DataListCell>,
+                            <DataListCell key="connecting-link" style={{ display: 'flex', alignItems: 'center' }}>
+                              <a
+                                href={t('learning.links.connecting')}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {t('home.viewDocumentation')} <ExternalLinkAltIcon />
+                              </a>
+                            </DataListCell>,
+                          ]}
+                        />
+                      </DataListItemRow>
+                    </DataListItem>
+                  )}
+
+                  <DataListItem aria-labelledby="learning-topic-operator">
+                    <DataListItemRow style={{ alignItems: 'center', minHeight: '3rem' }}>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="topic-operator-label" width={2} style={{ display: 'flex', alignItems: 'center' }}>
+                            <span id="learning-topic-operator">
+                              {t('learning.labels.topicOperatorUse')}
+                            </span>
+                          </DataListCell>,
+                          <DataListCell key="topic-operator-type" style={{ display: 'flex', alignItems: 'center' }}>
+                            <Label color="orange" isCompact>
+                              {t('home.documentation')}
+                            </Label>
+                          </DataListCell>,
+                          <DataListCell key="topic-operator-link" style={{ display: 'flex', alignItems: 'center' }}>
+                            <a
+                              href={t('learning.links.topicOperatorUse')}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {t('home.viewDocumentation')} <ExternalLinkAltIcon />
+                            </a>
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                </DataList>
+              </CardBody>
+            </CardExpandableContent>
+          </Card>
+        </PageSection>
+      )}
     </AppLayout>
   );
 }

--- a/api/src/main/webui/src/pages/kafka/groups/GroupsPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/groups/GroupsPage.tsx
@@ -19,6 +19,11 @@ import {
   SelectList,
   MenuToggle,
   MenuToggleElement,
+  Alert,
+  AlertActionLink,
+  AlertActionCloseButton,
+  Grid,
+  GridItem,
 } from '@patternfly/react-core';
 import { useGroups } from '@/api/hooks/useGroups';
 import { GroupsTable } from '@/components/kafka/groups/GroupsTable';
@@ -33,6 +38,7 @@ import {
   NoResultsEmptyState,
 } from '@/components/EmptyStates';
 import { useTableState } from '@/hooks';
+import { useShowLearning } from '@/hooks/useShowLearning';
 
 const GROUP_TYPES: GroupType[] = ['Classic', 'Consumer', 'Share', 'Streams'];
 
@@ -51,6 +57,7 @@ type SortableColumn = 'groupId' | 'type' | 'protocol' | 'state';
 export function GroupsPage() {
   const { t } = useTranslation();
   const { kafkaId } = useParams<{ kafkaId: string }>();
+  const showLearning = useShowLearning();
 
   // Table state (pagination + sorting)
   const table = useTableState<SortableColumn>({
@@ -64,6 +71,9 @@ export function GroupsPage() {
   const [selectedStates, setSelectedStates] = useState<GroupState[]>([]);
   const [isTypeSelectOpen, setIsTypeSelectOpen] = useState(false);
   const [isStateSelectOpen, setIsStateSelectOpen] = useState(false);
+
+  // Alert state
+  const [isAlertVisible, setIsAlertVisible] = useState(true);
 
   // Reset offset modal state
   const [isResetOffsetModalOpen, setIsResetOffsetModalOpen] = useState(false);
@@ -134,7 +144,31 @@ export function GroupsPage() {
         </Title>
       </PageSection>
       <PageSection>
-        <Toolbar>
+        <Grid hasGutter>
+          {showLearning && isAlertVisible && (
+            <GridItem>
+              <Alert
+                variant="info"
+                isInline
+                title={t('groups.alert')}
+                actionClose={
+                  <AlertActionCloseButton onClose={() => setIsAlertVisible(false)} />
+                }
+                actionLinks={
+                  <AlertActionLink
+                    component="a"
+                    href={t('groups.learnMoreLink')}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t('groups.learnMore')}
+                  </AlertActionLink>
+                }
+              />
+            </GridItem>
+          )}
+          <GridItem>
+            <Toolbar>
           <ToolbarContent>
             <ToolbarItem>
               <SearchInput
@@ -230,48 +264,50 @@ export function GroupsPage() {
               />
             </ToolbarItem>
           </ToolbarContent>
-        </Toolbar>
+            </Toolbar>
 
-      {isLoading ? (
-        <LoadingEmptyState />
-      ) : groups.length === 0 ? (
-        searchValue || selectedTypes.length > 0 || selectedStates.length > 0 ? (
-          <NoResultsEmptyState />
-        ) : (
-          <NoDataEmptyState
-            entityName="groups"
-            message="No groups are currently available in this Kafka cluster."
-          />
-        )
-      ) : (
-        <>
-          <GroupsTable
-            groups={groups}
-            kafkaId={kafkaId!}
-            sortBy={table.sortBy}
-            sortDirection={table.sortDirection}
-            onSort={table.handleSort}
-            onResetOffset={handleResetOffset}
-          />
-          <Toolbar>
-            <ToolbarContent>
-              <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
-                <Pagination
-                  itemCount={totalItems}
-                  perPage={table.pageSize}
-                  page={currentPage}
-                  onSetPage={() => {}}
-                  onPerPageSelect={table.handlePerPageChange}
-                  onNextClick={table.handleNextPage}
-                  onPreviousClick={table.handlePrevPage}
-                  variant={PaginationVariant.bottom}
-                  isCompact
+            {isLoading ? (
+              <LoadingEmptyState />
+            ) : groups.length === 0 ? (
+              searchValue || selectedTypes.length > 0 || selectedStates.length > 0 ? (
+                <NoResultsEmptyState />
+              ) : (
+                <NoDataEmptyState
+                  entityName="groups"
+                  message="No groups are currently available in this Kafka cluster."
                 />
-              </ToolbarItem>
-            </ToolbarContent>
-          </Toolbar>
-        </>
-      )}
+              )
+              ) : (
+                <>
+                  <GroupsTable
+                    groups={groups}
+                    kafkaId={kafkaId!}
+                    sortBy={table.sortBy}
+                    sortDirection={table.sortDirection}
+                    onSort={table.handleSort}
+                    onResetOffset={handleResetOffset}
+                  />
+                  <Toolbar>
+                    <ToolbarContent>
+                      <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
+                        <Pagination
+                          itemCount={totalItems}
+                          perPage={table.pageSize}
+                          page={currentPage}
+                          onSetPage={() => {}}
+                          onPerPageSelect={table.handlePerPageChange}
+                          onNextClick={table.handleNextPage}
+                          onPreviousClick={table.handlePrevPage}
+                          variant={PaginationVariant.bottom}
+                          isCompact
+                        />
+                      </ToolbarItem>
+                    </ToolbarContent>
+                  </Toolbar>
+                </>
+              )}
+          </GridItem>
+        </Grid>
       </PageSection>
 
       {selectedGroup && (

--- a/api/src/main/webui/src/pages/kafka/nodes/NodesRebalancesTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/nodes/NodesRebalancesTab.tsx
@@ -35,10 +35,12 @@ import { RebalancesTable } from '@/components/kafka/nodes/RebalancesTable';
 import { RebalancesCountCard } from '@/components/kafka/nodes/RebalancesCountCard';
 import { Rebalance, RebalanceStatus, RebalanceMode } from '@/api/types';
 import { useTableState } from '@/hooks';
+import { useShowLearning } from '@/hooks/useShowLearning';
 
 export function NodesRebalancesTab() {
   const { t } = useTranslation();
   const { kafkaId } = useParams<{ kafkaId: string }>();
+  const showLearning = useShowLearning();
 
   // Alert state
   const [isAlertVisible, setIsAlertVisible] = useState(true);
@@ -153,7 +155,7 @@ export function NodesRebalancesTab() {
     return (
       <PageSection isFilled>
         <Grid hasGutter>
-          {isAlertVisible && (
+          {showLearning && isAlertVisible && (
             <GridItem>
               <Alert
                 variant="info"

--- a/api/src/main/webui/src/pages/kafka/overview/KafkaOverview.tsx
+++ b/api/src/main/webui/src/pages/kafka/overview/KafkaOverview.tsx
@@ -24,6 +24,7 @@ import { useTopics } from '@/api/hooks/useTopics';
 import { useGroups } from '@/api/hooks/useGroups';
 import { useNodes } from '@/api/hooks/useNodes';
 import { useViewedTopics } from '@/api/hooks/useViewedTopics';
+import { useShowLearning } from '@/hooks/useShowLearning';
 import { OverviewLayout } from '@/components/kafka/overview/OverviewLayout';
 import { ClusterCard } from '@/components/kafka/overview/ClusterCard';
 import { ClusterChartsCard } from '@/components/kafka/overview/ClusterChartsCard';
@@ -39,6 +40,7 @@ function KafkaOverviewContent() {
   const { t } = useTranslation();
   const { kafkaId } = useParams<{ kafkaId: string }>();
   const openConnectionPanel = useOpenClusterConnectionPanel();
+  const showLearning = useShowLearning();
 
   // Fetch cluster data with conditions field
   const { data: clusterData, isLoading: clusterLoading } = useKafkaCluster(kafkaId, {
@@ -125,7 +127,7 @@ function KafkaOverviewContent() {
   const isLoading = clusterLoading || topicsSummaryLoading || groupsLoading;
 
   return (
-    <ClusterConnectionDrawer cluster={cluster} showLearning={true}>
+    <ClusterConnectionDrawer cluster={cluster} showLearning={showLearning}>
       <PageSection>
         <Flex
           justifyContent={{ default: 'justifyContentSpaceBetween' }}
@@ -141,7 +143,7 @@ function KafkaOverviewContent() {
           </FlexItem>
           <FlexItem>
             <Button
-              variant="secondary"
+              variant="primary"
               onClick={() => kafkaId && openConnectionPanel(kafkaId)}
             >
               {t('ConnectButton.cluster_connection_details')}

--- a/api/src/main/webui/src/pages/kafka/topics/TopicsPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/TopicsPage.tsx
@@ -53,12 +53,14 @@ import {
   NoResultsEmptyState,
 } from '@/components/EmptyStates';
 import { useTableState } from '@/hooks';
+import { useShowLearning } from '@/hooks/useShowLearning';
 
 type SortableColumn = 'name' | 'totalLeaderLogBytes';
 
 export function TopicsPage() {
   const { t } = useTranslation();
   const { kafkaId } = useParams<{ kafkaId: string }>();
+  const showLearning = useShowLearning();
   
   const [includeHidden, setIncludeHidden] = useState(false);
 
@@ -276,6 +278,14 @@ export function TopicsPage() {
             <NoDataEmptyState
               entityName="topics"
               message={t('topics.noTopicsDescription')}
+              learningLink={
+                showLearning && t('learning.links.topicOperatorUse')
+                  ? {
+                      href: t('learning.links.topicOperatorUse'),
+                      label: t('learning.labels.topicOperatorUse'),
+                    }
+                  : undefined
+              }
             />
           )
         ) : (
@@ -284,7 +294,12 @@ export function TopicsPage() {
               <Thead>
                 <Tr>
                   <Th sort={table.getSortParams('name')}>{t('topics.columnName')}</Th>
-                  <Th>{t('topics.columnStatus')}</Th>
+                  <Th>
+                    {t('topics.columnStatus')}{' '}
+                    <Tooltip content={t('topics.columnStatusTooltip')}>
+                      <HelpIcon />
+                    </Tooltip>
+                  </Th>
                   <Th modifier="fitContent" style={{ textAlign: 'right' }}>{t('topics.columnPartitions')}</Th>
                   <Th modifier="fitContent" style={{ textAlign: 'right' }}>{t('topics.columnGroups')}</Th>
                   <Th sort={table.getSortParams('totalLeaderLogBytes')} modifier="fitContent" style={{ textAlign: 'right' }}>{t('topics.columnStorage')}</Th>

--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -44,6 +44,8 @@ import io.xlate.validation.constraints.Expression;
 @Buildable(editableEnabled = false)
 public class ConsoleConfig {
 
+    OptionsConfig options = new OptionsConfig();
+
     KubernetesConfig kubernetes = new KubernetesConfig();
 
     @Valid
@@ -104,6 +106,14 @@ public class ConsoleConfig {
     public void clearSecurity() {
         security = new GlobalSecurityConfig();
         kafka.getClusters().forEach(k -> k.setSecurity(new KafkaSecurityConfig()));
+    }
+
+    public OptionsConfig getOptions() {
+        return options;
+    }
+
+    public void setOptions(OptionsConfig options) {
+        this.options = options;
     }
 
     public KubernetesConfig getKubernetes() {

--- a/common/src/main/java/com/github/streamshub/console/config/OptionsConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/OptionsConfig.java
@@ -1,0 +1,21 @@
+package com.github.streamshub.console.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.sundr.builder.annotations.Buildable;
+
+@JsonInclude(Include.NON_NULL)
+@Buildable(editableEnabled = false)
+public class OptionsConfig {
+
+    boolean showLearning = true;
+
+    public boolean isShowLearning() {
+        return showLearning;
+    }
+
+    public void setShowLearning(boolean showLearning) {
+        this.showLearning = showLearning;
+    }
+}

--- a/ui/tests/playwright/NodePropertyPage.test.tsx
+++ b/ui/tests/playwright/NodePropertyPage.test.tsx
@@ -6,7 +6,7 @@ test.beforeEach(async ({ authenticatedPage }) => {
 
 test("Node property page", async ({ page, authenticatedPage }) => {
   await test.step("Navigate to node property page", async () => {
-    await page.click('text="Nodes"');
+    await page.click('text="Kafka Nodes"');
     await expect(page.getByRole('columnheader', { name: 'Node ID' })).toBeVisible();
     await authenticatedPage.clickFirstLinkInTheTable("nodes-listing");
     await expect(page.getByRole('columnheader', { name: 'Property' })).toBeVisible();

--- a/ui/tests/playwright/NodesPage.test.tsx
+++ b/ui/tests/playwright/NodesPage.test.tsx
@@ -6,7 +6,7 @@ test.beforeEach(async ({ authenticatedPage }) => {
 
 test("Nodes page", async ({ page, authenticatedPage }) => {
   await test.step("Navigate to nodes page", async () => {
-    await authenticatedPage.clickLink('Nodes', "sidebar");
+    await authenticatedPage.clickLink('Kafka Nodes', "sidebar");
     await expect(page.getByRole('columnheader', { name: 'Rack' })).toBeVisible();
   });
   await test.step("Nodes page should display table", async () => {

--- a/ui/tests/playwright/auth.setup.ts
+++ b/ui/tests/playwright/auth.setup.ts
@@ -5,7 +5,9 @@ setup("authenticate", async ({ page }) => {
   await page.goto("./");
   //await page.waitForURL("**/login", { waitUntil: "commit" });
   //await page.getByRole("button", { name: 'Click to login anonymously' }).click();
-  //page.getByRole("button", { name: 'View' }).nth(0).click();
+  if (process.env.TEST_KAFKA_INDEX) {
+    page.getByRole("button", { name: 'View' }).nth(process.env.TEST_KAFKA_INDEX).click();
+  }
   await page.waitForURL("**/overview", { waitUntil: "commit" });
   await expect(page.getByRole("heading", { name: "Cluster overview" }),).toBeVisible();
   const newPage = page.mainFrame();


### PR DESCRIPTION
Work for several items identified in #2505 and also listed below.

---

### Landing Page
- Missing Recommended learning resources

### Cluster Overview Page
#### Page Header
- Missing Last updated time stamp and refresh button (added data reload button in masthead for use on any page)
- Cluster connection details button has a different style: before: filled blue no border / after: transparent with border

#### Kafka cluster details card
- Text under metrics difference: before "groups" after "consumer groups"

#### Recent topics card
- no docs link to "Using the Topic Operator to manage Kafka topics.

#### Cluster metrics card
- Difference in text on filter dropdown, before: "All Nodes" / after: "All brokers"
- Used disk space chart appears to have a different scale. Also it appears to be missing certain lines - I can't be sure but before the changes there appear to be all the dashed lines plotted for storage thresholds whereas after it appears to be missing them.

#### Topics card
- Changes to text: Before red exclamation point is "Unavailable" after is "Offline".
- Change in link text: before "View all" after "View all Topics"
- Changes to text: before: "14 topics | 114 partitions" after "114 Total topics | 114 Total partitions"
- Tooltips are vastly different, far more information is given before the changes than after.

#### Topic metrics
- Tooltip text next to Hide internal topics is different, after the change it doesn't have the information about internal topics being prefixed with an _

### Topics page
- Missing last updated timestamp and refresh button (added data reload button in masthead for use on any page)
- Missing tooltip next to the Status column title after changes.

### Kafka Nodes page
- One the primary navbar this page is called Kafka nodes before and is called Nodes after

### Kafka Connect Page
- Missing last updated timestamp and refresh button (added data reload button in masthead for use on any page)

### Groups page
- Missing last updated timestamp and refresh button (added data reload button in masthead for use on any page)
- Missing info banner with "Group types identify how kafka client applications coordinate work…… learn more link"
