### PR TITLE
Resolve @Valid container deprecation warnings

### DIFF
--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -52,17 +52,14 @@ public class ConsoleConfig {
     @ValidResourceTypes(type = ResourceTypes.Global.class)
     GlobalSecurityConfig security = new GlobalSecurityConfig();
 
-    @Valid
-    List<PrometheusConfig> metricsSources = new ArrayList<>();
+    List<@Valid PrometheusConfig> metricsSources = new ArrayList<>();
 
-    @Valid
-    List<SchemaRegistryConfig> schemaRegistries = new ArrayList<>();
+    List<@Valid SchemaRegistryConfig> schemaRegistries = new ArrayList<>();
 
     @Valid
     KafkaConfig kafka = new KafkaConfig();
 
-    @Valid
-    List<KafkaConnectConfig> kafkaConnectClusters = new ArrayList<>();
+    List<@Valid KafkaConnectConfig> kafkaConnectClusters = new ArrayList<>();
 
     @JsonIgnore
     @AssertTrue(message = "Metrics source names must be unique")

--- a/common/src/main/java/com/github/streamshub/console/config/KafkaConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/KafkaConfig.java
@@ -19,8 +19,7 @@ public class KafkaConfig {
 
     static final String UNIQUE_NAMES_MESSAGE = "Kafka cluster name and namespace combinations must be unique";
 
-    @Valid
-    List<KafkaClusterConfig> clusters = new ArrayList<>();
+    List<@Valid KafkaClusterConfig> clusters = new ArrayList<>();
 
     private boolean uniqueNames() {
         if (clusters == null) {

--- a/common/src/main/java/com/github/streamshub/console/config/security/RoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/security/RoleConfig.java
@@ -15,9 +15,8 @@ public class RoleConfig {
     @NotBlank
     private String name;
 
-    @Valid
     @NotEmpty
-    private List<RuleConfig> rules = new ArrayList<>();
+    private List<@Valid RuleConfig> rules = new ArrayList<>();
 
     public String getName() {
         return name;

--- a/common/src/main/java/com/github/streamshub/console/config/security/SecurityConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/security/SecurityConfig.java
@@ -10,14 +10,11 @@ import io.sundr.builder.annotations.Buildable;
 @Buildable(editableEnabled = false)
 public abstract class SecurityConfig {
 
-    @Valid
-    private List<SubjectConfig> subjects = new ArrayList<>();
+    private List<@Valid SubjectConfig> subjects = new ArrayList<>();
 
-    @Valid
-    private List<RoleConfig> roles = new ArrayList<>();
+    private List<@Valid RoleConfig> roles = new ArrayList<>();
 
-    @Valid
-    private List<AuditConfig> audit = new ArrayList<>();
+    private List<@Valid AuditConfig> audit = new ArrayList<>();
 
     public List<SubjectConfig> getSubjects() {
         return subjects;


### PR DESCRIPTION
Closes #2648 

## Summary

Fixes deprecation warnings from Hibernate Validator about applying `@Valid` directly to container types.

Updated common configuration models to move `@Valid` from `List` fields onto their element type arguments, for example:

```java
List<@Valid KafkaClusterConfig> clusters

