### PR TITLE
Form-based Kafka SCRAM and OAUTHBEARER authentication

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -191,12 +191,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -301,6 +301,7 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>

--- a/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/ClientFactory.java
@@ -484,9 +484,8 @@ public class ClientFactory {
              * so here we will only retrieve them (if applicable) and
              * set them in the admin configuration map.
              */
-            var adminConfigs = maybeAuthenticate(identity, ctx, Admin.class);
-            var admin = adminBuilder.apply(adminConfigs);
-            return new KafkaContext(ctx, filter.apply(admin));
+            var admin = createAdmin(filter, adminBuilder, ctx, identity.getCredential(SaslJaasConfigCredential.class));
+            return new KafkaContext(ctx, admin);
         }
 
         return ctx;
@@ -499,7 +498,8 @@ public class ClientFactory {
     @Produces
     @RequestScoped
     public Consumer<RecordData, RecordData> consumerSupplier(SecurityIdentity identity, KafkaContext context) {
-        var configs = maybeAuthenticate(identity, context, Consumer.class);
+        var configs = maybeAuthenticate(
+                identity.getCredential(SaslJaasConfigCredential.class), context, Consumer.class);
 
         return new KafkaConsumer<>(
                 configs,
@@ -514,7 +514,9 @@ public class ClientFactory {
     @Produces
     @RequestScoped
     public Producer<RecordData, RecordData> producerSupplier(SecurityIdentity identity, KafkaContext context) {
-        var configs = maybeAuthenticate(identity, context, Producer.class);
+        var configs = maybeAuthenticate(
+                identity.getCredential(SaslJaasConfigCredential.class), context, Producer.class);
+
         return new KafkaProducer<>(
                 configs,
                 context.schemaRegistryContext().keySerializer(),
@@ -525,13 +527,22 @@ public class ClientFactory {
         producer.close();
     }
 
-    Map<String, Object> maybeAuthenticate(SecurityIdentity identity, KafkaContext context, Class<?> clientType) {
+    public Admin createAdmin(UnaryOperator<Admin> filter,
+            Function<Map<String, Object>, Admin> adminBuilder,
+            KafkaContext context,
+            SaslJaasConfigCredential credential) {
+        var adminConfigs = maybeAuthenticate(credential, context, Admin.class);
+        var admin = adminBuilder.apply(adminConfigs);
+        return filter.apply(admin);
+    }
+
+    Map<String, Object> maybeAuthenticate(SaslJaasConfigCredential credential, KafkaContext context, Class<?> clientType) {
         Map<String, Object> configs = context.configs(clientType);
 
         if (configs.containsKey(SaslConfigs.SASL_MECHANISM)
                 && !configs.containsKey(SaslConfigs.SASL_JAAS_CONFIG)) {
             configs = new HashMap<>(configs);
-            configureAuthentication(identity, context.saslMechanism(clientType), configs);
+            configureAuthentication(credential, context.saslMechanism(clientType), configs);
         }
 
         return configs;
@@ -706,9 +717,7 @@ public class ClientFactory {
         }
     }
 
-    void configureAuthentication(SecurityIdentity identity, String saslMechanism, Map<String, Object> configs) {
-        SaslJaasConfigCredential credential = identity.getCredential(SaslJaasConfigCredential.class);
-
+    void configureAuthentication(SaslJaasConfigCredential credential, String saslMechanism, Map<String, Object> configs) {
         switch (saslMechanism) {
             case KafkaConfigs.MECHANISM_OAUTHBEARER:
                 configureOAuthBearer(credential, configs);

--- a/api/src/main/java/com/github/streamshub/console/api/MetadataResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/MetadataResource.java
@@ -2,6 +2,7 @@ package com.github.streamshub.console.api;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -76,6 +77,9 @@ public class MetadataResource {
                 .orElseGet(this::determinePlatform));
         meta.put("options", Map.of(
                 "showLearning", consoleConfig.getOptions().isShowLearning()
+        ));
+        meta.put("security", Map.of(
+                "oidcEnabled", Objects.nonNull(consoleConfig.getSecurity().getOidc())
         ));
 
         var replacementMetadata = Optional.<Map<String, Object>>of(Map.of(

--- a/api/src/main/java/com/github/streamshub/console/api/security/ConsoleAuthenticationMechanism.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/ConsoleAuthenticationMechanism.java
@@ -1,86 +1,47 @@
 package com.github.streamshub.console.api.security;
 
 import java.io.IOException;
-import java.security.Permission;
-import java.security.Principal;
-import java.util.Base64;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-import jakarta.json.JsonString;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
-import org.jose4j.jwt.JwtClaims;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.streamshub.console.api.ClientFactory;
 import com.github.streamshub.console.api.model.jsonapi.JsonApiError;
 import com.github.streamshub.console.api.model.jsonapi.JsonApiErrors;
 import com.github.streamshub.console.api.support.ErrorCategory;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.config.ConsoleConfig;
-import com.github.streamshub.console.config.KafkaClusterConfig;
-import com.github.streamshub.console.config.security.Decision;
-import com.github.streamshub.console.config.security.KafkaSecurityConfig;
-import com.github.streamshub.console.config.security.SubjectConfig;
 import com.github.streamshub.console.support.RootCause;
 
 import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
-import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
-import io.quarkus.security.AuthenticationFailedException;
-import io.quarkus.security.credential.Credential;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
 import io.quarkus.security.identity.request.AuthenticationRequest;
-import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
 import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
-import io.quarkus.security.runtime.QuarkusPrincipal;
-import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.FormAuthConfig.CookieSameSite;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.security.Form;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
 
 @Alternative
 @Priority(1)
 @ApplicationScoped
 public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechanism {
-
-    public static final String OAUTHBEARER = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
-    public static final String PLAIN = "PLAIN";
-    public static final String SCRAM_SHA256 = "SCRAM-SHA-256";
-    public static final String SCRAM_SHA512 = "SCRAM-SHA-512";
-
-    private static final String BEARER = "Bearer ";
-    private static final String BASIC = "Basic ";
-
-    static final String FULL_NAME = "fullName";
-
-    private static final SecurityIdentity ANONYMOUS = QuarkusSecurityIdentity.builder()
-            .setAnonymous(true)
-            .setPrincipal(new QuarkusPrincipal("ANONYMOUS"))
-            .addAttribute(FULL_NAME, "Anonymous")
-            .build();
 
     private static final Set<String> UNAUTHENTICATED_PATHS = Set.of(
             "/health",
@@ -99,13 +60,27 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
     ConsoleConfig consoleConfig;
 
     @Inject
-    Map<String, KafkaContext> contexts;
+    KafkaContext.Manager contextManager;
 
     @Inject
-    PermissionCache permissionCache;
+    IdentitySupport identities;
 
     @Inject
     OidcAuthenticationMechanism oidc;
+
+    public static HttpAuthenticationMechanism form(String clusterId) {
+        String securedPath = "/api/kafkas/" + clusterId;
+        return Form.builder()
+                        .httpOnlyCookie()
+                        .postLocation("/api/kafkas/" + clusterId + "/session")
+                        .usernameParameter("u")
+                        .passwordParameter("p")
+                        .cookieName("streamshub-console-kafka-" + clusterId)
+                        .cookiePath(securedPath)
+                        .cookieSameSite(CookieSameSite.STRICT)
+                        .landingPage(null)
+                        .build();
+    }
 
     boolean oidcEnabled() {
         return Objects.nonNull(consoleConfig.getSecurity().getOidc());
@@ -121,7 +96,7 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
 
         if (oidcEnabled()) {
             return oidc.authenticate(context, identityProviderManager)
-                    .map(identity -> augmentIdentity(context, identity))
+                    .map(identity -> identities.augmentIdentity(context, identity))
                     .onFailure().invoke(this::logAuthenticationFailure);
         }
 
@@ -134,30 +109,33 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
 
         if (clusterId == null) {
             // Let Kafka cluster listing (home page) be public when OIDC is not enabled
-            return Uni.createFrom().item(createAnonymousIdentity(null));
+            return Uni.createFrom().item(identities.createAnonymousIdentity(null));
         }
 
-        var ctx = contexts.get(clusterId);
+        var ctx = contextManager.acquire(clusterId);
 
         if (ctx == null) {
             // No Kafka context to establish identity, become anonymous
-            return Uni.createFrom().item(createAnonymousIdentity(null));
+            return Uni.createFrom().item(identities.createAnonymousIdentity(null));
         }
 
-        String saslMechanism = ctx.saslMechanism(Admin.class);
+        try {
+            String saslMechanism = ctx.saslMechanism(Admin.class);
 
-        if (ctx.admin() != null || saslMechanism.isEmpty()) {
-            // Admin credentials already given or there is no SASL authentication needed
-            return Uni.createFrom().item(createAnonymousIdentity(ctx));
+            if (ctx.admin() != null || saslMechanism.isEmpty()) {
+                // Admin credentials already given or there is no SASL authentication needed
+                return Uni.createFrom().item(identities.createAnonymousIdentity(ctx));
+            }
+
+            context.put("kafka.id", clusterId);
+            context.put("kafka.context", ctx);
+
+            return ctx.formAuthentication().authenticate(context, identityProviderManager)
+                .map(identity -> identities.augmentIdentity(context, identity))
+                .onFailure().invoke(this::logAuthenticationFailure);
+        } finally {
+            contextManager.release(ctx);
         }
-
-        var identity = createIdentity(ctx, context.request().headers(), saslMechanism);
-
-        if (identity != null) {
-            return Uni.createFrom().item(identity);
-        }
-
-        return Uni.createFrom().failure(new AuthenticationFailedException());
     }
 
     @Override
@@ -165,6 +143,11 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
         return getChallenge(context).map(challengeData -> {
             if (challengeData == null) {
                 return false;
+            }
+
+            if (!(challengeData instanceof PayloadChallengeData)) {
+                // This is challenge data from form-based login
+                return true;
             }
 
             var response = context.response();
@@ -206,31 +189,17 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
             return Uni.createFrom().nullItem();
         }
 
-        var ctx = contexts.get(clusterId);
+        var ctx = contextManager.acquire(clusterId);
 
         if (ctx == null) {
             return Uni.createFrom().nullItem();
         }
 
-        String saslMechanism = ctx.saslMechanism(Admin.class);
-        String scheme = getAuthorizationScheme(saslMechanism);
-        ChallengeData challenge;
-
-        if (scheme != null) {
-            var category = ErrorCategory.get(ErrorCategory.NotAuthenticated.class);
-            JsonApiError error = category.createError("Authentication credentials missing or invalid", null, null);
-            var responseBody = new JsonApiErrors(List.of(error));
-            challenge = new PayloadChallengeData(401, "WWW-Authenticate", scheme, responseBody);
-        } else {
-            log.warnf("Access not permitted to cluster %s with unknown SASL mechanism '%s'",
-                    clusterId, saslMechanism);
-            var category = ErrorCategory.get(ErrorCategory.ResourceNotFound.class);
-            JsonApiError error = category.createError(ClientFactory.NO_SUCH_KAFKA_MESSAGE.formatted(clusterId), null, null);
-            var responseBody = new JsonApiErrors(List.of(error));
-            challenge = new PayloadChallengeData(404, null, null, responseBody);
+        try {
+            return ctx.formAuthentication().getChallenge(context);
+        } finally {
+            contextManager.release(ctx);
         }
-
-        return Uni.createFrom().item(challenge);
     }
 
     @Override
@@ -239,11 +208,7 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
             return oidc.getCredentialTypes();
         }
 
-        return Set.of(
-            AnonymousAuthenticationRequest.class,
-            TokenAuthenticationRequest.class,
-            UsernamePasswordAuthenticationRequest.class
-        );
+        return Set.of(UsernamePasswordAuthenticationRequest.class, TrustedAuthenticationRequest.class);
     }
 
     private String getClusterId(RoutingContext context) {
@@ -255,157 +220,6 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
         return null;
     }
 
-    private String getAuthorizationScheme(String saslMechanism) {
-        switch (saslMechanism) {
-            case OAUTHBEARER:
-                return BEARER.trim();
-            case PLAIN, SCRAM_SHA256, SCRAM_SHA512:
-                return BASIC.trim();
-            default:
-                return null;
-        }
-    }
-
-    private SecurityIdentity createAnonymousIdentity(KafkaContext ctx) {
-        return createIdentity(ctx, ANONYMOUS);
-    }
-
-    private SecurityIdentity augmentIdentity(RoutingContext context, SecurityIdentity identity) {
-        if (identity != null) {
-            String clusterId = getClusterId(context);
-            var ctx = clusterId != null ? contexts.get(clusterId) : null;
-            return createIdentity(ctx, identity);
-        }
-        throw new AuthenticationFailedException();
-    }
-
-    private SecurityIdentity createIdentity(KafkaContext ctx, SecurityIdentity source) {
-        var builder = QuarkusSecurityIdentity.builder(source);
-        addRoleChecker(ctx, builder, source.getPrincipal());
-        return builder.build();
-    }
-
-    private SecurityIdentity createIdentity(KafkaContext ctx, MultiMap headers, String saslMechanism) {
-        switch (saslMechanism) {
-            case OAUTHBEARER:
-                return createOAuthIdentity(ctx, headers);
-            case PLAIN:
-                return createBasicIdentity(ctx, headers, SaslJaasConfigCredential::forPlainLogin);
-            case SCRAM_SHA256, SCRAM_SHA512:
-                return createBasicIdentity(ctx, headers, SaslJaasConfigCredential::forScramLogin);
-            default:
-                return null;
-        }
-    }
-
-    private SecurityIdentity createOAuthIdentity(KafkaContext ctx, MultiMap headers) {
-        return getAuthorization(headers, BEARER)
-            .map(accessToken -> {
-                var builder = QuarkusSecurityIdentity.builder();
-                builder.addCredential(SaslJaasConfigCredential.forOAuthLogin(accessToken));
-                Principal principal;
-
-                try {
-                    var claims = JwtClaims.parse(accessToken);
-                    principal = new OidcJwtCallerPrincipal(claims, null);
-                } catch (Exception e) {
-                    log.infof("JWT access token could not be parsed: %s", e.getMessage());
-                    principal = new QuarkusPrincipal("UNKNOWN");
-                }
-
-                builder.setPrincipal(principal);
-                addRoleChecker(ctx, builder, principal);
-                return builder.build();
-            })
-            .orElse(null);
-    }
-
-    private SecurityIdentity createBasicIdentity(KafkaContext ctx, MultiMap headers, BiFunction<String, String, Credential> credentialBuilder) {
-        return getBasicAuthentication(headers)
-            .map(userpass -> {
-                var builder = QuarkusSecurityIdentity.builder();
-                var principal = new QuarkusPrincipal(userpass[0]);
-                builder.addCredential(credentialBuilder.apply(userpass[0], userpass[1]));
-                builder.setPrincipal(principal);
-                addRoleChecker(ctx, builder, principal);
-                return builder.build();
-            })
-            .orElse(null);
-    }
-
-    private void addRoleChecker(KafkaContext ctx, QuarkusSecurityIdentity.Builder builder, Principal principal) {
-        var applicationPermissions = permissionCache.getPermissions();
-        var auditRules = permissionCache.getAuditRules();
-
-        if (applicationPermissions.isEmpty()) {
-            // No roles are defined - allow everything
-            builder.addPermissionChecker(requiredPermission -> {
-                auditLog(principal, requiredPermission, true, auditRules);
-                return Uni.createFrom().item(true);
-            });
-
-            return;
-        }
-
-        var roleNames = getPrincipalRoles(principal, ctx);
-
-        List<Permission> possessedPermissions = applicationPermissions
-                .entrySet()
-                .stream()
-                .filter(entry -> roleNames.contains(entry.getKey()))
-                .map(Map.Entry::getValue)
-                .flatMap(List::stream)
-                .toList();
-
-        builder.addPermissionChecker(requiredPermission -> {
-            var grantingPermission = possessedPermissions
-                    .stream()
-                    .filter(possessed -> possessed.implies(requiredPermission))
-                    .findFirst();
-
-            boolean allowed = grantingPermission.isPresent();
-
-            auditLog(principal, requiredPermission, allowed, auditRules);
-            return Uni.createFrom().item(allowed);
-        });
-    }
-
-    private Set<String> getPrincipalRoles(Principal principal, KafkaContext ctx) {
-        Stream<SubjectConfig> globalSubjects = consoleConfig
-                .getSecurity()
-                .getSubjects()
-                .stream();
-
-        Stream<SubjectConfig> clusterSubjects = Optional
-                .ofNullable(ctx)
-                .map(KafkaContext::clusterConfig)
-                .map(KafkaClusterConfig::getSecurity)
-                .map(KafkaSecurityConfig::getSubjects)
-                .map(Collection::stream)
-                .orElseGet(Stream::empty);
-
-        return Stream.concat(clusterSubjects, globalSubjects)
-                .filter(sub -> matchesPrincipal(sub, principal))
-                .flatMap(sub -> sub.getRoleNames().stream())
-                .distinct()
-                .collect(Collectors.toSet());
-    }
-
-    private void auditLog(Principal principal, Permission required, boolean allowed, Map<Permission, Decision> auditRules) {
-        if (required instanceof ConsolePermissionRequired consoleRequired && !consoleRequired.isAudited()) {
-            return;
-        }
-
-        for (Map.Entry<Permission, Decision> entry : auditRules.entrySet()) {
-            if (entry.getValue().logResult(allowed) && entry.getKey().implies(required)) {
-                log.infof("%s %s %s", principal.getName(), allowed ? "allowed" : "denied", required);
-                return;
-            }
-        }
-
-        log.tracef("%s %s %s", principal.getName(), allowed ? "allowed" : "denied", required);
-    }
-
     private void logAuthenticationFailure(Throwable t) {
         Throwable rootCause = RootCause.of(t).orElse(t);
 
@@ -414,56 +228,6 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
         } else {
             log.debugf("Authentication failed: %s", rootCause);
         }
-    }
-
-    private boolean matchesPrincipal(SubjectConfig subjectConfig, Principal principal) {
-        String claimName = subjectConfig.getClaim();
-        List<String> include = subjectConfig.getInclude();
-
-        if (claimName == null) {
-            return include.contains(principal.getName());
-        } else if (principal instanceof JsonWebToken jwt) {
-            Object claim = jwt.getClaim(claimName);
-
-            // array claim, like set/list of groups
-            if (claim instanceof Collection<?> values) {
-                for (Object value : values) {
-                    if (isIncluded(include, value)) {
-                        return true;
-                    }
-                }
-            } else {
-                return isIncluded(include, claim);
-            }
-        }
-
-        return false;
-    }
-
-    private static boolean isIncluded(List<String> include, Object value) {
-        if (value instanceof JsonString jsonString) {
-            value = jsonString.getString();
-        }
-
-        return value instanceof String && include.contains(value);
-    }
-
-    private Optional<String[]> getBasicAuthentication(MultiMap headers) {
-        return getAuthorization(headers, BASIC)
-            .map(Base64.getDecoder()::decode)
-            .map(String::new)
-            .filter(authn -> authn.indexOf(':') >= 0)
-            .map(authn -> new String[] {
-                authn.substring(0, authn.indexOf(':')),
-                authn.substring(authn.indexOf(':') + 1)
-            })
-            .filter(userPass -> !userPass[0].isEmpty() && !userPass[1].isEmpty());
-    }
-
-    private Optional<String> getAuthorization(MultiMap headers, String scheme) {
-        return Optional.ofNullable(headers.get(HttpHeaders.AUTHORIZATION))
-            .filter(header -> header.regionMatches(true, 0, scheme, 0, scheme.length()))
-            .map(header -> header.substring(scheme.length()));
     }
 
     private static class PayloadChallengeData extends ChallengeData {

--- a/api/src/main/java/com/github/streamshub/console/api/security/IdentitySupport.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/IdentitySupport.java
@@ -1,0 +1,268 @@
+package com.github.streamshub.console.api.security;
+
+import java.net.URI;
+import java.security.Permission;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonString;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.logging.Logger;
+
+import com.github.streamshub.console.api.support.KafkaContext;
+import com.github.streamshub.console.config.ConsoleConfig;
+import com.github.streamshub.console.config.KafkaClusterConfig;
+import com.github.streamshub.console.config.security.Decision;
+import com.github.streamshub.console.config.security.KafkaSecurityConfig;
+import com.github.streamshub.console.config.security.SubjectConfig;
+
+import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class IdentitySupport {
+
+    public static final String OAUTHBEARER = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+    public static final String PLAIN = "PLAIN";
+    public static final String SCRAM_SHA256 = "SCRAM-SHA-256";
+    public static final String SCRAM_SHA512 = "SCRAM-SHA-512";
+
+    public static final String FULL_NAME = "fullName";
+
+    private static final SecurityIdentity ANONYMOUS = QuarkusSecurityIdentity.builder()
+            .setAnonymous(true)
+            .setPrincipal(new QuarkusPrincipal("ANONYMOUS"))
+            .addAttribute(FULL_NAME, "Anonymous")
+            .build();
+
+    public static final String AUDIT_LOG_NAME = "io.streamshub.console.security.audit";
+    private static final Logger AUDIT = Logger.getLogger(AUDIT_LOG_NAME);
+
+    @Inject
+    OidcClients oidcClients;
+
+    @Inject
+    ConsoleConfig consoleConfig;
+
+    @Inject
+    Map<String, KafkaContext> contexts;
+
+    @Inject
+    PermissionCache permissionCache;
+
+    public SecurityIdentity createAnonymousIdentity(KafkaContext ctx) {
+        return createIdentity(ctx, ANONYMOUS);
+    }
+
+    public SecurityIdentity augmentIdentity(RoutingContext context, SecurityIdentity identity) {
+        if (identity != null) {
+            String clusterId = getClusterId(context);
+            var ctx = clusterId != null ? contexts.get(clusterId) : null;
+            return createIdentity(ctx, identity);
+        }
+        throw new AuthenticationFailedException("No identity found");
+    }
+
+    private String getClusterId(RoutingContext context) {
+        Pattern p = Pattern.compile("/api/kafkas/([^/]+)(?:/.*)?");
+        Matcher m = p.matcher(context.normalizedPath());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    private SecurityIdentity createIdentity(KafkaContext ctx, SecurityIdentity source) {
+        var builder = QuarkusSecurityIdentity.builder(source);
+        Principal principal = Optional.ofNullable(source.getAttribute("principal.name"))
+                .map(String.class::cast)
+                .map(QuarkusPrincipal::new)
+                .map(Principal.class::cast)
+                .orElseGet(source::getPrincipal);
+
+        builder.setPrincipal(principal);
+        addRoleChecker(ctx, builder, principal);
+        return builder.build();
+    }
+
+    public Uni<SaslJaasConfigCredential> createCredential(KafkaContext kafkaContext, UsernamePasswordAuthenticationRequest request) {
+        switch (kafkaContext.saslMechanism(Admin.class)) {
+            case OAUTHBEARER:
+                return createOAuthCredential(kafkaContext, request);
+            case PLAIN:
+                return Uni.createFrom().item(SaslJaasConfigCredential.forPlainLogin(
+                        request.getUsername(),
+                        new String(request.getPassword().getPassword())
+                ));
+            case SCRAM_SHA256, SCRAM_SHA512:
+                return Uni.createFrom().item(SaslJaasConfigCredential.forScramLogin(
+                        request.getUsername(),
+                        new String(request.getPassword().getPassword())
+                ));
+            default:
+                return null;
+        }
+    }
+
+    private Uni<SaslJaasConfigCredential> createOAuthCredential(
+            KafkaContext kafkaContext,
+            UsernamePasswordAuthenticationRequest request) {
+
+        var tokenUrl = kafkaContext.tokenUrl()
+                .orElseThrow(() -> new IllegalStateException("Token endpoint URL not available"));
+
+        var tokenPath = URI.create(tokenUrl).getPath();
+
+        if (tokenPath.isEmpty()) {
+            throw new IllegalArgumentException("Token endpoint URL missing path: " + tokenUrl);
+        }
+
+        var baseUrl = tokenUrl.substring(0, tokenUrl.indexOf(tokenPath));
+
+        // Build OIDC client config with user-provided credentials
+        var config = io.quarkus.oidc.client.runtime.OidcClientConfig.builder()
+                .id("streamshub-console-kafka-oidc-client-" + kafkaContext.clusterId())
+                .authServerUrl(baseUrl)
+                .discoveryEnabled(false)
+                .tokenPath(tokenPath)
+                .clientId(request.getUsername())
+                .credentials()
+                    .clientSecret(new String(request.getPassword().getPassword()))
+                    .end()
+                .grant(Grant.Type.CLIENT)
+                .build();
+
+        return oidcClients.newClient(config)
+                .onItem()
+                .transformToUni(client -> client.getTokens(Collections.emptyMap()))
+                .onItem()
+                // Create SASL/OAUTHBEARER credential with the access token
+                .transform(tokens -> SaslJaasConfigCredential.forOAuthLogin(tokens.getAccessToken()));
+    }
+
+    private void addRoleChecker(KafkaContext ctx, QuarkusSecurityIdentity.Builder builder, Principal principal) {
+        var applicationPermissions = permissionCache.getPermissions();
+        var auditRules = permissionCache.getAuditRules();
+
+        if (applicationPermissions.isEmpty()) {
+            // No roles are defined - allow everything
+            builder.addPermissionChecker(requiredPermission -> {
+                auditLog(principal, requiredPermission, true, auditRules);
+                return Uni.createFrom().item(true);
+            });
+
+            return;
+        }
+
+        var roleNames = getPrincipalRoles(principal, ctx);
+
+        List<Permission> possessedPermissions = applicationPermissions
+                .entrySet()
+                .stream()
+                .filter(entry -> roleNames.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .flatMap(List::stream)
+                .toList();
+
+        builder.addPermissionChecker(requiredPermission -> {
+            var grantingPermission = possessedPermissions
+                    .stream()
+                    .filter(possessed -> possessed.implies(requiredPermission))
+                    .findFirst();
+
+            boolean allowed = grantingPermission.isPresent();
+
+            auditLog(principal, requiredPermission, allowed, auditRules);
+            return Uni.createFrom().item(allowed);
+        });
+    }
+
+    private Set<String> getPrincipalRoles(Principal principal, KafkaContext ctx) {
+        Stream<SubjectConfig> globalSubjects = consoleConfig
+                .getSecurity()
+                .getSubjects()
+                .stream();
+
+        Stream<SubjectConfig> clusterSubjects = Optional
+                .ofNullable(ctx)
+                .map(KafkaContext::clusterConfig)
+                .map(KafkaClusterConfig::getSecurity)
+                .map(KafkaSecurityConfig::getSubjects)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
+
+        return Stream.concat(clusterSubjects, globalSubjects)
+                .filter(sub -> matchesPrincipal(sub, principal))
+                .flatMap(sub -> sub.getRoleNames().stream())
+                .distinct()
+                .collect(Collectors.toSet());
+    }
+
+    private void auditLog(Principal principal, Permission required, boolean allowed, Map<Permission, Decision> auditRules) {
+        if (required instanceof ConsolePermissionRequired consoleRequired && !consoleRequired.isAudited()) {
+            return;
+        }
+
+        for (Map.Entry<Permission, Decision> entry : auditRules.entrySet()) {
+            if (entry.getValue().logResult(allowed) && entry.getKey().implies(required)) {
+                AUDIT.infof("%s %s %s", principal.getName(), allowed ? "allowed" : "denied", required);
+                return;
+            }
+        }
+
+        AUDIT.tracef("%s %s %s", principal.getName(), allowed ? "allowed" : "denied", required);
+    }
+
+    private boolean matchesPrincipal(SubjectConfig subjectConfig, Principal principal) {
+        String claimName = subjectConfig.getClaim();
+        List<String> include = subjectConfig.getInclude();
+
+        if (claimName == null) {
+            return include.contains(principal.getName());
+        } else if (principal instanceof JsonWebToken jwt) {
+            Object claim = jwt.getClaim(claimName);
+
+            // array claim, like set/list of groups
+            if (claim instanceof Collection<?> values) {
+                for (Object value : values) {
+                    if (isIncluded(include, value)) {
+                        return true;
+                    }
+                }
+            } else {
+                return isIncluded(include, claim);
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isIncluded(List<String> include, Object value) {
+        if (value instanceof JsonString jsonString) {
+            value = jsonString.getString();
+        }
+
+        return value instanceof String && include.contains(value);
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/security/SaslJaasConfigCredential.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/SaslJaasConfigCredential.java
@@ -13,8 +13,10 @@ public class SaslJaasConfigCredential implements Credential {
             + " oauth.access.token=\"%s\" ;";
 
     private static final String BASIC_TEMPLATE = "%s required username=\"%%s\" password=\"%%s\" ;";
-    private static final String SASL_PLAIN_CONFIG_TEMPLATE = BASIC_TEMPLATE.formatted(PlainLoginModule.class.getName());
-    private static final String SASL_SCRAM_CONFIG_TEMPLATE = BASIC_TEMPLATE.formatted(ScramLoginModule.class.getName());
+    private static final String SASL_PLAIN_CONFIG_TEMPLATE = BASIC_TEMPLATE
+            .formatted(PlainLoginModule.class.getName());
+    private static final String SASL_SCRAM_CONFIG_TEMPLATE = BASIC_TEMPLATE
+            .formatted(ScramLoginModule.class.getName());
 
     public static SaslJaasConfigCredential forOAuthLogin(String accessToken) {
         return new SaslJaasConfigCredential(SASL_OAUTH_CONFIG_TEMPLATE.formatted(accessToken));
@@ -26,6 +28,10 @@ public class SaslJaasConfigCredential implements Credential {
 
     public static SaslJaasConfigCredential forScramLogin(String username, String password) {
         return new SaslJaasConfigCredential(SASL_SCRAM_CONFIG_TEMPLATE.formatted(username, password));
+    }
+
+    public static SaslJaasConfigCredential fromValue(String value) {
+        return new SaslJaasConfigCredential(value);
     }
 
     private final String value;

--- a/api/src/main/java/com/github/streamshub/console/api/security/SessionResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/SessionResource.java
@@ -81,12 +81,12 @@ public class SessionResource {
                 .flatMap(this::nameClaim)
                 .or(() -> nameClaim(oidcSession.getIdToken()));
         } else {
-            fullName = Optional.ofNullable(identity.getAttribute(ConsoleAuthenticationMechanism.FULL_NAME));
+            fullName = Optional.ofNullable(identity.getAttribute(IdentitySupport.FULL_NAME));
         }
 
         // this is not the `name` claim when the principal is a JWT
         properties.put("username", principal.getName());
-        fullName.ifPresent(fn -> properties.put(ConsoleAuthenticationMechanism.FULL_NAME, String.valueOf(fn)));
+        fullName.ifPresent(fn -> properties.put(IdentitySupport.FULL_NAME, String.valueOf(fn)));
         properties.put("anonymous", identity.isAnonymous());
 
         return Response.ok(properties).build();

--- a/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderLogin.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderLogin.java
@@ -67,8 +67,10 @@ public class KafkaIdentityProviderLogin implements IdentityProvider<UsernamePass
             SaslJaasConfigCredential credential) {
 
         var promise = new CompletableFuture<SecurityIdentity>();
-        var admin = clientFactory.createAdmin(filter, adminBuilder, kafkaContext, credential);
+        @SuppressWarnings("java:S2095") // Admin must remain open until async operation completes
+        Admin admin = clientFactory.createAdmin(filter, adminBuilder, kafkaContext, credential);
 
+        // Close admin after async operation completes (success or failure)
         promise.whenComplete((identity, error) -> {
             try {
                 admin.close();

--- a/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderLogin.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderLogin.java
@@ -10,6 +10,7 @@ import jakarta.inject.Inject;
 import jakarta.json.Json;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.jboss.logging.Logger;
 
 import com.github.streamshub.console.api.ClientFactory;
 import com.github.streamshub.console.api.security.IdentitySupport;
@@ -27,6 +28,9 @@ import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 public class KafkaIdentityProviderLogin implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+    @Inject
+    Logger logger;
 
     @Inject
     IdentitySupport identities;
@@ -63,26 +67,33 @@ public class KafkaIdentityProviderLogin implements IdentityProvider<UsernamePass
             SaslJaasConfigCredential credential) {
 
         var promise = new CompletableFuture<SecurityIdentity>();
+        var admin = clientFactory.createAdmin(filter, adminBuilder, kafkaContext, credential);
 
-        try (var admin = clientFactory.createAdmin(filter, adminBuilder, kafkaContext, credential)) {
-            admin.describeCluster()
-                    .clusterId()
-                    .toCompletionStage()
-                    .thenApply(clusterId -> {
-                        var principalJson = Json.createObjectBuilder()
-                                .add("name", principalName)
-                                .add("sasl.jaas.config", credential.value())
-                                .build();
+        promise.whenComplete((identity, error) -> {
+            try {
+                admin.close();
+            } catch (Exception e) {
+                logger.debug("Exception closing Admin client after login attempt", e);
+            }
+        });
 
-                        return QuarkusSecurityIdentity.builder()
-                                .setPrincipal(new QuarkusPrincipal(principalJson.toString()))
-                                .addAttribute("principal.name", principalName)
-                                .addCredential(credential)
-                                .build();
-                    })
-                    .thenApply(promise::complete)
-                    .exceptionally(promise::completeExceptionally);
-        }
+        admin.describeCluster()
+                .clusterId()
+                .toCompletionStage()
+                .thenApply(clusterId -> {
+                    var principalJson = Json.createObjectBuilder()
+                            .add("name", principalName)
+                            .add("sasl.jaas.config", credential.value())
+                            .build();
+
+                    return QuarkusSecurityIdentity.builder()
+                            .setPrincipal(new QuarkusPrincipal(principalJson.toString()))
+                            .addAttribute("principal.name", principalName)
+                            .addCredential(credential)
+                            .build();
+                })
+                .thenApply(promise::complete)
+                .exceptionally(promise::completeExceptionally);
 
         return Uni.createFrom().completionStage(promise);
     }

--- a/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderLogin.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderLogin.java
@@ -1,0 +1,89 @@
+package com.github.streamshub.console.api.security.kafka;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+
+import org.apache.kafka.clients.admin.Admin;
+
+import com.github.streamshub.console.api.ClientFactory;
+import com.github.streamshub.console.api.security.IdentitySupport;
+import com.github.streamshub.console.api.security.SaslJaasConfigCredential;
+import com.github.streamshub.console.api.support.KafkaContext;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class KafkaIdentityProviderLogin implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+    @Inject
+    IdentitySupport identities;
+
+    @Inject
+    ClientFactory clientFactory;
+
+    @Inject
+    UnaryOperator<Admin> filter;
+
+    @Inject
+    Function<Map<String, Object>, Admin> adminBuilder;
+
+    @Override
+    public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+        return UsernamePasswordAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest request,
+            AuthenticationRequestContext context) {
+
+        var routingContext = HttpSecurityUtils.getRoutingContextAttribute(request);
+        var kafkaContext = (KafkaContext) routingContext.get("kafka.context");
+
+        return identities.createCredential(kafkaContext, request)
+            .onItem()
+            .transformToUni(credential -> authenticate(kafkaContext, request.getUsername(), credential));
+    }
+
+    private Uni<SecurityIdentity> authenticate(
+            KafkaContext kafkaContext,
+            String principalName,
+            SaslJaasConfigCredential credential) {
+
+        var promise = new CompletableFuture<SecurityIdentity>();
+
+        try (var admin = clientFactory.createAdmin(filter, adminBuilder, kafkaContext, credential)) {
+            admin.describeCluster()
+                    .clusterId()
+                    .toCompletionStage()
+                    .thenApply(clusterId -> {
+                        var principalJson = Json.createObjectBuilder()
+                                .add("name", principalName)
+                                .add("sasl.jaas.config", credential.value())
+                                .build();
+
+                        return QuarkusSecurityIdentity.builder()
+                                .setPrincipal(new QuarkusPrincipal(principalJson.toString()))
+                                .addAttribute("principal.name", principalName)
+                                .addCredential(credential)
+                                .build();
+                    })
+                    .thenApply(promise::complete)
+                    .exceptionally(promise::completeExceptionally);
+        }
+
+        return Uni.createFrom().completionStage(promise);
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderTrusted.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaIdentityProviderTrusted.java
@@ -1,0 +1,48 @@
+package com.github.streamshub.console.api.security.kafka;
+
+import java.io.StringReader;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import com.github.streamshub.console.api.security.SaslJaasConfigCredential;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class KafkaIdentityProviderTrusted implements IdentityProvider<TrustedAuthenticationRequest> {
+
+    @Override
+    public Class<TrustedAuthenticationRequest> getRequestType() {
+        return TrustedAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(TrustedAuthenticationRequest request,
+            AuthenticationRequestContext context) {
+
+        var principal = request.getPrincipal();
+        JsonObject principalJson;
+
+        try (var reader = Json.createReader(new StringReader(principal))) {
+            principalJson = reader.readObject();
+
+            var identity = QuarkusSecurityIdentity.builder()
+                    .setPrincipal(new QuarkusPrincipal(principal))
+                    .addAttribute("principal.name", principalJson.getString("name"))
+                    .addCredential(SaslJaasConfigCredential.fromValue(principalJson.getString("sasl.jaas.config")))
+                    .build();
+
+            return Uni.createFrom().item(identity);
+        } catch (Exception e) {
+            return Uni.createFrom().failure(e);
+        }
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResource.java
@@ -1,0 +1,75 @@
+package com.github.streamshub.console.api.security.kafka;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+
+import com.github.streamshub.console.api.security.IdentitySupport;
+import com.github.streamshub.console.api.security.RedirectUriValidator;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.FormAuthenticationMechanism;
+
+@Path("kafkas/{clusterId}/session")
+public class KafkaSessionResource {
+
+    @Parameter(description = "Cluster identifier")
+    @PathParam("clusterId")
+    String clusterId;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    RedirectUriValidator redirectValidator;
+
+    @GET
+    @Path("user")
+    public Response getCurrentKafkaUser() {
+        Map<String, Object> properties = LinkedHashMap.newLinkedHashMap(3);
+        var principal = identity.getPrincipal();
+        Optional<String> fullName = Optional
+                .ofNullable(identity.getAttribute(IdentitySupport.FULL_NAME));
+
+        // this is not the `name` claim when the principal is a JWT
+        properties.put("username", principal.getName());
+        fullName.ifPresent(fn -> properties.put(IdentitySupport.FULL_NAME, String.valueOf(fn)));
+        properties.put("anonymous", identity.isAnonymous());
+
+        return Response.ok(properties).build();
+    }
+
+    @GET
+    @Path("logout")
+    public Response kafkaLogout(@QueryParam("redirect_uri") String redirectUri, UriInfo uriInfo) {
+        // Validate and sanitize the redirect URI to prevent open redirect vulnerabilities
+        URI safeRedirectUri = safeRedirectUri(redirectUri, uriInfo);
+        FormAuthenticationMechanism.logout(identity);
+        return Response.seeOther(safeRedirectUri).build();
+    }
+
+    private URI safeRedirectUri(String redirectUri, UriInfo uriInfo) {
+        // Validate and sanitize the redirect URI to prevent open redirect vulnerabilities
+        String safePath = redirectValidator.validateAndSanitize(redirectUri);
+
+        // Use the sanitized path together with the scheme, host, and port of the
+        // request to this resource.
+        return UriBuilder.fromUri(uriInfo.getRequestUri())
+            .replacePath(safePath)
+            .replaceQuery(null)
+            .fragment(null)
+            .build();
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/KafkaContext.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.streamshub.console.api.security.ConsoleAuthenticationMechanism;
 import com.github.streamshub.console.api.support.serdes.ForceCloseable;
 import com.github.streamshub.console.api.support.serdes.MultiformatDeserializer;
 import com.github.streamshub.console.api.support.serdes.MultiformatSerializer;
@@ -27,6 +28,7 @@ import com.github.streamshub.console.config.KafkaClusterConfig;
 import com.github.streamshub.console.config.SchemaRegistryConfig;
 
 import io.apicurio.registry.resolver.client.RegistryClientFacade;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaSpec;
@@ -142,6 +144,7 @@ public class KafkaContext implements Closeable {
     final Map<Class<?>, Map<String, Object>> configs;
     final Admin admin;
     boolean applicationScoped;
+    final HttpAuthenticationMechanism formAuthentication;
     SchemaRegistryContext schemaRegistryContext;
     PrometheusAPI prometheus;
 
@@ -151,6 +154,13 @@ public class KafkaContext implements Closeable {
         this.configs = Map.copyOf(configs);
         this.admin = admin;
         this.applicationScoped = true;
+
+        if (clusterConfig != null && admin == null) {
+            String id = clusterId(clusterConfig, Optional.ofNullable(resource));
+            this.formAuthentication = ConsoleAuthenticationMechanism.form(id);
+        } else {
+            this.formAuthentication = null;
+        }
     }
 
     public KafkaContext(KafkaContext other, Admin admin) {
@@ -239,6 +249,10 @@ public class KafkaContext implements Closeable {
         return applicationScoped;
     }
 
+    public HttpAuthenticationMechanism formAuthentication() {
+        return formAuthentication;
+    }
+
     public void schemaRegistryClient(RegistryClientFacade registryClient, SchemaRegistryConfig config, ObjectMapper objectMapper) {
         schemaRegistryContext = new SchemaRegistryContext(registryClient, config, objectMapper);
     }
@@ -275,14 +289,10 @@ public class KafkaContext implements Closeable {
                     .filter(listener -> listener.getName().equals(clusterConfig.getListener()))
                     .findFirst()
                     .map(GenericKafkaListener::getAuth)
-                    .map(authn -> {
-                        if (authn instanceof KafkaListenerAuthenticationCustom custom) {
-                            return tokenUrlCustom(custom);
-                        } else if (authn instanceof KafkaListenerAuthenticationOAuth oauth) {
-                            return oauth.getTokenEndpointUri();
-                        } else {
-                            return null;
-                        }
+                    .map(authn -> switch (authn) {
+                        case KafkaListenerAuthenticationCustom custom -> tokenUrlCustom(custom);
+                        case KafkaListenerAuthenticationOAuth oauth -> oauth.getTokenEndpointUri();
+                        default -> null;
                     }));
     }
 

--- a/api/src/main/webui/src/App.tsx
+++ b/api/src/main/webui/src/App.tsx
@@ -6,12 +6,15 @@
 import { Outlet } from 'react-router-dom';
 import { AppLayoutProvider } from '@/components/app/AppLayoutProvider';
 import { ThemeProvider } from '@/components/app/ThemeProvider';
+import { KafkaAuthProvider } from '@/components/auth/KafkaAuthProvider';
 
 function App() {
   return (
     <ThemeProvider>
       <AppLayoutProvider>
-        <Outlet />
+        <KafkaAuthProvider>
+          <Outlet />
+        </KafkaAuthProvider>
       </AppLayoutProvider>
     </ThemeProvider>
   );

--- a/api/src/main/webui/src/api/client.ts
+++ b/api/src/main/webui/src/api/client.ts
@@ -102,6 +102,23 @@ class ApiClient {
   }
 
   /**
+   * POST request with form-encoded body
+   */
+  postForm<T>(path: string, data: Record<string, string>, options?: RequestInit): Promise<T> {
+    const formBody = new URLSearchParams(data).toString();
+
+    return this.fetch<T>(path, {
+      ...options,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...options?.headers,
+      },
+      body: formBody,
+    });
+  }
+
+  /**
    * PATCH request
    */
   patch<T>(path: string, data: unknown, options?: RequestInit): Promise<T> {

--- a/api/src/main/webui/src/api/hooks/useKafkaAuth.ts
+++ b/api/src/main/webui/src/api/hooks/useKafkaAuth.ts
@@ -1,0 +1,27 @@
+/**
+ * TanStack Query hook for Kafka Cluster Authentication
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../client';
+
+/**
+ * Authenticate to a Kafka cluster using form authentication
+ */
+export function useKafkaAuth(clusterId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ username, password }: { username: string; password: string }) => {
+      // POST to /api/kafkas/{clusterId}/session with form parameters u and p
+      return apiClient.postForm<void>(`/api/kafkas/${clusterId}/session`, {
+        u: username,
+        p: password,
+      });
+    },
+    onSuccess: () => {
+      // Invalidate the session user query to refresh the user info in the masthead
+      queryClient.invalidateQueries({ queryKey: ['session-user', clusterId] });
+    },
+  });
+}

--- a/api/src/main/webui/src/api/hooks/useSession.ts
+++ b/api/src/main/webui/src/api/hooks/useSession.ts
@@ -8,11 +8,13 @@ import { apiClient } from '../client';
 /**
  * Fetch a single Kafka user by ID
  */
-export function useSessionUser() {
+export function useSessionUser(clusterId?: string) {
   return useQuery({
-    queryKey: ['session-user'],
+    queryKey: ['session-user', clusterId],
     queryFn: async () => {
-      const path = `/api/session/user`;
+      const path = clusterId
+        ? `/api/kafkas/${clusterId}/session/user`
+        : `/api/session/user`;
 
       return apiClient.get<{
         username: string,

--- a/api/src/main/webui/src/api/types.ts
+++ b/api/src/main/webui/src/api/types.ts
@@ -384,6 +384,9 @@ export interface Metadata {
     options: {
       showLearning: boolean;
     };
+    security: {
+      oidcEnabled: boolean;
+    };
   };
 }
 

--- a/api/src/main/webui/src/components/app/AppMasthead.tsx
+++ b/api/src/main/webui/src/components/app/AppMasthead.tsx
@@ -64,7 +64,9 @@ export function AppMasthead({
     setIsFeedbackModalOpen(false);
   };
 
-  const { data: sessionUser } = useSessionUser();
+  const sessionClusterId = metadata?.attributes.security.oidcEnabled ? undefined : currentClusterId;
+
+  const { data: sessionUser } = useSessionUser(sessionClusterId);
 
   const userDisplayName = useMemo(() => {
     if (!sessionUser) {
@@ -149,6 +151,7 @@ export function AppMasthead({
               </ToolbarGroup>
                 <UserDropdown
                   username={userDisplayName}
+                  clusterId={sessionClusterId}
                   anonymous={isAnonymous}
                 />
             </ToolbarContent>

--- a/api/src/main/webui/src/components/app/UserDropdown.tsx
+++ b/api/src/main/webui/src/components/app/UserDropdown.tsx
@@ -11,11 +11,12 @@ import { useTranslation } from 'react-i18next';
 
 interface UserDropdownProps {
   readonly username: string;
+  readonly clusterId?: string;
   readonly anonymous: boolean;
   readonly picture?: string;
 }
 
-export function UserDropdown({ username, anonymous, picture }: UserDropdownProps) {
+export function UserDropdown({ username, clusterId, anonymous, picture }: UserDropdownProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const logoutDisabled = anonymous;
@@ -55,7 +56,15 @@ export function UserDropdown({ username, anonymous, picture }: UserDropdownProps
       >
         <DropdownList>
           <DropdownItem key="logout" inert={logoutDisabled} isDisabled={logoutDisabled} onClick={() => {
-              window.location.href = `/api/session/logout?redirect_uri=${encodeURIComponent('/')}`;
+              let sessionPath;
+
+              if (clusterId) {
+                sessionPath = `/api/kafkas/${clusterId}/session`;
+              } else {
+                sessionPath = `/api/session`;
+              }
+
+              window.location.href = `${sessionPath}/logout?redirect_uri=${encodeURIComponent('/')}`;
             }}>
             {t('user.logout')}
           </DropdownItem>

--- a/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
+++ b/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
@@ -24,6 +24,13 @@ const initialAuthState = {
   pendingNavigation: undefined,
 };
 
+export type KafkaAuthShowLoginModalType = (
+  clusterId: string,
+  clusterName: string,
+  authMethod?: string,
+  pendingNavigation?: string
+) => void;
+
 interface KafkaAuthContextType {
   showLoginModal: (clusterId: string, clusterName: string, authMethod?: string, pendingNavigation?: string) => void;
   hideLoginModal: () => void;
@@ -132,6 +139,8 @@ export function KafkaAuthProvider({ children }: KafkaAuthProviderProps) {
       <QueryErrorHandler />
       {children}
       <KafkaLoginModal
+        // key forces a clean state when the modal is re-opened
+        key={authState.isModalOpen ? 'open' : 'closed'}
         isOpen={authState.isModalOpen}
         clusterName={authState.clusterName}
         authMethod={authState.authMethod}

--- a/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
+++ b/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
@@ -83,7 +83,7 @@ export function KafkaAuthProvider({ children }: KafkaAuthProviderProps) {
       if (targetClusterId) {
         // Get cluster name from the error context or use clusterId as fallback
         const clusterName = targetClusterId;
-        showLoginModal(targetClusterId, clusterName, window.location.pathname);
+        showLoginModal(targetClusterId, clusterName, undefined, window.location.pathname);
         return true; // Indicates the error was handled
       }
     }

--- a/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
+++ b/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
@@ -1,0 +1,144 @@
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { KafkaLoginModal } from './KafkaLoginModal';
+import { QueryErrorHandler } from './QueryErrorHandler';
+import { useKafkaAuth } from '@/api/hooks/useKafkaAuth';
+import { ApiError } from '@/api/client';
+
+interface AuthState {
+  isModalOpen: boolean;
+  clusterId: string;
+  clusterName: string;
+  authMethod?: string;
+  error?: string;
+  pendingNavigation?: string;
+}
+
+const initialAuthState = {
+  isModalOpen: false,
+  clusterId: '',
+  clusterName: '',
+  authMethod: undefined,
+  error: undefined,
+  pendingNavigation: undefined,
+};
+
+interface KafkaAuthContextType {
+  showLoginModal: (clusterId: string, clusterName: string, authMethod?: string, pendingNavigation?: string) => void;
+  hideLoginModal: () => void;
+  handleAuthError: (error: unknown, clusterId?: string) => boolean;
+}
+
+const KafkaAuthContext = createContext<KafkaAuthContextType | undefined>(undefined);
+
+export function useKafkaAuthContext() {
+  const context = useContext(KafkaAuthContext);
+  if (!context) {
+    throw new Error('useKafkaAuthContext must be used within KafkaAuthProvider');
+  }
+  return context;
+}
+
+interface KafkaAuthProviderProps {
+  children: ReactNode;
+}
+
+export function KafkaAuthProvider({ children }: KafkaAuthProviderProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { kafkaId } = useParams<{ kafkaId?: string }>();
+  
+  const [authState, setAuthState] = useState<AuthState>(initialAuthState);
+
+  const { mutateAsync: authenticate } = useKafkaAuth(authState.clusterId);
+
+  const showLoginModal = useCallback((clusterId: string, clusterName: string, authMethod?: string, pendingNavigation?: string) => {
+    setAuthState({
+      isModalOpen: true,
+      clusterId,
+      clusterName,
+      authMethod,
+      error: undefined,
+      pendingNavigation,
+    });
+  }, []);
+
+  const hideLoginModal = useCallback(() => {
+    setAuthState(initialAuthState);
+  }, []);
+
+  const handleAuthError = useCallback((error: unknown, clusterId?: string): boolean => {
+    // Check if this is a 401 error
+    if (error instanceof ApiError && error.status === 401) {
+      const targetClusterId = clusterId || kafkaId;
+      
+      if (targetClusterId) {
+        // Get cluster name from the error context or use clusterId as fallback
+        const clusterName = targetClusterId;
+        showLoginModal(targetClusterId, clusterName, window.location.pathname);
+        return true; // Indicates the error was handled
+      }
+    }
+    return false; // Indicates the error was not handled
+  }, [kafkaId, showLoginModal]);
+
+  const handleLogin = async (username: string, password: string) => {
+    try {
+      setAuthState(prev => ({ ...prev, error: undefined }));
+      await authenticate({ username, password });
+      
+      // Invalidate all queries for this cluster to refresh data after successful login
+      // This will refetch any data that was showing 401 errors
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          // Invalidate queries that have the clusterId in their query key
+          const queryKey = query.queryKey;
+          if (Array.isArray(queryKey)) {
+            // Check if any element in the query key matches the cluster ID
+            return queryKey.some(key => key === authState.clusterId);
+          }
+          return false;
+        },
+      });
+      
+      // On success, navigate to pending location or close modal
+      if (authState.pendingNavigation) {
+        navigate(authState.pendingNavigation);
+      }
+      
+      hideLoginModal();
+    } catch (error) {
+      // Set error to display in modal
+      if (error instanceof ApiError) {
+        setAuthState(prev => ({
+          ...prev,
+          error: error.errors?.[0]?.detail ||
+                 error.errors?.[0]?.title ||
+                 'Invalid username or password',
+        }));
+      } else {
+        setAuthState(prev => ({
+          ...prev,
+          error: 'Invalid username or password',
+        }));
+      }
+      throw error; // Re-throw to let the modal handle loading state
+    }
+  };
+
+  return (
+    <KafkaAuthContext.Provider value={{ showLoginModal, hideLoginModal, handleAuthError }}>
+      <QueryErrorHandler />
+      {children}
+      <KafkaLoginModal
+        isOpen={authState.isModalOpen}
+        clusterName={authState.clusterName}
+        authMethod={authState.authMethod}
+        onClose={hideLoginModal}
+        onLogin={handleLogin}
+        error={authState.error}
+      />
+    </KafkaAuthContext.Provider>
+  );
+}

--- a/api/src/main/webui/src/components/auth/KafkaLoginModal.tsx
+++ b/api/src/main/webui/src/components/auth/KafkaLoginModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Modal,
@@ -36,17 +36,9 @@ export function KafkaLoginModal({
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Clear fields when modal closes
-  useEffect(() => {
-    if (!isOpen) {
-      setUsername('');
-      setPassword('');
-    }
-  }, [isOpen]);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!username || !password) {
       return;
     }

--- a/api/src/main/webui/src/components/auth/KafkaLoginModal.tsx
+++ b/api/src/main/webui/src/components/auth/KafkaLoginModal.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Modal,
+  ModalVariant,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Form,
+  FormGroup,
+  TextInput,
+  Button,
+  Alert,
+  AlertVariant,
+} from '@patternfly/react-core';
+
+interface KafkaLoginModalProps {
+  isOpen: boolean;
+  clusterName: string;
+  authMethod?: string;
+  onClose: () => void;
+  onLogin: (username: string, password: string) => Promise<void>;
+  error?: string;
+}
+
+export function KafkaLoginModal({
+  isOpen,
+  clusterName,
+  authMethod,
+  onClose,
+  onLogin,
+  error,
+}: KafkaLoginModalProps) {
+  const { t } = useTranslation();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Clear fields when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setUsername('');
+      setPassword('');
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!username || !password) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onLogin(username, password);
+      // On success, the parent component will handle navigation
+      // and close the modal
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  };
+
+  // Determine the appropriate description key based on authentication method
+  const getDescriptionKey = () => {
+    switch (authMethod) {
+      case 'oauth':
+        return 'kafka.login.descriptionOAuth';
+      case 'basic':
+        return 'kafka.login.descriptionBasic';
+      default:
+        return 'kafka.login.description';
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      isOpen={isOpen}
+      onClose={handleClose}
+    >
+      <ModalHeader
+        title={t('kafka.login.title', 'Login to Kafka Cluster')}
+      />
+      <ModalBody>
+        <Form onSubmit={handleSubmit}>
+          {error && (
+            <Alert
+              variant={AlertVariant.danger}
+              title={t('kafka.login.error', 'Authentication failed')}
+              isInline
+              style={{ marginBottom: '1rem' }}
+            >
+              {error}
+            </Alert>
+          )}
+
+          <p style={{ marginBottom: '1rem' }}>
+            {t(getDescriptionKey(), { clusterName })}
+          </p>
+
+          <FormGroup
+            label={t('kafka.login.username', 'Username')}
+            isRequired
+            fieldId="username"
+          >
+            <TextInput
+              isRequired
+              type="text"
+              id="username"
+              name="username"
+              value={username}
+              onChange={(_event, value) => setUsername(value)}
+              isDisabled={isSubmitting}
+              autoComplete="username"
+            />
+          </FormGroup>
+
+          <FormGroup
+            label={t('kafka.login.password', 'Password')}
+            isRequired
+            fieldId="password"
+          >
+            <TextInput
+              isRequired
+              type="password"
+              id="password"
+              name="password"
+              value={password}
+              onChange={(_event, value) => setPassword(value)}
+              isDisabled={isSubmitting}
+              autoComplete="current-password"
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key="login"
+          variant="primary"
+          onClick={handleSubmit}
+          isDisabled={!username || !password || isSubmitting}
+          isLoading={isSubmitting}
+        >
+          {t('kafka.login.submit', 'Login')}
+        </Button>
+        <Button
+          key="cancel"
+          variant="link"
+          onClick={handleClose}
+          isDisabled={isSubmitting}
+        >
+          {t('common.cancel', 'Cancel')}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/api/src/main/webui/src/components/auth/QueryErrorHandler.tsx
+++ b/api/src/main/webui/src/components/auth/QueryErrorHandler.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useKafkaAuthContext } from './KafkaAuthProvider';
+
+/**
+ * Component that listens to TanStack Query errors and handles 401 responses
+ * by showing the login modal
+ */
+export function QueryErrorHandler() {
+  const queryClient = useQueryClient();
+  const { handleAuthError } = useKafkaAuthContext();
+
+  useEffect(() => {
+    // Set up a global error handler for queries
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      if (event.type === 'updated' && event.action.type === 'error') {
+        const error = event.action.error;
+        
+        // Try to extract clusterId from the query key
+        // Query keys typically follow pattern: ['resource-name', clusterId, ...otherParams]
+        const queryKey = event.query.queryKey;
+        let clusterId: string | undefined;
+        
+        // Check if the second element in the query key is a cluster ID
+        if (Array.isArray(queryKey) && queryKey.length > 1 && typeof queryKey[1] === 'string') {
+          // Common patterns: ['kafka-cluster', clusterId], ['topics', clusterId], etc.
+          clusterId = queryKey[1];
+        }
+        
+        // Handle the auth error
+        handleAuthError(error, clusterId);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [queryClient, handleAuthError]);
+
+  // This component doesn't render anything
+  return null;
+}

--- a/api/src/main/webui/src/components/home/ClustersDataView.tsx
+++ b/api/src/main/webui/src/components/home/ClustersDataView.tsx
@@ -14,7 +14,7 @@ import {
   ResourceListDataViewRowMapper
 } from '../common/ResourceListDataView';
 import { UseQueryResult } from '@tanstack/react-query';
-import { useKafkaAuthContext } from '@/components/auth/KafkaAuthProvider';
+import { KafkaAuthShowLoginModalType, useKafkaAuthContext } from '@/components/auth/KafkaAuthProvider';
 import { apiClient, ApiError } from '@/api/client';
 
 const columnNames = ['name', 'namespace', 'version', 'status'];
@@ -24,27 +24,8 @@ interface ClustersDataViewProps {
   onDataViewChange: (params: ResourceListParams) => void;
 }
 
-export function ClustersDataView({
-  clusterResult,
-  onDataViewChange,
-}: ClustersDataViewProps) {
-
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const { showLoginModal } = useKafkaAuthContext();
-
-  // Memoized sort handler to avoid recreating on every render
-  const handleSort = useCallback((
-    onSort: ((event: React.MouseEvent, sortBy: string, direction: 'asc' | 'desc') => void) | undefined,
-    event: React.MouseEvent,
-    columnIndex: number,
-    direction: 'asc' | 'desc'
-  ) => {
-    onSort?.(event, columnNames[columnIndex], direction);
-  }, []);
-
-  const handleViewCluster = async (cluster: KafkaCluster) => {
-    // Check if cluster requires authentication (basic or oauth)
+async function handleViewCluster(cluster: KafkaCluster, showLoginModal: KafkaAuthShowLoginModalType, navigate: ReturnType<typeof useNavigate>) {
+  // Check if cluster requires authentication (basic or oauth)
     const requiresAuth = cluster.meta?.authentication?.method === 'basic' ||
                          cluster.meta?.authentication?.method === 'oauth';
 
@@ -72,7 +53,26 @@ export function ClustersDataView({
       // No authentication required, navigate directly
       navigate(`/kafka/${cluster.id}`);
     }
-  };
+}
+
+export function ClustersDataView({
+  clusterResult,
+  onDataViewChange,
+}: ClustersDataViewProps) {
+
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { showLoginModal } = useKafkaAuthContext();
+
+  // Memoized sort handler to avoid recreating on every render
+  const handleSort = useCallback((
+    onSort: ((event: React.MouseEvent, sortBy: string, direction: 'asc' | 'desc') => void) | undefined,
+    event: React.MouseEvent,
+    columnIndex: number,
+    direction: 'asc' | 'desc'
+  ) => {
+    onSort?.(event, columnNames[columnIndex], direction);
+  }, []);
 
   const colMapper: ResourceListDataViewColumnMapper = useCallback(
     (sortBy, direction, onSort) => [
@@ -142,7 +142,7 @@ export function ClustersDataView({
           cell: (
             <Button
               variant="primary"
-              onClick={() => handleViewCluster(cluster)}
+              onClick={() => handleViewCluster(cluster, showLoginModal, navigate)}
             >
               {t('common.view')}
             </Button>
@@ -154,7 +154,7 @@ export function ClustersDataView({
         },
       ],
     }),
-    [t, navigate]
+    [t, showLoginModal, navigate]
   );
 
   return (

--- a/api/src/main/webui/src/components/home/ClustersDataView.tsx
+++ b/api/src/main/webui/src/components/home/ClustersDataView.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
+  Tooltip,
   Truncate,
 } from '@patternfly/react-core';
 import { ThProps } from '@patternfly/react-table';
@@ -16,6 +17,7 @@ import {
 import { UseQueryResult } from '@tanstack/react-query';
 import { KafkaAuthShowLoginModalType, useKafkaAuthContext } from '@/components/auth/KafkaAuthProvider';
 import { apiClient, ApiError } from '@/api/client';
+import { HelpIcon } from '@patternfly/react-icons';
 
 const columnNames = ['name', 'namespace', 'version', 'status'];
 
@@ -101,6 +103,9 @@ export function ClustersDataView({
         cell: t('kafka.status'),
       },
       {
+        cell: t('kafka.authentication'),
+      },
+      {
         cell: t('common.actions'),
         props: {
           modifier: 'fitContent',
@@ -127,7 +132,19 @@ export function ClustersDataView({
           },
         },
         {
-          cell: cluster.attributes.kafkaVersion || t('common.notAvailable', 'N/A'),
+          cell: cluster.attributes.kafkaVersion 
+            ? (<>
+                {cluster.attributes.kafkaVersion}
+                {!cluster.meta?.managed && (
+                  <>
+                    {" "}
+                    <Tooltip content={t("ClustersTable.version_derived")}>
+                      <HelpIcon />
+                    </Tooltip>
+                  </>
+                )}
+              </>)
+            : t('common.notAvailable', 'N/A'),
           props: {
             dataLabel: t('kafka.version'),
           },
@@ -137,6 +154,13 @@ export function ClustersDataView({
           props: {
             dataLabel: t('kafka.status'),
           },
+        },
+        {
+          cell: {
+            basic: t("ClustersTable.authentication_basic"),
+            oauth: t("ClustersTable.authentication_oauth"),
+            anonymous: t("ClustersTable.authentication_anonymous"),
+          }[cluster.meta?.authentication?.method ?? "anonymous"]
         },
         {
           cell: (

--- a/api/src/main/webui/src/components/home/ClustersDataView.tsx
+++ b/api/src/main/webui/src/components/home/ClustersDataView.tsx
@@ -14,6 +14,8 @@ import {
   ResourceListDataViewRowMapper
 } from '../common/ResourceListDataView';
 import { UseQueryResult } from '@tanstack/react-query';
+import { useKafkaAuthContext } from '@/components/auth/KafkaAuthProvider';
+import { apiClient, ApiError } from '@/api/client';
 
 const columnNames = ['name', 'namespace', 'version', 'status'];
 
@@ -29,6 +31,7 @@ export function ClustersDataView({
 
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { showLoginModal } = useKafkaAuthContext();
 
   // Memoized sort handler to avoid recreating on every render
   const handleSort = useCallback((
@@ -39,6 +42,37 @@ export function ClustersDataView({
   ) => {
     onSort?.(event, columnNames[columnIndex], direction);
   }, []);
+
+  const handleViewCluster = async (cluster: KafkaCluster) => {
+    // Check if cluster requires authentication (basic or oauth)
+    const requiresAuth = cluster.meta?.authentication?.method === 'basic' ||
+                         cluster.meta?.authentication?.method === 'oauth';
+
+    if (requiresAuth) {
+      // Try to access the cluster to check if authentication is needed
+      try {
+        await apiClient.get(`/api/kafkas/${cluster.id}`);
+        // If successful, navigate to the cluster
+        navigate(`/kafka/${cluster.id}`);
+      } catch (error) {
+        // If 401, show login modal
+        if (error instanceof ApiError && error.status === 401) {
+          showLoginModal(
+            cluster.id,
+            cluster.attributes.name,
+            cluster.meta?.authentication?.method,
+            `/kafka/${cluster.id}`
+          );
+        } else {
+          // For other errors, just navigate (let the cluster page handle it)
+          navigate(`/kafka/${cluster.id}`);
+        }
+      }
+    } else {
+      // No authentication required, navigate directly
+      navigate(`/kafka/${cluster.id}`);
+    }
+  };
 
   const colMapper: ResourceListDataViewColumnMapper = useCallback(
     (sortBy, direction, onSort) => [
@@ -108,7 +142,7 @@ export function ClustersDataView({
           cell: (
             <Button
               variant="primary"
-              onClick={() => navigate(`/kafka/${cluster.id}`)}
+              onClick={() => handleViewCluster(cluster)}
             >
               {t('common.view')}
             </Button>

--- a/api/src/main/webui/src/i18n/messages/en.json
+++ b/api/src/main/webui/src/i18n/messages/en.json
@@ -91,6 +91,17 @@
     "nodes": "Kafka Nodes",
     "users": "Kafka Users",
     "schemaRegistry": "Schema Registry",
+    "login": {
+      "title": "Login to Kafka Cluster",
+      "description": "Please enter your credentials to access cluster \"{{clusterName}}\".",
+      "descriptionOAuth": "Please enter your OAuth credentials to access cluster \"{{clusterName}}\".",
+      "descriptionBasic": "Please enter your SCRAM credentials to access cluster \"{{clusterName}}\".",
+      "username": "Username",
+      "password": "Password",
+      "submit": "Login",
+      "error": "Authentication failed",
+      "errorGeneric": "Invalid username or password"
+    },
     "connect": {
       "title": "Kafka Connect",
       "connectors": "Connectors",

--- a/api/src/main/webui/src/i18n/messages/en.json
+++ b/api/src/main/webui/src/i18n/messages/en.json
@@ -66,6 +66,7 @@
     "viewDocumentation": "View documentation"
   },
   "kafka": {
+    "authentication": "Authentication",
     "clusters": "Kafka Clusters",
     "selectCluster": "Kafka Clusters",
     "noCluster": "No clusters available",
@@ -759,7 +760,10 @@
   },
   "ClustersTable": {
     "version_derived": "Version derived from broker metadata",
-    "not_available": "N/A"
+    "not_available": "N/A",
+    "authentication_basic": "SCRAM-SHA",
+    "authentication_oauth": "OAuth (client credentials)",
+    "authentication_anonymous": "No authentication"
   },
   "metrics": {
     "all_topics": "All Topics",

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceIT.java
@@ -26,7 +26,7 @@ import jakarta.ws.rs.core.Response.Status;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.AfterAll;
@@ -40,7 +40,7 @@ import org.mockito.Mockito;
 
 import com.github.streamshub.console.api.model.KafkaCluster;
 import com.github.streamshub.console.api.model.ListFetchParams;
-import com.github.streamshub.console.api.security.ConsoleAuthenticationMechanism;
+import com.github.streamshub.console.api.security.IdentitySupport;
 import com.github.streamshub.console.api.service.KafkaClusterService;
 import com.github.streamshub.console.api.support.ErrorCategory;
 import com.github.streamshub.console.api.support.Holder;
@@ -52,18 +52,22 @@ import com.github.streamshub.console.config.security.GlobalSecurityConfigBuilder
 import com.github.streamshub.console.config.security.Privilege;
 import com.github.streamshub.console.config.security.ResourceTypes;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
-import com.github.streamshub.console.test.AdminClientSpy;
 import com.github.streamshub.console.test.LogCapture;
+import com.github.streamshub.console.test.OidcClientsSpy;
 import com.github.streamshub.console.test.TestHelper;
 import com.github.streamshub.console.test.VarargsAggregator;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.Tokens;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Uni;
 import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
@@ -72,6 +76,8 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAut
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationScramSha512Builder;
 import io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler;
 
+import static com.github.streamshub.console.test.TestHelper.authenticate;
+import static com.github.streamshub.console.test.TestHelper.mockAdminClient;
 import static com.github.streamshub.console.test.TestHelper.whenRequesting;
 import static java.util.Objects.isNull;
 import static org.awaitility.Awaitility.await;
@@ -92,6 +98,10 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @TestHTTPEndpoint(KafkaClustersResource.class)
@@ -106,7 +116,7 @@ class KafkaClustersResourceIT {
 
     static LogCapture auditLogCapture = LogCapture.with(logRecord -> logRecord
             .getLoggerName()
-            .equals(ConsoleAuthenticationMechanism.class.getName()),
+            .equals(IdentitySupport.AUDIT_LOG_NAME),
             Level.INFO);
 
     @Inject
@@ -126,6 +136,9 @@ class KafkaClustersResourceIT {
 
     @Inject
     ConsoleConfig consoleConfig;
+
+    @InjectMock
+    OidcClientsSpy oidcClients;
 
     TestHelper utils;
 
@@ -817,8 +830,20 @@ class KafkaClustersResourceIT {
                     .map(KafkaClusterConfig::clusterKey)
                     .anyMatch(Cache.metaNamespaceKeyFunc(kafka)::equals));
 
+        when(oidcClients.newClient(any())).thenAnswer(a1 -> {
+            OidcClient mockClient = mock(OidcClient.class);
+
+            when(mockClient.getTokens(anyMap())).thenAnswer(a2 -> {
+                return Uni.createFrom().item(new Tokens("my-access-token", null, null, null, null, null, null));
+            });
+
+            return Uni.createFrom().item(mockClient);
+        });
+
+        var cookies = authenticate("{clusterId}/session", clusterId, "my-client-id", "my-client-secret");
+
         whenRequesting(req -> req
-                .auth().oauth2("my-secure-token")
+                .cookies(cookies)
                 .get("{clusterId}", clusterId))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
@@ -830,6 +855,9 @@ class KafkaClustersResourceIT {
         assertEquals("OAUTHBEARER", clientConfig.get(SaslConfigs.SASL_MECHANISM));
         assertEquals(JaasClientOauthLoginCallbackHandler.class.getName(),
                 clientConfig.get(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS));
+        String saslJaasConfig = String.valueOf(clientConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+        assertThat(saslJaasConfig, containsString(OAuthBearerLoginModule.class.getName()));
+        assertThat(saslJaasConfig, containsString("oauth.access.token=\"my-access-token\""));
     }
 
     @ParameterizedTest
@@ -867,8 +895,10 @@ class KafkaClustersResourceIT {
                     .map(KafkaClusterConfig::clusterKey)
                     .anyMatch(Cache.metaNamespaceKeyFunc(kafka)::equals));
 
+        var cookies = authenticate("{clusterId}/session", clusterId, "my-user", "my-password");
+
         whenRequesting(req -> req
-                .auth().basic("u", "p")
+                .cookies(cookies)
                 .get("{clusterId}", clusterId))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
@@ -877,8 +907,10 @@ class KafkaClustersResourceIT {
 
         assertEquals(expectedProtocol, clientConfig.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
         assertEquals("SCRAM-SHA-512", clientConfig.get(SaslConfigs.SASL_MECHANISM));
-        assertThat(String.valueOf(clientConfig.get(SaslConfigs.SASL_JAAS_CONFIG)),
-                containsString(ScramLoginModule.class.getName()));
+        String saslJaasConfig = String.valueOf(clientConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+        assertThat(saslJaasConfig, containsString(ScramLoginModule.class.getName()));
+        assertThat(saslJaasConfig, containsString("username=\"my-user\""));
+        assertThat(saslJaasConfig, containsString("password=\"my-password\""));
     }
 
     @Test
@@ -1010,25 +1042,5 @@ class KafkaClustersResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.attributes.kafkaVersion", is(expectedVersion));
-    }
-
-    // Helper methods
-
-    static Map<String, Object> mockAdminClient() {
-        return mockAdminClient(Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name));
-    }
-
-    static Map<String, Object> mockAdminClient(Map<String, Object> overrides) {
-        Map<String, Object> clientConfig = new HashMap<>();
-
-        AdminClientSpy.install(config -> {
-            clientConfig.putAll(config);
-
-            Map<String, Object> newConfig = new HashMap<>(config);
-            newConfig.putAll(overrides);
-            return newConfig;
-        }, client -> { /* No-op */ });
-
-        return clientConfig;
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceMetricsIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceMetricsIT.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +24,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.eclipse.microprofile.config.Config;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
 import org.junit.jupiter.api.AfterAll;
@@ -45,7 +43,6 @@ import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.config.KafkaClusterConfig;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
-import com.github.streamshub.console.test.AdminClientSpy;
 import com.github.streamshub.console.test.LogCapture;
 import com.github.streamshub.console.test.TestHelper;
 
@@ -539,25 +536,5 @@ class KafkaClustersResourceMetricsIT implements ClientRequestFilter {
                     //hasEntry("range", arrayContaining("", "")),
                     hasEntry("custom-attribute", "attribute-value")
             )));
-    }
-
-    // Helper methods
-
-    static Map<String, Object> mockAdminClient() {
-        return mockAdminClient(Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name));
-    }
-
-    static Map<String, Object> mockAdminClient(Map<String, Object> overrides) {
-        Map<String, Object> clientConfig = new HashMap<>();
-
-        AdminClientSpy.install(config -> {
-            clientConfig.putAll(config);
-
-            Map<String, Object> newConfig = new HashMap<>(config);
-            newConfig.putAll(overrides);
-            return newConfig;
-        }, client -> { /* No-op */ });
-
-        return clientConfig;
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceOidcIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/KafkaClustersResourceOidcIT.java
@@ -2,7 +2,6 @@ package com.github.streamshub.console.api;
 
 import java.net.URI;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -12,7 +11,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +25,6 @@ import com.github.streamshub.console.config.security.GlobalSecurityConfigBuilder
 import com.github.streamshub.console.config.security.Privilege;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.utils.TokenUtils;
-import com.github.streamshub.console.test.AdminClientSpy;
 import com.github.streamshub.console.test.TestHelper;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -347,25 +344,5 @@ class KafkaClustersResourceOidcIT {
                 .get("{clusterId}", clusterId1))
             .assertThat()
             .statusCode(is(expectedStatus.getStatusCode()));
-    }
-
-    // Helper methods
-
-    static Map<String, Object> mockAdminClient() {
-        return mockAdminClient(Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name));
-    }
-
-    static Map<String, Object> mockAdminClient(Map<String, Object> overrides) {
-        Map<String, Object> clientConfig = new HashMap<>();
-
-        AdminClientSpy.install(config -> {
-            clientConfig.putAll(config);
-
-            Map<String, Object> newConfig = new HashMap<>(config);
-            newConfig.putAll(overrides);
-            return newConfig;
-        }, client -> { /* No-op */ });
-
-        return clientConfig;
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceIT.java
@@ -87,7 +87,7 @@ import org.mockito.stubbing.Answer;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import com.github.streamshub.console.api.security.ConsoleAuthenticationMechanism;
+import com.github.streamshub.console.api.security.IdentitySupport;
 import com.github.streamshub.console.api.service.TopicService;
 import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.api.support.KafkaContext;
@@ -162,7 +162,7 @@ class TopicsResourceIT {
 
     static LogCapture auditLogCapture = LogCapture.with(logRecord -> logRecord
             .getLoggerName()
-            .equals(ConsoleAuthenticationMechanism.class.getName()),
+            .equals(IdentitySupport.AUDIT_LOG_NAME),
             Level.INFO);
 
     @Inject

--- a/api/src/test/java/com/github/streamshub/console/api/TopicsResourceOidcIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/TopicsResourceOidcIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.AggregateWith;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.github.streamshub.console.api.security.ConsoleAuthenticationMechanism;
+import com.github.streamshub.console.api.security.IdentitySupport;
 import com.github.streamshub.console.api.support.KafkaContext;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.config.KafkaClusterConfig;
@@ -74,7 +74,7 @@ class TopicsResourceOidcIT {
 
     static LogCapture auditLogCapture = LogCapture.with(logRecord -> logRecord
             .getLoggerName()
-            .equals(ConsoleAuthenticationMechanism.class.getName()),
+            .equals(IdentitySupport.AUDIT_LOG_NAME),
             Level.INFO);
 
     @Inject

--- a/api/src/test/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResourceIT.java
@@ -1,0 +1,160 @@
+package com.github.streamshub.console.api.security.kafka;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import com.github.streamshub.console.api.support.KafkaContext;
+import com.github.streamshub.console.config.ConsoleConfig;
+import com.github.streamshub.console.config.KafkaClusterConfig;
+import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
+import com.github.streamshub.console.test.TestHelper;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.cache.Cache;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthentication;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationScramSha512Builder;
+
+import static com.github.streamshub.console.test.TestHelper.authenticate;
+import static com.github.streamshub.console.test.TestHelper.mockAdminClient;
+import static com.github.streamshub.console.test.TestHelper.whenRequesting;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@TestHTTPEndpoint(KafkaSessionResource.class)
+@TestProfile(TestPlainProfile.class)
+class KafkaSessionResourceIT {
+
+    private static final String AUTHN_SCRAM_TAG = "AUTHN_SCRAM";
+
+    @Inject
+    Config config;
+
+    @Inject
+    KubernetesClient client;
+
+    @TestHTTPResource
+    String testUri;
+
+    @Inject
+    Map<String, KafkaContext> configuredContexts;
+
+    @Inject
+    ConsoleConfig consoleConfig;
+
+    TestHelper utils;
+    String clusterId;
+    URI bootstrapServers;
+    Map<String, String> sessionCookies;
+
+    @BeforeEach
+    void setup(TestInfo testInfo) {
+        bootstrapServers = URI.create(config.getValue(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, String.class));
+        utils = new TestHelper(URI.create("/"), config);
+        utils.resetSecurity(consoleConfig, false);
+
+        client.resources(Kafka.class).inAnyNamespace().delete();
+        clusterId = UUID.randomUUID().toString();
+
+        KafkaListenerAuthentication authn = null;
+
+        if (testInfo.getTags().contains(AUTHN_SCRAM_TAG)) {
+            authn = new KafkaListenerAuthenticationScramSha512Builder().build();
+        }
+
+        /*
+         * Create a Kafka CR that proxies to kafka1.
+         * test-kafka3 is predefined in KafkaUnsecuredResourceManager
+         */
+        Kafka kafka = new KafkaBuilder(utils.buildKafkaResource("test-kafka3", clusterId, bootstrapServers, authn))
+                .editSpec()
+                    .editKafka()
+                    .editMatchingListener(l -> "listener0".equals(l.getName()))
+                        .withTls(false)
+                    .endListener()
+                .endKafka()
+                .endSpec()
+                .build();
+
+        utils.apply(client, kafka);
+
+        // Wait for the added cluster to be configured in the context map
+        await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> configuredContexts.values()
+                    .stream()
+                    .map(KafkaContext::clusterConfig)
+                    .map(KafkaClusterConfig::clusterKey)
+                    .anyMatch(Cache.metaNamespaceKeyFunc(kafka)::equals));
+
+        if (testInfo.getTags().contains(AUTHN_SCRAM_TAG)) {
+            mockAdminClient();
+            this.sessionCookies = authenticate("", clusterId, "my-user", "my-password");
+        } else {
+            this.sessionCookies = Collections.emptyMap();
+        }
+    }
+
+    @Test
+    @Tag(AUTHN_SCRAM_TAG)
+    void testGetCurrentKafkaUserSCRAM() {
+        whenRequesting(req -> req
+                .cookies(sessionCookies)
+                .get("user", clusterId))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("anonymous", is(false))
+            .body("username", is("my-user"))
+            .body(".", not(hasKey("fullName")));
+    }
+
+    @Test
+    @Tag(AUTHN_SCRAM_TAG)
+    void testLogoutSCRAM() {
+        var expectedLocation = UriBuilder.fromUri(testUri)
+                .replacePath("/some/path")
+                .build()
+                .toString();
+
+        whenRequesting(req -> req
+                .queryParam("redirect_uri", "/some/path")
+                .cookies(sessionCookies)
+                .redirects().follow(false)
+                .get("logout", clusterId))
+            .assertThat()
+            .statusCode(is(Status.SEE_OTHER.getStatusCode()))
+            .header("Location", is(expectedLocation));
+    }
+
+    @Test
+    void testGetCurrentUserAnonymous() {
+        whenRequesting(req -> req
+                .get("user", clusterId))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("anonymous", is(true))
+            .body("username", is("ANONYMOUS"))
+            .body("fullName", is("Anonymous"));
+    }
+}

--- a/api/src/test/java/com/github/streamshub/console/test/OidcClientsSpy.java
+++ b/api/src/test/java/com/github/streamshub/console/test/OidcClientsSpy.java
@@ -1,0 +1,52 @@
+package com.github.streamshub.console.test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
+import io.quarkus.oidc.client.runtime.OidcClientsImpl;
+import io.quarkus.test.Mock;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Spy/wrapper class for OidcClients that will proxy method calls to the
+ * default OidcClients instance provided by Quarkus. This class can be mocked
+ * in tests in order to provide a mocked client which may provide test-case
+ * values for access tokens, etc. 
+ */
+@Mock
+@ApplicationScoped
+public class OidcClientsSpy implements OidcClients {
+
+    @Inject
+    Instance<OidcClientsImpl> target;
+
+    @Override
+    public void close() throws IOException {
+        target.get().close();
+    }
+
+    @Override
+    public OidcClient getClient() {
+        return target.get().getClient();
+    }
+
+    @Override
+    public OidcClient getClient(String id) {
+        return target.get().getClient(id);
+    }
+
+    @Override
+    public Uni<OidcClient> newClient(OidcClientConfig clientConfig) {
+        return Uni.createFrom()
+            .completionStage(CompletableFuture.supplyAsync(target::get))
+            .onItem()
+            .transformToUni(clients -> clients.newClient(clientConfig));
+    }
+}

--- a/api/src/test/java/com/github/streamshub/console/test/TestHelper.java
+++ b/api/src/test/java/com/github/streamshub/console/test/TestHelper.java
@@ -2,6 +2,8 @@ package com.github.streamshub.console.test;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -14,9 +16,12 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
+import jakarta.ws.rs.core.Response.Status;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
 
@@ -40,6 +45,7 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthentication;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestHelper {
@@ -208,5 +214,38 @@ public class TestHelper {
                     .endContent()
                 .endTrustStore()
             .endOidc();
+    }
+
+    public static Map<String, Object> mockAdminClient() {
+        return mockAdminClient(Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name));
+    }
+
+    public static Map<String, Object> mockAdminClient(Map<String, Object> overrides) {
+        Map<String, Object> clientConfig = new HashMap<>();
+
+        AdminClientSpy.install(config -> {
+            clientConfig.putAll(config);
+
+            Map<String, Object> newConfig = new HashMap<>(config);
+            newConfig.putAll(overrides);
+            return newConfig;
+        }, client -> { /* No-op */ });
+
+        return clientConfig;
+    }
+
+    public static Map<String, String> authenticate(String path, String clusterId, String username, String password) {
+        var sessionCookieName = "streamshub-console-kafka-" + clusterId;
+
+        var sessionCookie = whenRequesting(req -> req
+                .formParams(Map.of("u", username, "p", password))
+                .post(path, clusterId))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .cookie(sessionCookieName)
+            .extract()
+            .cookie(sessionCookieName);
+
+        return Map.of(sessionCookieName, sessionCookie);
     }
 }

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaClusterConfig.java
@@ -127,7 +127,7 @@ public class KafkaClusterConfig implements Named {
 
     public void setKind(ClusterKind kind) {
         this.kind = kind;
-    }   
+    }
 
     public Map<String, String> getProperties() {
         return properties;

--- a/docs/sources/modules/proc-logging-in.adoc
+++ b/docs/sources/modules/proc-logging-in.adoc
@@ -4,10 +4,15 @@
 = Logging in to a Kafka cluster from the homepage
 
 [role="_abstract"]
+[WARNING]
+====
+**This authentication method is deprecated.** Entering personal Kafka credentials into the console is insecure because credentials are transmitted through and stored by the console. Use OIDC application-scoped authentication instead (see xref:ref-authentication-options-{context}[]).
+====
+
 The console supports authenticated user login to a Kafka cluster using SCRAM-SHA-512 and OAuth 2.0 authentication mechanisms.
 For secure login, authentication must be configured in your Strimzi managed Kafka cluster.
 
-NOTE: If authentication is not set up for a Kafka cluster or the credentials have been provided using the Kafka `sasl.jaas.config` property (which defines SASL authentication settings) in the console configuration, you can log in anonymously to the cluster without authentication.
+NOTE: If authentication is not set up for a Kafka cluster or the credentials have been provided using the Kafka `sasl.jaas.config` property (which defines SASL authentication settings) in the console configuration, you can log in anonymously to the cluster without authentication. The per-Kafka login prompt only appears when SASL authentication is enabled but no console credentials are configured.
 
 .Prerequisites
 

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -77,12 +77,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -127,6 +127,7 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This re-implements the form-based Kafka authentication from the previous Next.js UI. Rather than a separate login page, this PR introduces a login modal that will be used whenever the back-end responds with a 401/unauthorized. Session cookies are scoped to each Kafka cluster the user has logged in to.

Closes #2496 

- Updated documentation with deprecation and security notices for form-based authentication.
- Restored "Authentication" column in clusters table 
  <img width="1521" height="581" alt="image" src="https://github.com/user-attachments/assets/a4fde142-71df-49d2-a24b-1ea3ce304f4a" />
- Modal appears when accessing cluster where user is unauthenticated
  <img width="920" height="575" alt="image" src="https://github.com/user-attachments/assets/10542280-11d5-44dd-95f2-b88117aa2c46" />
- Toggling between clusters does not prompt to log-in while session is active.

