### PR TITLE
[0.12.x] Disable Next.js image optimization disk cache

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -33,6 +33,10 @@ const nextConfig = {
           },
         }
       : undefined,
+  images: {
+    // disable the disk cache entirely
+    maximumDiskCacheSize: 0,
+  },
 };
 
 module.exports = withNextIntl(nextConfig);

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -36,6 +36,12 @@ const nextConfig = {
   images: {
     // disable the disk cache entirely
     maximumDiskCacheSize: 0,
+    // block all local image optimizations
+    localPatterns: [],
+    // block all remote image optimizations
+    remotePatterns: [],
+    // disable image optimization
+    unoptimized: true,
   },
 };
 


### PR DESCRIPTION
The Console UI does not currently use the optimization feature, so this is a safeguard to ensure it cannot be triggered.