### PR TITLE
Migrate topic listings to use common fetch and data view component

### DIFF
--- a/api/src/main/webui/src/api/hooks/useResourceList.ts
+++ b/api/src/main/webui/src/api/hooks/useResourceList.ts
@@ -16,6 +16,11 @@ export interface ResourceListPageParams {
   } | string;
 }
 
+export interface ResourceListFilterValue {
+  operator: 'eq' | 'in' | 'like';
+  value: string;
+}
+
 export interface ResourceListParams {
   /**
    * Parameters for pagination (page size, sorting, etc.)
@@ -24,7 +29,7 @@ export interface ResourceListParams {
   /**
    * Parameters for filtering by specific fields (search, etc.)
    */
-  filters?: Record<string, string | string[]>;
+  filters?: Record<string, string | string[] | ResourceListFilterValue>;
   /**
    * Comma-separated list of fields to include in the response.
    * @example
@@ -84,10 +89,21 @@ export function useResourceList<T extends Resource>(
         updatePageParams(params.page, searchParams);
       }
 
-      // Handle name filter
       if (params?.filters) {
         Object.entries(params.filters).forEach(([key, value]) => {
-          searchParams.set(`filter[${key}]`, `like,*${value}*`);
+          if (Array.isArray(value)) {
+            if (value.length > 0) {
+              searchParams.set(`filter[${key}]`, `in,${value.join(',')}`);
+            }
+            return;
+          }
+
+          if (typeof value === 'string') {
+            searchParams.set(`filter[${key}]`, `like,*${value}*`);
+            return;
+          }
+
+          searchParams.set(`filter[${key}]`, `${value.operator},${value.value}`);
         });
       }
 

--- a/api/src/main/webui/src/api/hooks/useResourceList.ts
+++ b/api/src/main/webui/src/api/hooks/useResourceList.ts
@@ -80,6 +80,7 @@ export function useResourceList<T extends Resource>(
   return useQuery({
     queryKey: [
       resourceType + '-resource-list-query',
+      path,
       JSON.stringify(params),
     ],
     queryFn: async () => {

--- a/api/src/main/webui/src/api/hooks/useTopics.ts
+++ b/api/src/main/webui/src/api/hooks/useTopics.ts
@@ -4,86 +4,24 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../client';
-import { TopicsResponse, Topic } from '../types';
+import { Topic } from '../types';
+import { ResourceListParams, useResourceList } from './useResourceList';
 
 /**
  * Fetch all topics for a Kafka cluster
  */
 export function useTopics(
   kafkaId: string | undefined,
-  params?: {
-    pageSize?: number;
-    pageCursor?: string;
-    sort?: string;
-    sortDir?: 'asc' | 'desc';
-    name?: string;
-    status?: string[];
-    id?: string;
-    includeHidden?: boolean;
-    fields?: string[];
-  }
+  params?: ResourceListParams
 ) {
-  return useQuery({
-    queryKey: [
-      'topics',
-      kafkaId,
-      params?.pageSize,
-      params?.pageCursor,
-      params?.sort,
-      params?.sortDir,
-      params?.name,
-      params?.status,
-      params?.id,
-      params?.includeHidden,
-      params?.fields,
-    ],
-    queryFn: async () => {
-      if (!kafkaId) {
-        throw new Error('Kafka ID is required');
-      }
-
-      const searchParams = new URLSearchParams();
-
-      if (params?.pageSize) {
-        searchParams.set('page[size]', params.pageSize.toString());
-      }
-
-      // Handle cursor-based pagination
-      if (params?.pageCursor) {
-        if (params.pageCursor.startsWith('after:')) {
-          searchParams.set('page[after]', params.pageCursor.slice(6));
-        } else if (params.pageCursor.startsWith('before:')) {
-          searchParams.set('page[before]', params.pageCursor.slice(7));
-        }
-      }
-
-      if (params?.sort) {
-        const sortPrefix = params.sortDir === 'desc' ? '-' : '';
-        searchParams.set('sort', `${sortPrefix}${params.sort}`);
-      }
-      if (params?.name) {
-        searchParams.set('filter[name]', `like,*${params.name}*`);
-      }
-      if (params?.status && params.status.length > 0) {
-        searchParams.set('filter[status]', `in,${params.status.join(',')}`);
-      }
-      if (params?.id) {
-        searchParams.set('filter[id]', params.id);
-      }
-      if (params?.includeHidden) {
-        searchParams.set('filter[visibility]', 'in,internal,external');
-      }
-      if (params?.fields) {
-        searchParams.set('fields[topics]', params.fields.join(','));
-      }
-
-      const queryString = searchParams.toString();
-      const path = `/api/kafkas/${kafkaId}/topics${queryString ? `?${queryString}` : ''}`;
-
-      return apiClient.get<TopicsResponse>(path);
-    },
-    enabled: !!kafkaId,
-  });
+  return useResourceList<Topic>(
+    'topics',
+    `/api/kafkas/${kafkaId}/topics`,
+    {
+      ...params,
+      enabled: !!kafkaId && (params?.enabled ?? true),
+    }
+  );
 }
 
 /**

--- a/api/src/main/webui/src/api/types.ts
+++ b/api/src/main/webui/src/api/types.ts
@@ -10,13 +10,15 @@
 // All `meta` properties are generic records with can be extended with type-specific properties.
 export type AbstractMeta = Record<string, unknown>;
 
+export type PaginationMeta = {
+  total: number;
+  pageNumber: number;
+  rangeTruncated: boolean;
+};
+
 export interface ListResponse<T extends Resource> {
   meta?: AbstractMeta & {
-    page: {
-      total: number;
-      pageNumber: number;
-      rangeTruncated: boolean;
-    } & Record<string, unknown>;
+    page: PaginationMeta;
   };
   links?: {
     first?: string;
@@ -58,7 +60,7 @@ export interface ResourceIdentifier {
   id: string;
 }
 
-export interface MetaWithPrivileges {
+export interface MetaWithPrivileges extends AbstractMeta {
   privileges?: string[];
 }
 
@@ -66,7 +68,10 @@ export interface Resource {
   type: string;
   id: string;
   attributes?: Record<string, unknown>;
-  relationships?: Record<string, { data: ResourceIdentifier | ResourceIdentifier[] }>;
+  relationships?: Record<string, {
+    data?: ResourceIdentifier | ResourceIdentifier[] | unknown[];
+    meta?: Record<string, unknown>;
+  } | null>;
   meta?: AbstractMeta;
 }
 
@@ -108,15 +113,6 @@ export interface KafkaCluster extends Resource {
   };
 }
 
-export interface KafkaClustersResponse {
-  data: KafkaCluster[];
-  meta?: MetaWithPrivileges & {
-    page?: {
-      total?: number;
-    };
-  };
-}
-
 // Topic types
 export interface Partition {
   partition: number;
@@ -150,6 +146,22 @@ export interface ConfigValue {
   documentation?: string;
 }
 
+export type TopicStatusSummary = {
+  FullyReplicated?: number;
+  UnderReplicated?: number;
+  PartiallyOffline?: number;
+  Offline?: number;
+  Unknown?: number;
+};
+
+export interface TopicListMeta extends MetaWithPrivileges {
+  page: PaginationMeta;
+  summary: {
+    statuses: TopicStatusSummary;
+    totalPartitions: number;
+  };
+}
+
 export interface Topic {
   id: string;
   type: 'topics';
@@ -173,30 +185,6 @@ export interface Topic {
       };
       data?: unknown[];
     } | null;
-  };
-}
-
-export interface TopicsResponse {
-  data: Topic[];
-  meta: MetaWithPrivileges & {
-    page: {
-      total: number;
-      pageNumber: number;
-    };
-    summary: {
-      statuses: {
-        FullyReplicated?: number;
-        UnderReplicated?: number;
-        PartiallyOffline?: number;
-        Offline?: number;
-        Unknown?: number;
-      };
-      totalPartitions: number;
-    };
-  };
-  links: {
-    next?: string;
-    prev?: string;
   };
 }
 

--- a/api/src/main/webui/src/components/common/DataViewFilters.tsx
+++ b/api/src/main/webui/src/components/common/DataViewFilters.tsx
@@ -3,11 +3,13 @@
 // This file is adapted from PatternFly with minimal changes
 /**
  * This component was copied from @patternfly/react-data-view and modified to support arbitrary children,
- * e.g. to allow filters to render icons. The original component uses JSON.stringify to generate the childrenHash,
- * which breaks with a cyclic object error for some React component children.
+ * e.g. to allow filters to render icons. The original component uses JSON.stringify over child element properties
+ * to generate the childrenHash, which breaks with a cyclic object error for some React component children.
  * 
  * This component should be kept in sync with the original component and removed if and when the original no longer
- * uses JSON.stringify.
+ * results in cyclic object errors from JSON.stringify.
+ * 
+ * See: https://github.com/patternfly/patternfly-react/issues/12536
  */
 import { Children, isValidElement, cloneElement, useMemo, useState, useRef, useEffect, ReactElement, ReactNode } from 'react';
 import {
@@ -61,8 +63,12 @@ export const DataViewFilters = <T extends object>({
   const attributeContainerRef = useRef<HTMLDivElement>(null);
 
   const childrenHash = useMemo(() =>
-    Children.map(children, (child) =>
-      isValidElement(child) ? { type: child.type, key: child.key, props: child.props } : child
+    JSON.stringify(
+      Children.map(children, (child) =>
+        isValidElement(child)
+          ? { key: child.key, filterId: (child.props as any).filterId, title: (child.props as any).title }
+          : child
+      )
     )
   , [ children ]);
 

--- a/api/src/main/webui/src/components/common/DataViewFilters.tsx
+++ b/api/src/main/webui/src/components/common/DataViewFilters.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable */
+// @ts-nocheck
+// This file is adapted from PatternFly with minimal changes
+/**
+ * This component was copied from @patternfly/react-data-view and modified to support arbitrary children,
+ * e.g. to allow filters to render icons. The original component uses JSON.stringify to generate the childrenHash,
+ * which breaks with a cyclic object error for some React component children.
+ * 
+ * This component should be kept in sync with the original component and removed if and when the original no longer
+ * uses JSON.stringify.
+ */
+import { Children, isValidElement, cloneElement, useMemo, useState, useRef, useEffect, ReactElement, ReactNode } from 'react';
+import {
+  Menu, MenuContent, MenuItem, MenuList, MenuToggle, Popper, ToolbarGroup, ToolbarToggleGroup, ToolbarToggleGroupProps,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+
+export interface DataViewFilterOption {
+  /** Filter option label */
+  label: ReactNode;
+  /** Filter option value */
+  value: string;
+}
+
+// helper interface to generate attribute menu
+interface DataViewFilterIdentifiers {
+  filterId: string;
+  title: string;
+}
+
+/** extends ToolbarToggleGroupProps */
+export interface DataViewFiltersProps<T extends object> extends Omit<ToolbarToggleGroupProps, 'toggleIcon' | 'breakpoint' | 'onChange'> {
+  /** Content rendered inside the data view */
+  children: React.ReactNode;
+  /** Optional onChange callback shared across filters */
+  onChange?: (key: string, newValues: Partial<T>) => void;
+  /** Optional values shared across filters */
+  values?: T;
+  /** Icon for the toolbar toggle group */
+  toggleIcon?: ToolbarToggleGroupProps['toggleIcon'];
+  /** Breakpoint for the toolbar toggle group */
+  breakpoint?: ToolbarToggleGroupProps['breakpoint'];
+  /** Custom OUIA ID */
+  ouiaId?: string;
+};
+
+
+export const DataViewFilters = <T extends object>({
+  children,
+  ouiaId = 'DataViewFilters',
+  toggleIcon = <FilterIcon />,
+  breakpoint = 'xl',
+  onChange,
+  values,
+  ...props
+}: DataViewFiltersProps<T>) => {
+  const [ activeAttributeMenu, setActiveAttributeMenu ] = useState<string>('');
+  const [ isAttributeMenuOpen, setIsAttributeMenuOpen ] = useState(false);
+  const attributeToggleRef = useRef<HTMLButtonElement>(null);
+  const attributeMenuRef = useRef<HTMLDivElement>(null);
+  const attributeContainerRef = useRef<HTMLDivElement>(null);
+
+  const childrenHash = useMemo(() =>
+    Children.map(children, (child) =>
+      isValidElement(child) ? { type: child.type, key: child.key, props: child.props } : child
+    )
+  , [ children ]);
+
+  const filterItems: DataViewFilterIdentifiers[] = useMemo(() => Children.toArray(children)
+    .map(child =>
+      isValidElement(child) ? { filterId: String((child.props as any).filterId), title: String((child.props as any).title) } : undefined
+    ).filter((item): item is DataViewFilterIdentifiers => !!item), [ childrenHash ]);
+
+  useEffect(() => {
+    filterItems.length > 0 && setActiveAttributeMenu(filterItems[0].title);
+  }, [ filterItems ]);
+
+  const handleClickOutside = (event: MouseEvent) => 
+    isAttributeMenuOpen &&
+    !attributeMenuRef.current?.contains(event.target as Node) &&
+    !attributeToggleRef.current?.contains(event.target as Node)
+    && setIsAttributeMenuOpen(false);
+
+  useEffect(() => {
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [ isAttributeMenuOpen ]);
+
+  const attributeToggle = (
+    <MenuToggle
+      ref={attributeToggleRef}
+      onClick={() => setIsAttributeMenuOpen(!isAttributeMenuOpen)}
+      isExpanded={isAttributeMenuOpen}
+      icon={toggleIcon}
+    >
+      {activeAttributeMenu}
+    </MenuToggle>
+  );
+
+  const attributeMenu = (
+    <Menu
+      ref={attributeMenuRef}
+      onSelect={(_ev, itemId) => {
+        const selectedItem = filterItems.find(item => item.filterId === itemId);
+        selectedItem && setActiveAttributeMenu(selectedItem.title);
+        setIsAttributeMenuOpen(false);
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          {filterItems.map(item => (
+            <MenuItem key={item.filterId} itemId={item.filterId}>
+              {item.title}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <ToolbarToggleGroup data-ouia-component-id={ouiaId} toggleIcon={toggleIcon} breakpoint={breakpoint} {...props}>
+      <ToolbarGroup variant="filter-group">
+        <div ref={attributeContainerRef}>
+          <Popper
+            trigger={attributeToggle}
+            triggerRef={attributeToggleRef}
+            popper={attributeMenu}
+            popperRef={attributeMenuRef}
+            appendTo={attributeContainerRef.current || undefined}
+            isVisible={isAttributeMenuOpen}
+          />
+        </div>
+        {Children.map(children, (child) =>
+          isValidElement(child)
+            ? cloneElement(child as ReactElement<{
+              showToolbarItem: boolean;
+              onChange: (_e: unknown, values: unknown) => void;
+              value: unknown;
+            }>, {
+              showToolbarItem: activeAttributeMenu === (child.props as any).title,
+              onChange: (event, value) => onChange?.((child.props as any).filterId, { [(child.props as any).filterId]: value } as Partial<T>),
+              value: values?.[(child.props as any).filterId],
+              ...(child.props as any)
+            })
+            : child
+        )}
+      </ToolbarGroup>
+    </ToolbarToggleGroup>
+  );
+};
+
+export default DataViewFilters;

--- a/api/src/main/webui/src/components/common/ResourceListDataView.tsx
+++ b/api/src/main/webui/src/components/common/ResourceListDataView.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   DataView,
+  DataViewCheckboxFilter,
   DataViewTable,
   DataViewToolbar,
   DataViewTextFilter,
@@ -23,15 +24,16 @@ import {
  */
 import { DataViewTh } from '@patternfly/react-data-view/dist/cjs/DataViewTable';
 import {
-  Pagination,
   EmptyState,
   EmptyStateBody,
+  Pagination,
+  Switch,
 } from '@patternfly/react-core';
 import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
-import { SearchIcon, CubesIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
+import { CubesIcon, ErrorCircleOIcon, SearchIcon } from '@patternfly/react-icons';
 import { ISortBy, Tbody, Td, Tr } from '@patternfly/react-table';
 import { ListResponse, Resource } from '@/api/types';
-import { DataViewFilters } from '@patternfly/react-data-view/dist/dynamic/DataViewFilters';
+import { DataViewFilters } from './DataViewFilters';
 import { ResourceListParams } from '@/api/hooks/useResourceList';
 import { UseQueryResult } from '@tanstack/react-query';
 import { ApiError } from '@/api/client';
@@ -46,12 +48,50 @@ const perPageOptions = [
 
 const DEFAULT_PAGE_SIZE = 10;
 
+type FilterValue = string | string[] | boolean;
+
+interface ResourceListTextFilterConfig {
+  type: 'text';
+  title: string;
+  placeholder: string;
+  initialValue?: string;
+  chipLabel?: string;
+}
+
+interface ResourceListCheckboxFilterOption {
+  value: string;
+  label: React.ReactNode;
+}
+
+interface ResourceListCheckboxFilterConfig {
+  type: 'checkbox';
+  title: string;
+  placeholder: string;
+  initialValue?: string[];
+  chipLabel?: string;
+  options: ResourceListCheckboxFilterOption[];
+}
+
+interface ResourceListToggleFilterConfig {
+  type: 'toggle';
+  title: string;
+  placeholder?: string;
+  initialValue?: boolean;
+  chipLabel?: string;
+  label: React.ReactNode;
+}
+
+export type ResourceListFilterConfig =
+  | ResourceListTextFilterConfig
+  | ResourceListCheckboxFilterConfig
+  | ResourceListToggleFilterConfig;
+
 // Custom hook for text filter handlers
 const useTextFilterHandlers = (
   filterId: string,
   pendingFilters: Record<string, string>,
   setPendingFilters: React.Dispatch<React.SetStateAction<Record<string, string>>>,
-  onSetFilters: (newFilters: Partial<Record<string, string | string[]>>) => void,
+  onSetFilters: (newFilters: Partial<Record<string, FilterValue>>) => void,
 ) => {
   const handleChange = useCallback((_event: React.FormEvent<HTMLInputElement> | undefined, value: string) => {
     if (value) {
@@ -87,7 +127,7 @@ const useTextFilterHandlers = (
 type TextFilterWrapperProps = DataViewTextFilterProps & {
   pendingFilters: Record<string, string>;
   setPendingFilters: React.Dispatch<React.SetStateAction<Record<string, string>>>;
-  onSetFilters: (newFilters: Partial<Record<string, string | string[]>>) => void;
+  onSetFilters: (newFilters: Partial<Record<string, FilterValue>>) => void;
 };
 
 // Component wrapper for text filter to avoid hooks-in-callback issue
@@ -107,6 +147,30 @@ const TextFilterWrapper: React.FC<TextFilterWrapperProps> = (props) => {
     />,
     [filterProps, handleChange, handleClear, handleSearch]);
 }
+
+function ToggleFilter({
+  filterId,
+  filter,
+  isChecked,
+  onChange,
+}: {
+  filterId: string;
+  filter: ResourceListToggleFilterConfig;
+  isChecked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div style={{ display: 'inline-flex', alignSelf: 'center' }}>
+      <Switch
+        id={`${filterId}-filter-toggle`}
+        label={filter.label}
+        isChecked={isChecked}
+        onChange={(_event, checked) => onChange(checked)}
+      />
+    </div>
+  );
+}
+
 export interface ResourceListDataViewColumnMapper {
   (
     sortBy?: string, 
@@ -133,12 +197,7 @@ export interface ResourceListDataViewProps<T extends Resource> {
     dependencies: unknown[];
     callback: ResourceListDataViewRowMapper<T>;
   };
-  dataFilters?: Record<string, {
-    type: 'text' | 'checkbox';
-    title: string;
-    placeholder: string;
-    initialValue?: string | string[];
-  }>;
+  dataFilters?: Record<string, ResourceListFilterConfig>;
   ariaLabel?: string;
   ouiaIdPrefix?: string;
   onDataViewChange: (params: ResourceListParams) => void;
@@ -168,19 +227,22 @@ export function ResourceListDataView<T extends Resource>({
       if (config.type === 'checkbox') {
         // Empty array for checkbox filters
         acc[filterId] = config.initialValue ?? [];
+      } else if (config.type === 'toggle') {
+        // False for toggle filters
+        acc[filterId] = config.initialValue ?? false;
       } else {
         // Empty string for text filters
         acc[filterId] = config.initialValue ?? '';
       }
       return acc;
-    }, {} as Record<string, string | string[]>);
+    }, {} as Record<string, FilterValue>);
   }, [ dataFilters ]);
 
   const {
     filters,
     onSetFilters,
     clearAllFilters
-  } = useDataViewFilters<Record<string, string | string[]>>({
+  } = useDataViewFilters<Record<string, FilterValue>>({
     initialFilters,
     searchParams,
     setSearchParams: () => {
@@ -224,9 +286,19 @@ export function ResourceListDataView<T extends Resource>({
     return params;
   }, [sortParam]);
 
-  const { sortBy, direction, onSort } = useDataViewSort({
+  const { sortBy, direction, onSort: originalOnSort } = useDataViewSort({
     searchParams: sortSearchParams,
   });
+
+  const onSort = useCallback((
+    event: React.MouseEvent | React.KeyboardEvent | MouseEvent | undefined,
+    newSortBy: string,
+    newDirection: ISortBy["direction"]
+  ) => {
+    setBeforeCursor(undefined);
+    setAfterCursor(undefined);
+    originalOnSort?.(event, newSortBy, newDirection);
+  }, [originalOnSort]);
 
   const listResponse = resourceResult.data;
   const totalCount = listResponse?.meta?.page?.total ?? 0;
@@ -285,8 +357,8 @@ export function ResourceListDataView<T extends Resource>({
     setPendingFilters({});
   }, [clearAllFilters]);
 
-  const handleFilterChange = useCallback((_key: string, newValues: Partial<Record<string, string | string[]>>) => {
-    onSetFilters(newValues as Record<string, string | string[]>);
+  const handleFilterChange = useCallback((_key: string, newValues: Partial<Record<string, FilterValue>>) => {
+    onSetFilters(newValues as Record<string, FilterValue>);
   }, [onSetFilters]);
 
   // Manually sync to URL in a single effect
@@ -302,12 +374,22 @@ export function ResourceListDataView<T extends Resource>({
         let newValue: string | undefined;
         const oldNormalized: string | undefined = oldValue;
         
-        if (value) {
-          if (Array.isArray(value)) {
+        if (Array.isArray(value)) {
+          if (value.length > 0) {
             newValue = value.join(',');
+            newParams.set(key, newValue);
           } else {
-            newValue = value;
+            newValue = undefined;
           }
+        } else if (typeof value === 'boolean') {
+          if (value) {
+            newValue = 'true';
+            newParams.set(key, newValue);
+          } else {
+            newValue = undefined;
+          }
+        } else if (value) {
+          newValue = value;
           newParams.set(key, newValue);
         } else {
           newValue = undefined;
@@ -389,7 +471,15 @@ export function ResourceListDataView<T extends Resource>({
     const searchFilters: Record<string, string | string[]> = {};
 
     Object.entries(filters).forEach(([ key, value ]) => {
-      if (value) {
+      if (Array.isArray(value)) {
+        if (value.length > 0) {
+          searchFilters[key] = value;
+        }
+      } else if (typeof value === 'boolean') {
+        if (value) {
+          searchFilters[key] = 'true';
+        }
+      } else if (value) {
         searchFilters[key] = value;
       }
     });
@@ -428,7 +518,10 @@ export function ResourceListDataView<T extends Resource>({
       if (Array.isArray(value)) {
         return value.length > 0;
       }
-      return value?.trim().length > 0
+      if (typeof value === 'boolean') {
+        return value;
+      }
+      return value?.trim().length > 0;
     });
 
     return (
@@ -464,6 +557,14 @@ export function ResourceListDataView<T extends Resource>({
     [perPage, columns.length]
   );
 
+  const serializableFilters = dataFilters
+    ? Object.entries(dataFilters).filter(([, filter]) => filter.type !== 'toggle')
+    : [];
+
+  const toggleFilters = dataFilters
+    ? Object.entries(dataFilters).filter(([, filter]) => filter.type === 'toggle')
+    : [];
+
   return (
     <DataViewEventsProvider>
       <DataView activeState={activeState}>
@@ -471,27 +572,54 @@ export function ResourceListDataView<T extends Resource>({
         <DataViewToolbar
           ouiaId={`${ouiaIdPrefix}-toolbar`}
           clearAllFilters={handleClearAllFilters}
-          filters={ dataFilters &&
-            <DataViewFilters
-              onChange={handleFilterChange}
-              values={filters}>
-              { Object.entries(dataFilters).map(([name, filter]) => {
-                if (filter.type === 'checkbox') {
-                  return <React.Fragment key={`filter-${name}`} />; // TODO: Add checkbox filter component
-                } else {
-                  return <TextFilterWrapper
-                    key={`filter-${name}`}
-                    filterId={name}
-                    title={filter.title}
-                    placeholder={filter.placeholder}
-                    pendingFilters={pendingFilters}
-                    setPendingFilters={setPendingFilters}
-                    onSetFilters={onSetFilters}
-                  />;
-                }
-              })}
-            </DataViewFilters>
-          }
+          filters={serializableFilters.length > 0 && (
+            <>
+              <DataViewFilters
+                onChange={handleFilterChange}
+                values={filters}>
+                {serializableFilters.map(([name, filter]) => {
+                  if (filter.type === 'checkbox') {
+                    return (
+                      <DataViewCheckboxFilter
+                        key={`filter-${name}`}
+                        filterId={name}
+                        title={filter.title}
+                        chipTitle={filter.chipLabel}
+                        placeholder={filter.placeholder}
+                        value={Array.isArray(filters[name]) ? filters[name] as string[] : []}
+                        options={filter.options.map(option => ({
+                          label: option.label,
+                          value: option.value,
+                        }))}
+                        onChange={(_event, newValues) => onSetFilters({ [name]: newValues ?? [] })}
+                      />
+                    );
+                  }
+
+                  if (filter.type === 'text') {
+                    return <TextFilterWrapper
+                      key={`filter-${name}`}
+                      filterId={name}
+                      title={filter.title}
+                      placeholder={filter.placeholder}
+                      pendingFilters={pendingFilters}
+                      setPendingFilters={setPendingFilters}
+                      onSetFilters={onSetFilters}
+                    />;
+                  }
+                }).filter(entry => entry !== undefined)}
+              </DataViewFilters>
+              {toggleFilters.map(([name, filter]) => (
+                <ToggleFilter
+                  key={`filter-${name}`}
+                  filterId={name}
+                  filter={filter as ResourceListToggleFilterConfig}
+                  isChecked={filters[name] === true}
+                  onChange={(checked) => onSetFilters({ [name]: checked })}
+                />
+              ))}
+            </>
+          )}
           pagination={paginationControl}
         />
 

--- a/api/src/main/webui/src/components/common/ResourceListDataView.tsx
+++ b/api/src/main/webui/src/components/common/ResourceListDataView.tsx
@@ -614,7 +614,7 @@ export function ResourceListDataView<T extends Resource>({
                   key={`filter-${name}`}
                   filterId={name}
                   filter={filter as ResourceListToggleFilterConfig}
-                  isChecked={filters[name] === true}
+                  isChecked={String(filters[name]) === 'true'}
                   onChange={(checked) => onSetFilters({ [name]: checked })}
                 />
               ))}

--- a/api/src/main/webui/src/components/home/ClustersDataView.tsx
+++ b/api/src/main/webui/src/components/home/ClustersDataView.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -116,6 +116,11 @@ export function ClustersDataView({
     [t, handleSort]
   );
 
+  const colProvider = useMemo(() => ({
+    dependencies: [t, handleSort],
+    callback: colMapper,
+  }), [colMapper, t, handleSort]);
+
   const rowMapper: ResourceListDataViewRowMapper<KafkaCluster> = useCallback(
     (cluster) => ({
       id: cluster.id,
@@ -187,6 +192,11 @@ export function ClustersDataView({
     [t, showLoginModal, navigate]
   );
 
+  const rowProvider = useMemo(() => ({
+    dependencies: [navigate, t],
+    callback: rowMapper,
+  }), [rowMapper, navigate, t]);
+
   return (
     <ResourceListDataView
       resourceResult={clusterResult}
@@ -200,14 +210,8 @@ export function ClustersDataView({
           placeholder: t('kafka.filterByName'),
         },
       }}
-      columnProvider={{
-        dependencies: [t, handleSort],
-        callback: colMapper,
-      }}
-      rowProvider={{
-        dependencies: [navigate, t],
-        callback: rowMapper,
-      }}
+      columnProvider={colProvider}
+      rowProvider={rowProvider}
       />
   );
 }

--- a/api/src/main/webui/src/components/kafka/overview/TopicChartsCard.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/TopicChartsCard.tsx
@@ -57,14 +57,14 @@ export function TopicChartsCard({
   const [selectedDuration, setSelectedDuration] = useState<DurationOptions>(
     DurationOptions.Last5minutes
   );
-  const [hideInternal, setHideInternal] = useState(true);
+  const [showInternal, setShowInternal] = useState(false);
 
-  // Filter topics based on hideInternal setting
+  // Filter topics based on showInternal setting
   const filteredTopics = useMemo(() => {
-    return hideInternal
-      ? topics.filter((t) => !t.isInternal)
-      : topics;
-  }, [topics, hideInternal]);
+    return showInternal
+      ? topics
+      : topics.filter((t) => !t.isInternal);
+  }, [topics, showInternal]);
 
   // Selected topic that is actually present in the filtered list
   const [validSelectedTopic, validSelectedTopicName] = useMemo(() => {
@@ -165,15 +165,15 @@ export function TopicChartsCard({
                   <Switch
                     label={
                       <>
-                        {t('topics.hideInternalTopics')}
+                        {t('topics.showInternalTopics')}
                         &nbsp;
-                        <Tooltip content={t('topics.hideInternalTopicsTooltip')}>
+                        <Tooltip content={t('topics.showInternalTopicsTooltip')}>
                           <HelpIcon />
                         </Tooltip>
                       </>
                     }
-                    isChecked={hideInternal}
-                    onChange={(_event, checked) => setHideInternal(checked)}
+                    isChecked={showInternal}
+                    onChange={(_event, checked) => setShowInternal(checked)}
                   />
                 </FlexItem>
                 <FlexItem>

--- a/api/src/main/webui/src/components/kafka/topics/TopicsDataView.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/TopicsDataView.tsx
@@ -1,0 +1,257 @@
+import { useCallback } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ThProps } from '@patternfly/react-table';
+import { UseQueryResult } from '@tanstack/react-query';
+import { Topic, ListResponse } from '@/api/types';
+import { ResourceListFilterValue, ResourceListParams } from '@/api/hooks/useResourceList';
+import {
+  ResourceListDataView,
+  ResourceListDataViewColumnMapper,
+  ResourceListDataViewRowMapper,
+} from '@/components/common/ResourceListDataView';
+import { ManagedTopicLabel } from './ManagedTopicLabel';
+import { StatusLabel } from '@/components/StatusLabel';
+import { TOPIC_STATUS_CONFIG } from '@/components/StatusLabel/configs';
+import type { TopicStatus } from '@/components/StatusLabel/configs';
+import { formatBytes } from '@/utils/format';
+import { HelpIcon } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core';
+
+const columnNames = ['name', 'status', 'numPartitions', 'groups', 'totalLeaderLogBytes'] as const;
+
+interface TopicsDataViewProps {
+  topicResult: UseQueryResult<ListResponse<Topic>, Error>;
+  onDataViewChange: (params: ResourceListParams) => void;
+}
+
+export function TopicsDataView({
+  topicResult,
+  onDataViewChange,
+}: TopicsDataViewProps) {
+  const { t } = useTranslation();
+  const { kafkaId } = useParams<{ kafkaId: string }>();
+
+  const handleDataViewChange = useCallback((params: ResourceListParams) => {
+    const filters: Record<string, string | string[] | ResourceListFilterValue> = {};
+
+    Object.entries(params.filters ?? {}).forEach(([key, value]) => {
+      if (key === 'includeHidden') {
+        if (value === 'true') {
+          filters.visibility = {
+            operator: 'in',
+            value: 'internal,external',
+          };
+        }
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        if (value.length > 0) {
+          filters[key] = {
+            operator: 'in',
+            value: value.join(','),
+          };
+        }
+        return;
+      }
+
+      if (typeof value === 'string' && value.length > 0) {
+        filters[key] = key === 'id' ? {
+          operator: 'eq',
+          value,
+        } : value ;
+      }
+    });
+
+    onDataViewChange({
+      ...params,
+      filters,
+    });
+  }, [onDataViewChange]);
+
+  const handleSort = useCallback((
+    onSort: ((event: React.MouseEvent, sortBy: string, direction: 'asc' | 'desc') => void) | undefined,
+    event: React.MouseEvent,
+    columnIndex: number,
+    direction: 'asc' | 'desc'
+  ) => {
+    onSort?.(event, columnNames[columnIndex], direction);
+  }, []);
+
+  const colMapper: ResourceListDataViewColumnMapper = useCallback(
+    (sortBy, direction, onSort) => [
+      {
+        cell: t('topics.columnName'),
+        props: {
+          sort: {
+            sortBy: {
+              index: sortBy ? columnNames.indexOf(sortBy as typeof columnNames[number]) : undefined,
+              direction,
+            },
+            columnIndex: 0,
+            onSort: (event, columnIndex, sortDirection) =>
+              handleSort(onSort, event, columnIndex, sortDirection),
+          } as ThProps['sort'],
+        },
+      },
+      {
+        cell: 
+          <>
+            {t('topics.columnStatus')}
+            {' '}
+            <Tooltip content={t('topics.columnStatusTooltip')}>
+              <HelpIcon />
+            </Tooltip>
+          </>,
+      },
+      {
+        cell: t('topics.columnPartitions'),
+        props: {
+          modifier: 'fitContent',
+          style: { textAlign: 'right' },
+        },
+      },
+      {
+        cell: t('topics.columnGroups'),
+        props: {
+          modifier: 'fitContent',
+          style: { textAlign: 'right' },
+        },
+      },
+      {
+        cell: t('topics.columnStorage'),
+        props: {
+          modifier: 'fitContent',
+          style: { textAlign: 'right' },
+          sort: {
+            sortBy: {
+              index: sortBy ? columnNames.indexOf(sortBy as typeof columnNames[number]) : undefined,
+              direction,
+            },
+            columnIndex: 4,
+            onSort: (event, columnIndex, sortDirection) =>
+              handleSort(onSort, event, columnIndex, sortDirection),
+          } as ThProps['sort'],
+        },
+      },
+    ],
+    [t, handleSort]
+  );
+
+  const rowMapper: ResourceListDataViewRowMapper<Topic> = useCallback(
+    (topic) => ({
+      id: topic.id,
+      row: [
+        {
+          cell: (
+            <>
+              <Link to={`/kafka/${kafkaId}/topics/${topic.id}`}>
+                {topic.attributes.name}
+              </Link>
+              {topic.meta?.managed === true && <ManagedTopicLabel />}
+            </>
+          ),
+          props: {
+            dataLabel: t('topics.columnName'),
+          },
+        },
+        {
+          cell: topic.attributes.status ? (
+            <StatusLabel status={topic.attributes.status} config={TOPIC_STATUS_CONFIG} />
+          ) : '-',
+          props: {
+            dataLabel: t('topics.columnStatus'),
+          },
+        },
+        {
+          cell: topic.attributes.numPartitions !== null && topic.attributes.numPartitions !== undefined ? (
+            <Link to={`/kafka/${kafkaId}/topics/${topic.id}/partitions`}>
+              {topic.attributes.numPartitions}
+            </Link>
+          ) : '-',
+          props: {
+            dataLabel: t('topics.columnPartitions'),
+            modifier: 'fitContent',
+            style: { textAlign: 'right' },
+          },
+        },
+        {
+          cell: topic.relationships?.groups?.meta?.count !== undefined ? (
+            <Link to={`/kafka/${kafkaId}/topics/${topic.id}/groups`}>
+              {topic.relationships.groups.meta.count}
+            </Link>
+          ) : (
+            topic.relationships?.groups?.meta?.count ?? '-'
+          ),
+          props: {
+            dataLabel: t('topics.columnGroups'),
+            modifier: 'fitContent',
+            style: { textAlign: 'right' },
+          },
+        },
+        {
+          cell: formatBytes(topic.attributes.totalLeaderLogBytes),
+          props: {
+            dataLabel: t('topics.columnStorage'),
+            modifier: 'fitContent',
+            style: { textAlign: 'right' },
+          },
+        },
+      ],
+    }),
+    [kafkaId, t]
+  );
+
+  return (
+    <ResourceListDataView
+      resourceResult={topicResult}
+      onDataViewChange={handleDataViewChange}
+      ariaLabel={t('topics.tableLabel')}
+      ouiaIdPrefix="topics"
+      dataFilters={{
+        name: {
+          type: 'text',
+          title: t('topics.filter.name'),
+          placeholder: t('topics.filter.namePlaceholder'),
+        },
+        status: {
+          type: 'checkbox',
+          title: t('topics.filter.status'),
+          placeholder: t('topics.filter.selectStatus'),
+          options: Object.keys(TOPIC_STATUS_CONFIG).map((status) => ({
+            value: status,
+            label: <StatusLabel status={status as TopicStatus} config={TOPIC_STATUS_CONFIG} />,
+          })),
+        },
+        id: {
+          type: 'text',
+          title: t('topics.filter.topicId'),
+          placeholder: t('topics.filter.idPlaceholder'),
+        },
+        includeHidden: {
+          type: 'toggle',
+          title: t('topics.showInternalTopics'),
+          chipLabel: t('topics.showInternalTopics'),
+          initialValue: false,
+          label: (
+            <>
+              {t('topics.showInternalTopics')}{' '}
+              <Tooltip content={t('topics.showInternalTopicsTooltip')}>
+                <HelpIcon />
+              </Tooltip>
+            </>
+          ),
+        },
+      }}
+      columnProvider={{
+        dependencies: [t, handleSort],
+        callback: colMapper,
+      }}
+      rowProvider={{
+        dependencies: [kafkaId, t],
+        callback: rowMapper,
+      }}
+    />
+  );
+}

--- a/api/src/main/webui/src/components/kafka/topics/TopicsDataView.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/TopicsDataView.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ThProps } from '@patternfly/react-table';
@@ -139,6 +139,11 @@ export function TopicsDataView({
     [t, handleSort]
   );
 
+  const colProvider = useMemo(() => ({
+      dependencies: [t, handleSort],
+      callback: colMapper,
+  }), [colMapper, t, handleSort]);
+
   const rowMapper: ResourceListDataViewRowMapper<Topic> = useCallback(
     (topic) => ({
       id: topic.id,
@@ -203,6 +208,11 @@ export function TopicsDataView({
     [kafkaId, t]
   );
 
+  const rowProvider = useMemo(() => ({
+    dependencies: [kafkaId, t],
+    callback: rowMapper,
+  }), [rowMapper, kafkaId, t]);
+
   return (
     <ResourceListDataView
       resourceResult={topicResult}
@@ -244,14 +254,8 @@ export function TopicsDataView({
           ),
         },
       }}
-      columnProvider={{
-        dependencies: [t, handleSort],
-        callback: colMapper,
-      }}
-      rowProvider={{
-        dependencies: [kafkaId, t],
-        callback: rowMapper,
-      }}
+      columnProvider={colProvider}
+      rowProvider={rowProvider}
     />
   );
 }

--- a/api/src/main/webui/src/i18n/messages/en.json
+++ b/api/src/main/webui/src/i18n/messages/en.json
@@ -160,8 +160,8 @@
     "columnPartitions": "Partitions",
     "columnGroups": "Groups",
     "columnStorage": "Storage",
-    "hideInternalTopics": "Hide internal topics",
-    "hideInternalTopicsTooltip": "By convention internal topics are prefixed with __. These topics are usually created and managed by Kafka.",
+    "showInternalTopics": "Show internal topics",
+    "showInternalTopicsTooltip": "By convention internal topics are prefixed with __. These topics are usually created and managed by Kafka.",
     "filter": {
       "name": "Name",
       "topicId": "Topic ID",

--- a/api/src/main/webui/src/pages/kafka/overview/KafkaOverview.tsx
+++ b/api/src/main/webui/src/pages/kafka/overview/KafkaOverview.tsx
@@ -34,7 +34,8 @@ import { TopicChartsCard } from '@/components/kafka/overview/TopicChartsCard';
 import { ClusterConnectionProvider } from '@/components/kafka/overview/ClusterConnectionProvider';
 import { ClusterConnectionDrawer } from '@/components/kafka/overview/ClusterConnectionDrawer';
 import { useOpenClusterConnectionPanel } from '@/components/kafka/overview/ClusterConnectionContext';
-import type { Node, Topic, TopicsResponse } from '@/api/types';
+import type { Node, Topic, TopicListMeta } from '@/api/types';
+import { useMemo } from 'react';
 
 function KafkaOverviewContent() {
   const { t } = useTranslation();
@@ -50,16 +51,22 @@ function KafkaOverviewContent() {
 
   // Fetch topics summary for partition counts
   const { data: topicsSummaryData, isLoading: topicsSummaryLoading } = useTopics(kafkaId, {
-    pageSize: 1,
-    fields: ['status'],
+    fields: 'status',
+    page: {
+      size: 1,
+    },
   });
 
   // Fetch all topics for topic charts filter
   const { data: allTopicsData } = useTopics(kafkaId, {
-    includeHidden: true,
-    fields: ['name,visibility'],
-    sort: 'name',
-    pageSize: 100,
+    fields: 'name,visibility',
+    filters: {
+      visibility: [ 'internal', 'external' ],
+    },
+    page: {
+      sort: 'name',
+      size: 100,
+    },
   });
 
   // Fetch groups count
@@ -78,22 +85,28 @@ function KafkaOverviewContent() {
   });
 
   // Calculate broker counts
-  const brokersTotal = nodesData?.data?.filter(
-    (node: Node) => node.attributes.roles?.includes('broker')
-  ).length ?? 0;
+  const brokersTotal = useMemo(() => 
+    nodesData?.data?.filter(
+      (node: Node) => node.attributes.roles?.includes('broker')
+    ).length ?? 0,
+    [nodesData?.data]
+  );
 
   // Count online brokers (those with Running status)
-  const brokersOnline = nodesData?.data?.filter(
-    (node: Node) =>
-      node.attributes.roles?.includes('broker') &&
-      node.attributes.broker?.status === 'Running'
-  ).length ?? brokersTotal; // Default to total if status not available
+  const brokersOnline = useMemo(() =>
+    nodesData?.data?.filter(
+      (node: Node) =>
+        node.attributes.roles?.includes('broker') &&
+        node.attributes.broker?.status === 'Running'
+    ).length ?? brokersTotal, // Default to total if status not available
+    [nodesData?.data, brokersTotal]
+  );
 
   // Get groups count from meta
   const groupsCount = groupsData?.meta?.page?.total;
 
   // Get topic statistics from meta.summary (if available)
-  const topicsMeta: TopicsResponse['meta'] | undefined = topicsSummaryData?.meta;
+  const topicsMeta: TopicListMeta | undefined = topicsSummaryData?.meta as TopicListMeta;
   const totalTopics = topicsMeta?.page?.total ?? 0;
   
   // Calculate partition statistics
@@ -110,19 +123,25 @@ function KafkaOverviewContent() {
   const metricsAvailable = !isVirtualCluster;
 
   // Prepare nodes list for charts
-  const nodes = nodesData?.data
-    ?.filter((node: Node) => node.attributes.roles?.includes('broker'))
-    .map((node: Node) => ({
-      id: parseInt(node.id, 10),
-      name: `Node ${node.id}`,
-    })) ?? [];
+  const nodes = useMemo(() =>
+    nodesData?.data
+      ?.filter((node: Node) => node.attributes.roles?.includes('broker'))
+      .map((node: Node) => ({
+        id: parseInt(node.id, 10),
+        name: `Node ${node.id}`,
+      })) ?? [],
+    [nodesData?.data]
+  );
 
   // Prepare topics list for charts
-  const topics = allTopicsData?.data?.map((topic: Topic) => ({
-    id: topic.id,
-    name: topic.attributes.name,
-    isInternal: topic.attributes.visibility === 'internal',
-  })) ?? [];
+  const topics = useMemo(() =>
+    allTopicsData?.data?.map((topic: Topic) => ({
+      id: topic.id,
+      name: topic.attributes.name,
+      isInternal: topic.attributes.visibility === 'internal',
+    })) ?? [],
+    [allTopicsData?.data]
+  );
 
   const isLoading = clusterLoading || topicsSummaryLoading || groupsLoading;
 

--- a/api/src/main/webui/src/pages/kafka/topics/TopicsPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/TopicsPage.tsx
@@ -2,174 +2,48 @@
  * Topics Page - List all topics in a Kafka cluster
  */
 
-import { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useCallback, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,
   Title,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
   Spinner,
-  Pagination,
-  PaginationVariant,
-  Switch,
   Tooltip,
   Label,
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
-import {
-  Table,
-  Thead,
-  Tr,
-  Th,
-  Tbody,
-  Td,
-} from '@patternfly/react-table';
 import {
   ExclamationTriangleIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
 } from '@patternfly/react-icons';
 import { useTopics } from '@/api/hooks/useTopics';
-import { formatBytes } from '@/utils/format';
-import {
-  TopicsFilterToolbar,
-  TopicsFilterChips,
-  TopicsFilterState,
-  TopicsFilterType,
-  TopicStatus,
-} from '@/components/kafka/topics/TopicsFilter';
-import { ManagedTopicLabel } from '@/components/kafka/topics/ManagedTopicLabel';
-import { StatusLabel } from '@/components/StatusLabel';
-import { TOPIC_STATUS_CONFIG } from '@/components/StatusLabel/configs';
-import {
-  LoadingEmptyState,
-  ErrorEmptyState,
-  NoDataEmptyState,
-  NoResultsEmptyState,
-} from '@/components/EmptyStates';
-import { useTableState } from '@/hooks';
-import { useShowLearning } from '@/hooks/useShowLearning';
+import { ResourceListParams } from '@/api/hooks/useResourceList';
+import { TopicStatusSummary } from '@/api/types';
+import { TopicsDataView } from '@/components/kafka/topics/TopicsDataView';
 
-type SortableColumn = 'name' | 'totalLeaderLogBytes';
+const TOPIC_LISTING_FIELDS = 'name,status,numPartitions,totalLeaderLogBytes,groups';
 
 export function TopicsPage() {
   const { t } = useTranslation();
   const { kafkaId } = useParams<{ kafkaId: string }>();
-  const showLearning = useShowLearning();
-  
-  const [includeHidden, setIncludeHidden] = useState(false);
-
-  // Advanced filtering state
-  const [selectedFilterType, setSelectedFilterType] = useState<TopicsFilterType>('name');
-  const [filterValue, setFilterValue] = useState('');
-  const [filters, setFilters] = useState<TopicsFilterState>({});
-
-  // Table state: pagination + sorting (call BEFORE data fetching)
-  const table = useTableState<SortableColumn>({
-    initialSortColumn: 'name',
-    initialSortDirection: 'asc',
+  const [dataParams, setDataParams] = useState<ResourceListParams>({
+    fields: TOPIC_LISTING_FIELDS,
   });
 
-  // Fetch topics data
-  const { data, isLoading, error } = useTopics(kafkaId, {
-    pageSize: table.pageSize,
-    pageCursor: table.pageCursor,
-    sort: table.sortBy,
-    sortDir: table.sortDirection,
-    name: filters.name,
-    id: filters.id,
-    status: filters.status,
-    includeHidden,
-    fields: ['name', 'status', 'numPartitions', 'totalLeaderLogBytes', 'groups'],
-  });
+  const topicResult = useTopics(kafkaId, dataParams);
+  const { isLoading } = topicResult;
+  const totalItems = topicResult.data?.meta?.page?.total || 0;
+  const statusSummary = (topicResult.data?.meta?.summary as { statuses?: TopicStatusSummary } | undefined)?.statuses;
 
-  // Update table state with response data
-  useEffect(() => {
-    table.setData(data);
-  }, [data, table]);
-
-  const topics = data?.data || [];
-  const totalItems = data?.meta.page.total || 0;
-  const currentPage = data?.meta.page.pageNumber || 1;
-  const statusSummary = data?.meta.summary?.statuses;
-
-
-  const handleFilterSubmit = () => {
-    if (selectedFilterType === 'status') {
-      // Status filters are applied immediately via checkbox toggles
-      return;
-    }
-
-    if (!filterValue.trim()) {
-      return;
-    }
-
-    setFilters((prev) => ({
-      ...prev,
-      [selectedFilterType]: filterValue.trim(),
-    }));
-    setFilterValue('');
-    table.resetPagination(); // Reset to first page on filter change
-  };
-
-  const handleStatusToggle = (status: TopicStatus) => {
-    setFilters((prev) => {
-      const currentStatuses = prev.status || [];
-      const newStatuses = currentStatuses.includes(status)
-        ? currentStatuses.filter((s) => s !== status)
-        : [...currentStatuses, status];
-      
-      return {
-        ...prev,
-        status: newStatuses.length > 0 ? newStatuses : undefined,
-      };
+  const handleDataViewChange = useCallback((params: ResourceListParams) => {
+    setDataParams({
+      ...params,
+      fields: TOPIC_LISTING_FIELDS,
     });
-    table.resetPagination(); // Reset to first page on filter change
-  };
-
-  const handleRemoveFilter = (type: 'name' | 'id' | 'status', value?: string) => {
-    setFilters((prev) => {
-      if (type === 'status' && value) {
-        const newStatuses = (prev.status || []).filter((s) => s !== value);
-        return {
-          ...prev,
-          status: newStatuses.length > 0 ? newStatuses : undefined,
-        };
-      }
-      
-      const newFilters = { ...prev };
-      delete newFilters[type];
-      return newFilters;
-    });
-    table.resetPagination();
-  };
-
-  const handleClearAllFilters = () => {
-    setFilters({});
-    setFilterValue('');
-    table.resetPagination();
-  };
-
-  if (isLoading) {
-    return (
-      <PageSection>
-        <LoadingEmptyState message={t('topics.loading')} />
-      </PageSection>
-    );
-  }
-
-  if (error) {
-    return (
-      <PageSection>
-        <ErrorEmptyState error={error} />
-      </PageSection>
-    );
-  }
+  }, []);
 
   return (
     <>
@@ -216,158 +90,10 @@ export function TopicsPage() {
         </Title>
       </PageSection>
       <PageSection>
-        <Toolbar>
-          <ToolbarContent>
-            <ToolbarItem>
-              <TopicsFilterToolbar
-                selectedFilterType={selectedFilterType}
-                onFilterTypeChange={setSelectedFilterType}
-                filterValue={filterValue}
-                onFilterValueChange={setFilterValue}
-                onFilterSubmit={handleFilterSubmit}
-                selectedStatuses={filters.status || []}
-                onStatusToggle={handleStatusToggle}
-              />
-            </ToolbarItem>
-            <ToolbarItem alignSelf="center">
-              <Switch
-                label={
-                  <>
-                    {t('topics.hideInternalTopics')}&nbsp;
-                    <Tooltip content={t('topics.hideInternalTopicsTooltip')}>
-                      <HelpIcon />
-                    </Tooltip>
-                  </>
-                }
-                isChecked={!includeHidden}
-                onChange={(_event, checked) => {
-                  setIncludeHidden(!checked);
-                  table.resetPagination();
-                }}
-              />
-            </ToolbarItem>
-            <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
-              <Pagination
-                itemCount={totalItems}
-                perPage={table.pageSize}
-                page={currentPage}
-                onSetPage={() => {}}
-                onPerPageSelect={table.handlePerPageChange}
-                onNextClick={table.handleNextPage}
-                onPreviousClick={table.handlePrevPage}
-                isDisabled={false}
-                variant={PaginationVariant.top}
-                isCompact
-                titles={{
-                  paginationAriaLabel: t('topics.tableLabel'),
-                }}
-              />
-            </ToolbarItem>
-          </ToolbarContent>
-          <TopicsFilterChips
-            filters={filters}
-            onRemoveFilter={handleRemoveFilter}
-            onClearAllFilters={handleClearAllFilters}
-          />
-        </Toolbar>
-
-        {topics.length === 0 ? (
-          filters.name || filters.id || filters.status ? (
-            <NoResultsEmptyState />
-          ) : (
-            <NoDataEmptyState
-              entityName="topics"
-              message={t('topics.noTopicsDescription')}
-              learningLink={
-                showLearning && t('learning.links.topicOperatorUse')
-                  ? {
-                      href: t('learning.links.topicOperatorUse'),
-                      label: t('learning.labels.topicOperatorUse'),
-                    }
-                  : undefined
-              }
-            />
-          )
-        ) : (
-          <>
-            <Table ouiaId={"topics-listing"} aria-label={t('topics.tableLabel')} variant="compact">
-              <Thead>
-                <Tr>
-                  <Th sort={table.getSortParams('name')}>{t('topics.columnName')}</Th>
-                  <Th>
-                    {t('topics.columnStatus')}{' '}
-                    <Tooltip content={t('topics.columnStatusTooltip')}>
-                      <HelpIcon />
-                    </Tooltip>
-                  </Th>
-                  <Th modifier="fitContent" style={{ textAlign: 'right' }}>{t('topics.columnPartitions')}</Th>
-                  <Th modifier="fitContent" style={{ textAlign: 'right' }}>{t('topics.columnGroups')}</Th>
-                  <Th sort={table.getSortParams('totalLeaderLogBytes')} modifier="fitContent" style={{ textAlign: 'right' }}>{t('topics.columnStorage')}</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {topics.map((topic) => (
-                  <Tr key={topic.id}>
-                    <Td dataLabel={t('topics.columnName')}>
-                      <Link to={`/kafka/${kafkaId}/topics/${topic.id}`}>
-                        {topic.attributes.name}
-                      </Link>
-                      {topic.meta?.managed === true && <ManagedTopicLabel />}
-                    </Td>
-                    <Td dataLabel={t('topics.columnStatus')}>
-                      {topic.attributes.status && (
-                        <StatusLabel status={topic.attributes.status} config={TOPIC_STATUS_CONFIG} />
-                      )}
-                    </Td>
-                    <Td dataLabel={t('topics.columnPartitions')} modifier="fitContent" style={{ textAlign: 'right' }}>
-                      {topic.attributes.numPartitions !== null && topic.attributes.numPartitions !== undefined ? (
-                        <Link to={`/kafka/${kafkaId}/topics/${topic.id}/partitions`}>
-                          {topic.attributes.numPartitions}
-                        </Link>
-                      ) : (
-                        '-'
-                      )}
-                    </Td>
-                    <Td dataLabel={t('topics.columnGroups')} modifier="fitContent" style={{ textAlign: 'right' }}>
-                      {topic.relationships?.groups?.meta?.count !== undefined ? (
-                        <Link to={`/kafka/${kafkaId}/topics/${topic.id}/groups`}>
-                          {topic.relationships.groups.meta.count}
-                        </Link>
-                      ) : (
-                        topic.relationships?.groups?.meta?.count ?? '-'
-                      )}
-                    </Td>
-                    <Td dataLabel={t('topics.columnStorage')} modifier="fitContent" style={{ textAlign: 'right' }}>
-                      {formatBytes(topic.attributes.totalLeaderLogBytes)}
-                    </Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-
-            <Toolbar>
-              <ToolbarContent>
-                <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
-                  <Pagination
-                    itemCount={totalItems}
-                    perPage={table.pageSize}
-                    page={currentPage}
-                    onSetPage={() => {}}
-                    onPerPageSelect={table.handlePerPageChange}
-                    onNextClick={table.handleNextPage}
-                    onPreviousClick={table.handlePrevPage}
-                    isDisabled={false}
-                    variant={PaginationVariant.bottom}
-                    isCompact
-                    titles={{
-                      paginationAriaLabel: t('topics.tableLabel'),
-                    }}
-                  />
-                </ToolbarItem>
-              </ToolbarContent>
-            </Toolbar>
-          </>
-        )}
+        <TopicsDataView
+          topicResult={topicResult}
+          onDataViewChange={handleDataViewChange}
+        />
       </PageSection>
     </>
   );

--- a/ui/tests/playwright/MessagesPage.test.tsx
+++ b/ui/tests/playwright/MessagesPage.test.tsx
@@ -7,7 +7,7 @@ test.beforeEach(async ({ authenticatedPage }) => {
 test("Messages page with messages", async ({ page }) => {
   await test.step("Navigate to topic with data", async () => {
     page
-      .locator(`table[data-ouia-component-id="topics-listing"] tbody tr`)
+      .locator(`table[data-ouia-component-id="topics-table"] tbody tr`)
       .filter({ hasNotText: "0 B" })
       .first()
       .locator(`td[data-label="Name"] a`)
@@ -40,7 +40,7 @@ test("Messages page with messages", async ({ page }) => {
 test("Messages page without messages", async ({ page }) => {
   await test.step("Navigate to topic without data", async () => {
     page
-      .locator(`table[data-ouia-component-id="topics-listing"] tbody tr`)
+      .locator(`table[data-ouia-component-id="topics-table"] tbody tr`)
       .filter({ hasText: "0 B" })
       .first()
       .locator(`td[data-label="Name"] a`)

--- a/ui/tests/playwright/TopicsPage.test.tsx
+++ b/ui/tests/playwright/TopicsPage.test.tsx
@@ -9,11 +9,11 @@ test("Topics page", async ({ page }) => {
     const label = page.locator("label.pf-v6-c-switch").first();
     expect(label).not.toBeNull();
     const labelText = await label?.innerText();
-    expect(labelText?.trim()).toBe("Hide internal topics");
+    expect(labelText?.trim()).toBe("Show internal topics");
     const input = label?.locator("input.pf-v6-c-switch__input").first();
     expect(input).not.toBeNull();
     const isChecked = await input?.isChecked();
-    expect(isChecked).toBe(true);
+    expect(isChecked).toBe(false);
     //const button = await page.$('button:has-text("Create Topic")');
     //expect(button).not.toBeNull();
     const filterInput = page.locator("div.pf-v6-c-input-group input").first();

--- a/ui/tests/playwright/authenticated-page.ts
+++ b/ui/tests/playwright/authenticated-page.ts
@@ -51,7 +51,7 @@ export class AuthenticatedPage {
 
   async goToFirstTopic(waitForLoaded = true) {
     await this.goToTopics(waitForLoaded);
-    await this.clickFirstLinkInTheTable("topics-listing");
+    await this.clickFirstLinkInTheTable("topics-table");
     if (waitForLoaded) {
       // wait for 'Topics' link to be in the breadcrumbs
       await expect(


### PR DESCRIPTION
Migrate the topics table to use the new data view component. 

This PR also reverses the toggle control to show internal topics. Previously, the toggle would show them when off and hide them when on - with label "Hide internal topics" and "on" by default. With the change, the label reads "Show internal topics" and is disabled/off by default. See screenshot below.

<img width="1127" height="603" alt="image" src="https://github.com/user-attachments/assets/cf61c7a6-5247-4a50-a26a-5c9f45d8257a" />
