### PR TITLE
Log error response body stream when received from metrics retrieval

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/service/MetricsService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/MetricsService.java
@@ -1,5 +1,9 @@
 package com.github.streamshub.console.api.service;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -132,7 +136,7 @@ public class MetricsService {
                 Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
                 Instant start = now.minus(durationMinutes, ChronoUnit.MINUTES);
                 Instant end = now;
-            
+
                 String step = calculateStep(durationMinutes);
 
                 return prometheusAPI.queryRange(query, start, end, step);
@@ -154,21 +158,21 @@ public class MetricsService {
 
     private String calculateStep(int durationMinutes) {
         if (durationMinutes <= 15) {
-            return "15s";   
+            return "15s";
         }
         if (durationMinutes <= 60) {
-            return "1m";  
-        } 
+            return "1m";
+        }
         if (durationMinutes <= 360) {
-            return "5m";  
-        } 
+            return "5m";
+        }
         if (durationMinutes <= 1440) {
-            return "15m"; 
+            return "15m";
         }
         if (durationMinutes <= 2880) {
-            return "30m"; 
+            return "30m";
         }
-        return "2h";                               
+        return "2h";
     }
 
     <M> CompletionStage<Map<String, List<M>>> fetchMetrics(
@@ -179,9 +183,15 @@ public class MetricsService {
             try {
                 return extractMetrics(operation.get(), builder);
             } catch (WebApplicationException wae) {
-                logger.warnf("Failed to retrieve Kafka cluster metrics, status %d: %s",
+                var entity = wae.getResponse().getEntity();
+
+                if (entity instanceof InputStream stream) {
+                    entity = readStream(stream);
+                }
+
+                logger.warnf("Failed to retrieve Kafka cluster metrics, status %d: '%s'",
                         wae.getResponse().getStatus(),
-                        wae.getResponse().getEntity());
+                        entity);
                 return Collections.emptyMap();
             } catch (Exception e) {
                 logger.warnf(e, "Failed to retrieve Kafka cluster metrics");
@@ -209,5 +219,32 @@ public class MetricsService {
                 return Map.entry(metricName, builder.apply(metric, attributes));
             })
             .collect(groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, toList())));
