### PR TITLE
Bump Quarkus LTS from 3.27 to 3.33, project updates

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/security/ConsoleAuthenticationMechanism.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/ConsoleAuthenticationMechanism.java
@@ -169,11 +169,7 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
 
             var response = context.response();
             response.setStatusCode(challengeData.status);
-
-            if (challengeData.headerName != null) {
-                response.headers().set(challengeData.headerName, challengeData.headerContent);
-            }
-
+            challengeData.getHeaders().forEach(response.headers()::set);
             response.headers().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
 
             try {
@@ -479,7 +475,7 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
         }
 
         public PayloadChallengeData(ChallengeData data, Object payload) {
-            super(data.status, data.headerName, data.headerContent);
+            super(data.status, data.getHeaders());
             this.payload = payload;
         }
     }

--- a/api/src/main/java/com/github/streamshub/console/api/support/TrustedTlsConfiguration.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/TrustedTlsConfiguration.java
@@ -203,5 +203,10 @@ class TrustedTlsConfiguration extends BaseTlsConfiguration {
         public Optional<String> provider() {
             return Optional.empty();
         }
+
+        @Override
+        public Optional<List<Path>> certDirs() {
+            return Optional.empty();
+        }
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/api/GroupsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/GroupsResourceIT.java
@@ -1,7 +1,10 @@
 package com.github.streamshub.console.api;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -11,7 +14,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 import jakarta.json.Json;
@@ -46,8 +51,9 @@ import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -841,11 +847,23 @@ class GroupsResourceIT {
         }
     }
 
+    static Stream<Arguments> testPatchConsumerGroupWithInvalidRequestCases() throws IOException {
+        try (var stream = GroupsResourceIT.class.getResourceAsStream("/patchConsumerGroup-invalid-requests.txt")) {
+            String text = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            return Arrays.stream(text.split("@"))
+                    .filter(Predicate.not(String::isBlank))
+                    .map(rec -> rec.split("\\|"))
+                    .map(elements -> Arguments.of(
+                            elements[0].strip(),
+                            elements[1].strip(),
+                            Status.valueOf(elements[2].strip()),
+                            elements[3].strip()
+                        ));
+        }
+    }
+
     @ParameterizedTest
-    @CsvFileSource(
-        delimiter = '|',
-        lineSeparator = "@\n",
-        resources = { "/patchConsumerGroup-invalid-requests.txt" })
+    @MethodSource("testPatchConsumerGroupWithInvalidRequestCases")
     void testPatchConsumerGroupWithInvalidRequest(String label, String requestBody, Status responseStatus, String expectedResponse)
             throws JSONException {
 

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -1,10 +1,13 @@
 package com.github.streamshub.console.api;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -75,8 +79,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.AggregateWith;
-import org.junit.jupiter.params.provider.CsvFileSource;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -2145,11 +2150,23 @@ class TopicsResourceIT {
             .body("data.attributes.configs.'retention.ms'.value", is("300000"));
     }
 
+    static Stream<Arguments> testPatchTopicWithInvalidRequestCases() throws IOException {
+        try (var stream = TopicsResourceIT.class.getResourceAsStream("/patchTopic-invalid-requests.txt")) {
+            String text = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            return Arrays.stream(text.split("@"))
+                    .filter(Predicate.not(String::isBlank))
+                    .map(rec -> rec.split("\\|"))
+                    .map(elements -> Arguments.of(
+                            elements[0].strip(),
+                            elements[1].strip(),
+                            Status.valueOf(elements[2].strip()),
+                            elements[3].strip()
+                        ));
+        }
+    }
+
     @ParameterizedTest
-    @CsvFileSource(
-        delimiter = '|',
-        lineSeparator = "@\n",
-        resources = { "/patchTopic-invalid-requests.txt" })
+    @MethodSource("testPatchTopicWithInvalidRequestCases")
     void testPatchTopicWithInvalidRequest(String label, String requestBody, Status responseStatus, String expectedResponse)
             throws JSONException {
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- Dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.3.1</quarkus.platform.version>
+        <quarkus.platform.version>3.33.1.1</quarkus.platform.version>
         <strimzi-api.version>1.0.0</strimzi-api.version>
         <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
         <apicurio-registry.version>3.2.4</apicurio-registry.version>
@@ -118,7 +118,17 @@
             </dependency>
             <dependency>
                 <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-java-sdk</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-java-sdk-common</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serde-common</artifactId>
                 <version>${apicurio-registry.version}</version>
             </dependency>
             <dependency>

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/interfaces/TestBucketExtensionContext.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/interfaces/TestBucketExtensionContext.java
@@ -4,7 +4,6 @@ import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.MediaType;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -151,7 +150,7 @@ public class TestBucketExtensionContext implements ExtensionContext {
     }
 
     @Override
-    public <T> Optional<T> getConfigurationParameter(String key, Function<String, T> transformer) {
+    public <T> Optional<T> getConfigurationParameter(String key, Function<? super String, ? extends T> transformer) {
         return delegate.getConfigurationParameter(key, transformer);
     }
 
@@ -168,11 +167,6 @@ public class TestBucketExtensionContext implements ExtensionContext {
     @Override
     public void publishReportEntry(String value) {
         delegate.publishReportEntry(value);
-    }
-
-    @Override
-    public void publishFile(String name, MediaType mediaType, ThrowingConsumer<Path> action) {
-        delegate.publishFile(name, mediaType, action);
     }
 
     @Override
@@ -198,5 +192,10 @@ public class TestBucketExtensionContext implements ExtensionContext {
     @Override
     public ExecutableInvoker getExecutableInvoker() {
         return delegate.getExecutableInvoker();
+    }
+
+    @Override
+    public void publishFile(String name, org.junit.jupiter.api.MediaType mediaType, ThrowingConsumer<Path> action) {
+        delegate.publishFile(name, mediaType, action);
     }
 }


### PR DESCRIPTION
Updates Quarkus to 3.33 LTS. This also includes a bump to JUnit 6. The `@CsvFileSource` no longer supports custom `lineSeparate` so the tests using it have been rewritten to use a `@MethodSource` instead.