### PR TITLE
fix: restore Kroxy Virtual labels, Kafka version fetch error handling

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
@@ -72,6 +72,13 @@ public class KafkaClusterService {
     private static final String AUTHN_KEY = "authentication";
     private static final String AUTHN_METHOD_KEY = "method";
 
+    /**
+     * Options for the describeFeatures operation used to obtain a Kafka cluster
+     * version when a Strimzi Kafka CR is not present. We keep the timeout low to
+     * limit impact to list cluster operations.
+     */
+    private static final DescribeFeaturesOptions FEATURES_OPTS = new DescribeFeaturesOptions().timeoutMs(5000);
+
     @Inject
     Logger logger;
 
@@ -272,8 +279,7 @@ public class KafkaClusterService {
              * application-wide authentication.
              */
             Optional.ofNullable(kafkaContext.admin())
-                    .map(admin -> admin.describeFeatures(new DescribeFeaturesOptions()
-                        .timeoutMs(5000)))
+                    .map(admin -> admin.describeFeatures(FEATURES_OPTS))
                     .map(DescribeFeaturesResult::featureMetadata)
                     .map(metadata -> {
                         try {

--- a/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
+++ b/api/src/main/java/com/github/streamshub/console/api/service/KafkaClusterService.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.BadRequestException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.DescribeFeaturesOptions;
 import org.apache.kafka.clients.admin.DescribeFeaturesResult;
 import org.apache.kafka.clients.admin.FeatureMetadata;
 import org.apache.kafka.clients.admin.FinalizedVersionRange;
@@ -271,9 +272,17 @@ public class KafkaClusterService {
              * application-wide authentication.
              */
             Optional.ofNullable(kafkaContext.admin())
-                    .map(Admin::describeFeatures)
+                    .map(admin -> admin.describeFeatures(new DescribeFeaturesOptions()
+                        .timeoutMs(5000)))
                     .map(DescribeFeaturesResult::featureMetadata)
-                    .map(metadata -> get(() -> metadata))
+                    .map(metadata -> {
+                        try {
+                            return get(() -> metadata);
+                        } catch (Exception e) {
+                            logger.infof("Exception fetching feature metadata for cluster %s: %s", config.clusterKey(), e);
+                            return null;
+                        }
+                    })
                     .map(FeatureMetadata::finalizedFeatures)
                     .map(features -> features.get(MetadataVersion.FEATURE_NAME))
                     .map(FinalizedVersionRange::maxVersionLevel)

--- a/api/src/main/webui/src/components/home/ClustersDataView.tsx
+++ b/api/src/main/webui/src/components/home/ClustersDataView.tsx
@@ -18,6 +18,7 @@ import { UseQueryResult } from '@tanstack/react-query';
 import { KafkaAuthShowLoginModalType, useKafkaAuthContext } from '@/components/auth/KafkaAuthProvider';
 import { apiClient, ApiError } from '@/api/client';
 import { HelpIcon } from '@patternfly/react-icons';
+import { KroxyliciousClusterLabel } from '@/components/kafka/KroxyliciousClusterLabel';
 
 const columnNames = ['name', 'namespace', 'version', 'status'];
 
@@ -120,7 +121,12 @@ export function ClustersDataView({
       id: cluster.id,
       row: [
         {
-          cell: <Truncate content={cluster.attributes.name} />,
+          cell: (
+            <>
+              <Truncate content={cluster.attributes.name} />
+              <KroxyliciousClusterLabel cluster={cluster} />
+            </>
+          ),
           props: {
             dataLabel: t('kafka.name'),
           },

--- a/api/src/main/webui/src/components/kafka/ClusterSwitcher.tsx
+++ b/api/src/main/webui/src/components/kafka/ClusterSwitcher.tsx
@@ -26,6 +26,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useRef, useState } from 'react';
 import { KafkaCluster } from '@/api/types';
+import { KroxyliciousClusterLabel } from './KroxyliciousClusterLabel';
 
 export interface ClusterSwitcherProps {
   clusters: KafkaCluster[];
@@ -100,7 +101,10 @@ export function ClusterSwitcher({
             isSelected={currentClusterId === cluster.id}
           >
             <Flex>
-              <FlexItem>{cluster.attributes.name}</FlexItem>
+              <FlexItem>
+                {cluster.attributes.name}
+                <KroxyliciousClusterLabel cluster={cluster} />
+              </FlexItem>
               <FlexItem align={{ default: 'alignRight' }}>
                 {cluster.id !== currentClusterId && (
                   <Tooltip content={t('kafka.switchToCluster')}>

--- a/api/src/main/webui/src/components/kafka/KroxyliciousClusterLabel.tsx
+++ b/api/src/main/webui/src/components/kafka/KroxyliciousClusterLabel.tsx
@@ -1,0 +1,39 @@
+/**
+ * Kroxylicious Cluster Label Component
+ *
+ * Displays a badge indicating that a cluster is a Kroxylicious virtual cluster.
+ * Shows a blue label with an info icon and tooltip explaining what it means.
+ */
+
+import { KafkaCluster } from '@/api/types';
+import { Label, Tooltip } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+
+export function KroxyliciousClusterLabel({
+  cluster,
+  clusterKind,
+} : {
+  cluster?: KafkaCluster;
+  clusterKind?: string;
+}) {
+  const { t } = useTranslation();
+  const kind = clusterKind || cluster?.meta?.kind;
+
+  if (kind !== 'virtualkafkaclusters.kroxylicious.io') {
+    return null;
+  }
+
+  return (
+    <Tooltip content={t('KroxyliciousCluster.tooltip')}>
+      <Label
+        isCompact
+        color="blue"
+        icon={<InfoCircleIcon />}
+        className="pf-v6-u-ml-sm"
+      >
+        {t('KroxyliciousCluster.label')}
+      </Label>
+    </Tooltip>
+  );
+}

--- a/api/src/main/webui/src/i18n/messages/en.json
+++ b/api/src/main/webui/src/i18n/messages/en.json
@@ -65,6 +65,10 @@
     "documentation": "Documentation",
     "viewDocumentation": "View documentation"
   },
+  "KroxyliciousCluster": {
+    "label": "Virtual",
+    "tooltip": "A virtual cluster is a logical Kafka endpoint that clients connect to. The proxy forwards requests to a physical Kafka cluster through its filters."
+  },
   "kafka": {
     "authentication": "Authentication",
     "clusters": "Kafka Clusters",

--- a/api/src/main/webui/src/pages/kafka/KafkaLayout.tsx
+++ b/api/src/main/webui/src/pages/kafka/KafkaLayout.tsx
@@ -23,6 +23,7 @@ import { KafkaClusterSidebar } from '@/components/kafka/KafkaClusterSidebar';
 import { AppMasthead } from '@/components/app/AppMasthead';
 import { ReconciliationControls } from '@/components/kafka/overview/ReconciliationControls';
 import { useGroup } from '@/api/hooks/useGroups';
+import { KroxyliciousClusterLabel } from '@/components/kafka/KroxyliciousClusterLabel';
 
 export function KafkaLayout() {
   const { t } = useTranslation();
@@ -207,6 +208,7 @@ export function KafkaLayout() {
       <BreadcrumbItem>
         <Link to={`/kafka/${kafkaId}`}>
           {clusterName}
+          <KroxyliciousClusterLabel cluster={cluster} />
         </Link>
       </BreadcrumbItem>
       {isTopicDetailPage && (


### PR DESCRIPTION
Restore the `Virtual` labels for the non-Next.js UI. Also adds a timeout and error handling (log & continue) when the Kafka version cannot be retrieved.

<img width="333" height="329" alt="image" src="https://github.com/user-attachments/assets/b15c0899-f9f1-49db-9b2e-b6d925eb053e" />