+    }
+
+    /**
+     * Reads up to 200 characters from the response stream as a string
+     * for logging.
+     */
+    private String readStream(InputStream stream) {
+        StringBuilder buffer = new StringBuilder();
+
+        try (Reader reader = new InputStreamReader(stream)) {
+            char[] data = new char[201];
+            int length = reader.read(data);
+
+            if (length > 0) {
+                buffer.append(data, 0, Math.min(length, 200));
+
+                if (length > 200) {
+                    buffer.append("...");
+                }
+            }
+        } catch (IOException ioe) {
+            logger.warnf(ioe, "Error deserializing metrics response error body");
+            buffer.setLength(0);
+            buffer.append("<Unknown>");
+        }
+
+        return buffer.toString();
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceMetricsIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceMetricsIT.java
@@ -1,6 +1,8 @@
 package com.github.streamshub.console.api;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Base64;
@@ -10,6 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 import jakarta.inject.Inject;
 import jakarta.json.Json;
@@ -25,11 +28,16 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.eclipse.microprofile.config.Config;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 import com.github.streamshub.console.api.model.KafkaCluster;
 import com.github.streamshub.console.api.service.MetricsService;
@@ -38,6 +46,7 @@ import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.config.KafkaClusterConfig;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.test.AdminClientSpy;
+import com.github.streamshub.console.test.LogCapture;
 import com.github.streamshub.console.test.TestHelper;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -50,16 +59,23 @@ import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import static com.github.streamshub.console.test.TestHelper.whenRequesting;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 
 @QuarkusTest
 @TestHTTPEndpoint(KafkaClustersResource.class)
@@ -70,6 +86,11 @@ class KafkaClustersResourceMetricsIT implements ClientRequestFilter {
             .add("data", Json.createObjectBuilder()
                     .add("result", Json.createArrayBuilder()))
             .build();
+
+    static LogCapture logCapture = LogCapture.with(logRecord -> logRecord
+            .getLoggerName()
+            .equals(MetricsService.class.getName()),
+            Level.WARNING);
 
     @Inject
     Config config;
@@ -94,6 +115,16 @@ class KafkaClustersResourceMetricsIT implements ClientRequestFilter {
     Consumer<ClientRequestContext> filterQuery;
     Consumer<ClientRequestContext> filterQueryRange;
 
+    @BeforeAll
+    static void initialize() {
+        logCapture.register();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        logCapture.deregister();
+    }
+
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
         var requestUri = requestContext.getUri();
@@ -110,6 +141,7 @@ class KafkaClustersResourceMetricsIT implements ClientRequestFilter {
         filterQuery = ctx -> { /* No-op */ };
         filterQueryRange = ctx -> { /* No-op */ };
         metricsService.setAdditionalFilter(Optional.of(this));
+        logCapture.records().clear();
 
         String metricsSource;
 
@@ -364,6 +396,93 @@ class KafkaClustersResourceMetricsIT implements ClientRequestFilter {
             .body("data.attributes.metrics", allOf(
                     hasEntry(is("values"), anEmptyMap()),
                     hasEntry(is("ranges"), anEmptyMap())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        """
+        EXPECTED: Prometheus error""",
+        """
+        EXPECTED: Prometheus error\
+        01234567890123456789012345678901234567890123456789\
+        01234567890123456789012345678901234567890123456789\
+        01234567890123456789012345678901234567890123456789\
+        012345678901234567890123""",
+        """
+        EXPECTED: Prometheus error\
+        01234567890123456789012345678901234567890123456789\
+        01234567890123456789012345678901234567890123456789\
+        01234567890123456789012345678901234567890123456789\
+        0123456789012345678901234"""
+    })
+    void testDescribeClusterWithMetricsErrorStream(String responseBody) {
+        filterQuery = ctx -> {
+            Response error = Response.status(Status.SERVICE_UNAVAILABLE)
+                    .entity(new ByteArrayInputStream(responseBody.getBytes()))
+                    .build();
+            throw new WebApplicationException(error);
+        };
+
+        filterQueryRange = ctx -> {
+            throw new RuntimeException("EXPECTED");
+        };
+
+        whenRequesting(req -> req
+                .param("fields[" + KafkaCluster.API_TYPE + "]", "name,metrics")
+                .get("{clusterId}", clusterId1))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("data.attributes.name", equalTo("test-kafka1"))
+            .body("data.attributes.metrics", allOf(
+                    hasEntry(is("values"), anEmptyMap()),
+                    hasEntry(is("ranges"), anEmptyMap())));
+
+        var logs = logCapture.records();
+        var expected = responseBody.length() > 200 ? responseBody.substring(0, 200) + "..." : responseBody;
+
+        assertThat(logs, hasItem(hasProperty("message", containsString(
+                "status %d: '%s'".formatted(Status.SERVICE_UNAVAILABLE.getStatusCode(), expected)
+        ))));
+    }
+
+    @Test
+    void testDescribeClusterWithMetricsErrorStreamException() throws IOException {
+        InputStream stream = Mockito.mock(InputStream.class);
+        IOException thrown = new IOException("EXPECTED");
+
+        Mockito.when(stream.read(any(byte[].class), eq(0), anyInt())).thenAnswer(args -> {
+            throw thrown;
+        });
+
+        filterQuery = ctx -> {
+            Response error = Response.status(Status.SERVICE_UNAVAILABLE)
+                    .entity(stream)
+                    .build();
+            throw new WebApplicationException(error);
+        };
+
+        filterQueryRange = ctx -> {
+            throw new RuntimeException("EXPECTED");
+        };
+
+        whenRequesting(req -> req
+                .param("fields[" + KafkaCluster.API_TYPE + "]", "name,metrics")
+                .get("{clusterId}", clusterId1))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("data.attributes.name", equalTo("test-kafka1"))
+            .body("data.attributes.metrics", allOf(
+                    hasEntry(is("values"), anEmptyMap()),
+                    hasEntry(is("ranges"), anEmptyMap())));
+
+        var logs = logCapture.records();
+
+        assertThat(logs, hasItem(hasProperty("thrown", equalTo(thrown))));
+
+        assertThat(logs, hasItem(hasProperty("message", containsString(
+                "status %d: '%s'".formatted(Status.SERVICE_UNAVAILABLE.getStatusCode(), "<Unknown>")
+        ))));
     }
 
     @Test


### PR DESCRIPTION
Improves the logging of an error response body received when calling Prometheus for metrics.

Before, the messages are like below (notice input stream object default `toString` is displayed)
```
WARN  [com.git.str.con.api.ser.MetricsService] Failed to retrieve Kafka cluster metrics, status 401: io.netty.buffer.ByteBufInputStream@47bd2d1d
```

After:
```
WARN  [com.git.str.con.api.ser.MetricsService] Failed to retrieve Kafka cluster metrics, status 401: Unauthorized
```