### PR TITLE
Adjust console startup probe for CPU-constrained scenarios

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -17,6 +17,11 @@ quarkus.kubernetes.name=streamshub-console-operator
 quarkus.kubernetes.rbac.service-accounts.streamshub-console-operator.namespace=
 quarkus.kubernetes.env.fields."CONSOLE_DEPLOYMENT_DEFAULT_IMAGE_TAG"=metadata.labels['app.kubernetes.io/version']
 
+# Tolerate slow startup under constrained CPU, avoiding crash loops (#2676)
+quarkus.kubernetes.startup-probe.initial-delay=3s
+quarkus.kubernetes.startup-probe.period=5s
+quarkus.kubernetes.startup-probe.failure-threshold=24
+
 # Not needed. Disable to support read-only FS
 # See https://github.com/eclipse-vertx/vert.x/blob/1a28a6f0913802951dc5e6536dc99963f80b466a/vertx-core/src/main/asciidoc/filesystem.adoc?plain=1#L130
 quarkus.vertx.caching=false

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
@@ -38,11 +38,11 @@ spec:
             path: /health/started
             port: http
             scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: 3
+          periodSeconds: 5
           timeoutSeconds: 10
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 24
         livenessProbe:
           httpGet:
             path: /health/live


### PR DESCRIPTION
Adjusts the `console-api` startup probe per #2676 so it tolerates slow startups under constrained CPU:

- `failureThreshold`: 3 -> 24
- `initialDelaySeconds`: 5 -> 3
- `periodSeconds`: 10 -> 5

The startup window becomes ~2 minutes (3 + 5*24 = 123s) instead of failing after only 3 checks and crash looping.

I kept the existing `path: /health/started` and `port: http` (rather than the `/q/health/started` and `8080` shown in the issue example): the API sets `quarkus.http.non-application-root-path` to the root path, so the health endpoints are served under `/health`, not `/q/health`. Only the timing values were changed.

Closes #2676
