### PR TITLE
Add TLS configuration support to operator and server

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/security/TlsKeyStoreProvider.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/TlsKeyStoreProvider.java
@@ -1,0 +1,38 @@
+package com.github.streamshub.console.api.security;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import com.github.streamshub.console.config.ConsoleConfig;
+
+import io.quarkus.tls.runtime.KeyStoreAndKeyCertOptions;
+import io.quarkus.tls.runtime.KeyStoreProvider;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.PemKeyCertOptions;
+
+@ApplicationScoped
+public class TlsKeyStoreProvider implements KeyStoreProvider {
+
+    @Inject
+    ConsoleConfig consoleConfig;
+
+    @Override
+    public KeyStoreAndKeyCertOptions getKeyStore(Vertx vertx) {
+        return Optional.ofNullable(consoleConfig.getTls())
+            .map(tlsConfig -> {
+                try {
+                    var options = new PemKeyCertOptions()
+                            .addCertValue(Buffer.buffer(tlsConfig.getCertificate().get()))
+                            .addKeyValue(Buffer.buffer(tlsConfig.getKey().get()));
+                    var keyStore = options.loadKeyStore(vertx);
+                    return new KeyStoreAndKeyCertOptions(keyStore, options);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .orElse(null);
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/ConsoleTlsConfigSource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/ConsoleTlsConfigSource.java
@@ -1,0 +1,99 @@
+package com.github.streamshub.console.api.support;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * A MicroProfile {@link ConfigSource} that inspects the console configuration YAML at startup
+ * and, when a {@code tls} block is present, automatically sets
+ * {@code quarkus.http.insecure-requests=disabled} so that the HTTP server only binds on the
+ * SSL port (8443) and rejects plain HTTP connections.
+ * <p>
+ * This source is loaded by the {@code ServiceLoader} mechanism very early in the Quarkus
+ * runtime bootstrap — before the Vert.x HTTP server recorder reads its configuration — so the
+ * property is visible to all subsequent configuration consumers including the HTTP server setup.
+ * <p>
+ * The config path is resolved in priority order:
+ * <ol>
+ *   <li>System property {@code console.config-path} — set as a system property by the Quarkus
+ *       test framework when a test profile overrides it via {@code getConfigOverrides()}, or
+ *       passed on the command line as {@code -Dconsole.config-path=...}.</li>
+ *   <li>Environment variable {@code CONSOLE_CONFIG_PATH} — the canonical production mechanism
+ *       used by the operator deployment YAML.</li>
+ * </ol>
+ */
+public class ConsoleTlsConfigSource implements ConfigSource {
+
+    private static final String INSECURE_REQUESTS_KEY = "quarkus.http.insecure-requests";
+
+    /**
+     * Ordinal above the default application.properties ordinal (250) so this source wins when
+     * TLS is detected, but below explicit environment-variable overrides (300+).
+     */
+    private static final int ORDINAL = 275;
+
+    private final Map<String, String> properties;
+
+    public ConsoleTlsConfigSource() {
+        this.properties = Map.of(INSECURE_REQUESTS_KEY, tlsConfigured() ? "disabled" : "enabled");
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return properties.keySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return "ConsoleTlsConfigSource";
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ORDINAL;
+    }
+
+    /**
+     * Resolves the console config YAML path and parses it just enough to detect a top-level
+     * {@code tls} field, returning true when found.
+     */
+    private static boolean tlsConfigured() {
+        String configPath = resolveConfigPath();
+
+        if (configPath != null && !configPath.isBlank()) {
+            try (InputStream in = Files.newInputStream(Path.of(configPath))) {
+                JsonNode root = new ObjectMapper(new YAMLFactory()).readTree(in);
+                return root != null && root.hasNonNull("tls");
+            } catch (IOException e) {
+                // Unreadable / malformed YAML — leave the default behaviour alone
+            }
+        }
+
+        return false;
+    }
+
+    private static String resolveConfigPath() {
+        // System property takes precedence (test profiles, -D flags)
+        String value = System.getProperty("console.config-path");
+        if (value == null) {
+            // Fall back to the environment variable used by the operator deployment
+            value = System.getenv("CONSOLE_CONFIG_PATH");
+        }
+        return value;
+    }
+}

--- a/api/src/main/java/com/github/streamshub/console/api/support/TrustStoreSupport.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/TrustStoreSupport.java
@@ -31,11 +31,16 @@ public class TrustStoreSupport {
     private static final String TRUST_PREFIX_SCHEMA_REGISTRY = "schema-registry:";
     private static final String TRUST_PREFIX_OIDC_PROVIDER = "oidc-provider:";
 
-    @Inject
     TlsConfigurationRegistry tlsRegistry;
 
-    @Inject
     Vertx vertx;
+
+    @Inject
+    public TrustStoreSupport(Vertx vertx, TlsConfigurationRegistry tlsRegistry, ConsoleConfig config) {
+        this.vertx = vertx;
+        this.tlsRegistry = tlsRegistry;
+        registerTrustStores(config);
+    }
 
     /*
      * public for testing only
@@ -65,7 +70,7 @@ public class TrustStoreSupport {
     /**
      * Extract trust store configuration and register with the TLS registry.
      */
-    public ConsoleConfig registerTrustStores(ConsoleConfig config) {
+    public void registerTrustStores(ConsoleConfig config) {
         registerTrustStores(config.getKafkaConnectClusters(), null);
         registerTrustStores(config.getMetricsSources(), null);
         registerTrustStores(config.getSchemaRegistries(), null);
@@ -74,8 +79,6 @@ public class TrustStoreSupport {
         if (oidcConfig != null) {
             registerTrustStores(List.of(oidcConfig), null);
         }
-
-        return config;
     }
 
     private void registerTrustStores(List<? extends Trustable> trustables, Trustable context) {

--- a/api/src/main/java/com/github/streamshub/console/api/support/factories/ConsoleConfigFactory.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/factories/ConsoleConfigFactory.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.github.streamshub.console.api.support.TrustStoreSupport;
 import com.github.streamshub.console.api.support.UncheckedIO;
 import com.github.streamshub.console.api.support.ValidationProxy;
 import com.github.streamshub.console.config.ConsoleConfig;
@@ -44,9 +43,6 @@ public class ConsoleConfigFactory {
     @Inject
     ValidationProxy validationService;
 
-    @Inject
-    TrustStoreSupport trustStores;
-
     @Produces
     @ApplicationScoped
     public ConsoleConfig produceConsoleConfig() {
@@ -57,7 +53,6 @@ public class ConsoleConfigFactory {
             .filter(Objects::nonNull)
             .map(this::loadConfiguration)
             .map(validationService::validate)
-            .map(trustStores::registerTrustStores)
             .orElseGet(() -> {
                 log.warn("Console configuration has not been specified using `console.config-path` property");
                 return new ConsoleConfig();

--- a/api/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/api/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+com.github.streamshub.console.api.support.ConsoleTlsConfigSource

--- a/api/src/test/java/com/github/streamshub/console/api/MetadataResourceTlsIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/MetadataResourceTlsIT.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
-import com.github.streamshub.console.kafka.systemtest.TestPlainNoK8sProfile;
+import com.github.streamshub.console.kafka.systemtest.TestTlsProfile;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -22,31 +22,36 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @QuarkusTest
 @TestHTTPEndpoint(MetadataResource.class)
-@TestProfile(TestPlainNoK8sProfile.class)
-class MetadataResourceNoK8sIT {
+@TestProfile(TestTlsProfile.class)
+class MetadataResourceTlsIT {
 
     @Inject
     @ConfigProperty(name = "quarkus.http.test-ssl-port")
     int testSslPort;
 
+    @Inject
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int testPort;
+
     @Test
-    void testGetMetadataDefaultUnknown() {
-        whenRequesting(req -> req.get())
+    void testMetadataAvailableOnHttpsPort() {
+        // The lambda receives the RequestSpecification and adds the generated CA trust store
+        // so RestAssured accepts the server certificate issued by TlsHelper.
+        whenRequesting(req -> req
+                .trustStore(TestTlsProfile.TLS.getTrustStore())
+                .get(URI.create("https://localhost:%d/api/metadata".formatted(testSslPort))))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.id", is("console-meta"))
             .body("data.type", is("metadata"))
             .body("data.attributes.version", is(ConfigProvider.getConfig()
-                    .getValue("quarkus.application.version", String.class)))
-            .body("data.attributes.platform", is("Unknown"));
+                    .getValue("quarkus.application.version", String.class)));
     }
 
     @Test
-    void testHttpsPortNotAvailableWithoutTls() {
-        // When no TLS is configured, Quarkus does not bind the SSL port at all.
+    void testPlainHttpPortNotAvailable() {
+        // With insecure-requests=disabled Quarkus does not bind the HTTP port at all.
         assertThrows(ConnectException.class, () ->
-            whenRequesting(req -> req
-                    .relaxedHTTPSValidation()
-                    .get(URI.create("https://localhost:%d/api/metadata".formatted(testSslPort)))));
+            whenRequesting(req -> req.get("http://localhost:%d/api/metadata".formatted(testPort))));
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestTlsProfile.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/TestTlsProfile.java
@@ -1,0 +1,88 @@
+package com.github.streamshub.console.kafka.systemtest;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.github.streamshub.console.test.TlsHelper;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * Minimal test profile that starts Quarkus with a TLS-enabled console configuration.
+ * <p>
+ * No Kubernetes, Kafka, Keycloak, or Strimzi resources are required — this profile only
+ * exercises the HTTP server TLS binding.  The generated certificate is available statically
+ * via {@link #TLS} so that tests can configure RestAssured with the correct trust store.
+ */
+public class TestTlsProfile implements QuarkusTestProfile {
+
+    /** TLS material generated once per JVM for this profile. */
+    public static final TlsHelper TLS = TlsHelper.newInstance("localhost");
+
+    private static final Path CONFIG_FILE = writeTempConfig();
+
+    @Override
+    public String getConfigProfile() {
+        // Re-use the "testplain" profile so dev-services and Keycloak are still disabled,
+        // but override specific properties below.
+        return "testplain";
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "console.config-path", CONFIG_FILE.toAbsolutePath().toString(),
+                // Kubernetes dev-services not needed for a pure TLS binding test
+                "quarkus.kubernetes-client.devservices.enabled", "false");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static Path writeTempConfig() {
+        try {
+            // Escape PEM newlines for inline YAML block scalar
+            String certPem = TLS.getServerCertificatePem();
+            String keyPem  = TLS.getServerPrivateKeyPem();
+
+            // Use YAML literal block scalars (|) so multi-line PEM content is preserved exactly
+            String yaml = """
+                    kubernetes:
+                      enabled: false
+                    tls:
+                      certificate:
+                        value: |
+                    %s
+                      key:
+                        value: |
+                    %s
+                    """.formatted(indent(certPem, 8), indent(keyPem, 8));
+
+            Path file = Files.createTempFile("console-config-tls-", ".yaml");
+            file.toFile().deleteOnExit();
+            Files.writeString(file, yaml);
+            return file;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write temporary TLS console config", e);
+        }
+    }
+
+    /** Indents every line of {@code text} by {@code spaces} spaces. */
+    private static String indent(String text, int spaces) {
+        String prefix = " ".repeat(spaces);
+        return text.lines()
+                .map(line -> prefix + line)
+                .reduce("", (a, b) -> a.isEmpty() ? b : a + "\n" + b);
+    }
+}

--- a/api/src/test/java/com/github/streamshub/console/test/TlsHelper.java
+++ b/api/src/test/java/com/github/streamshub/console/test/TlsHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
@@ -78,6 +79,28 @@ public class TlsHelper {
         try {
             return pemEncodeCertificate(rootCA);
         } catch (CertificateEncodingException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getServerCertificatePem() {
+        try {
+            Certificate serverCert = keyStore.getCertificate("localhost");
+            return pemEncodeCertificate(serverCert);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getServerPrivateKeyPem() {
+        try {
+            Key privateKey = keyStore.getKey("localhost", null);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            out.write("-----BEGIN PRIVATE KEY-----\n".getBytes(StandardCharsets.UTF_8));
+            out.write(Base64.getMimeEncoder(80, new byte[] {'\n'}).encode(privateKey.getEncoded()));
+            out.write("\n-----END PRIVATE KEY-----\n".getBytes(StandardCharsets.UTF_8));
+            return new String(out.toByteArray(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/ConsoleConfig.java
@@ -49,6 +49,9 @@ public class ConsoleConfig {
     KubernetesConfig kubernetes = new KubernetesConfig();
 
     @Valid
+    TlsConfig tls;
+
+    @Valid
     @ValidResourceTypes(type = ResourceTypes.Global.class)
     GlobalSecurityConfig security = new GlobalSecurityConfig();
 
@@ -119,6 +122,14 @@ public class ConsoleConfig {
 
     public void setKubernetes(KubernetesConfig kubernetes) {
         this.kubernetes = kubernetes;
+    }
+
+    public TlsConfig getTls() {
+        return tls;
+    }
+
+    public void setTls(TlsConfig tls) {
+        this.tls = tls;
     }
 
     public GlobalSecurityConfig getSecurity() {

--- a/common/src/main/java/com/github/streamshub/console/config/TlsConfig.java
+++ b/common/src/main/java/com/github/streamshub/console/config/TlsConfig.java
@@ -1,0 +1,37 @@
+package com.github.streamshub.console.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(editableEnabled = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TlsConfig {
+
+    @NotNull
+    @Valid
+    private Value certificate;
+
+    @NotNull
+    @Valid
+    private Value key;
+
+    public Value getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(Value certificate) {
+        this.certificate = certificate;
+    }
+
+    public Value getKey() {
+        return key;
+    }
+
+    public void setKey(Value key) {
+        this.key = key;
+    }
+}

--- a/docs/sources/assemblies/assembly-deploying.adoc
+++ b/docs/sources/assemblies/assembly-deploying.adoc
@@ -38,6 +38,8 @@ include::../modules/deploying/proc-deploying-operator-crd.adoc[leveloffset=+2]
 //include::../modules/deploying/proc-deploying-operator-olm-ui.adoc[leveloffset=+2]
 //Using the operator to deploy the console
 include::../modules/deploying/proc-connecting-console.adoc[leveloffset=+1]
+//TLS configuration for the console server
+include::../modules/deploying/ref-tls-configuration.adoc[leveloffset=+2]
 //virtual kafka clusters
 include::../modules/deploying/ref-virtual-kafka-clusters.adoc[leveloffset=+2]
 //cluster connection authentication options

--- a/docs/sources/modules/deploying/proc-connecting-console.adoc
+++ b/docs/sources/modules/deploying/proc-connecting-console.adoc
@@ -45,7 +45,8 @@ spec:
           name: console-kafka-user1
 ----
 
-* `hostname` defines the hostname used to access the console over HTTP.
+* `hostname` defines the hostname used to access the console.
+When TLS is configured (see xref:ref-tls-configuration-{context}[Configuring TLS for the console server]), the console is accessed over HTTPS.
 * `kafkaClusters.name` specifies the name of the Strimzi `Kafka` resource that represents the cluster.
 * `kafkaClusters.namespace` specifies the namespace where the `Kafka` resource is deployed.
 * `kafkaClusters.listener` specifies the listener used to expose the Kafka cluster for console connections.
@@ -80,3 +81,5 @@ console-kafka  1/1    1       1
 . Access the console.
 +
 When the console is running, use the hostname specified in the `Console` resource (`spec.hostname`) to access the user interface.
+If TLS is enabled, use `https://` to access the console.
+For more information, see xref:ref-tls-configuration-{context}[Configuring TLS for the console server].

--- a/docs/sources/modules/deploying/ref-tls-configuration.adoc
+++ b/docs/sources/modules/deploying/ref-tls-configuration.adoc
@@ -15,11 +15,11 @@ When `spec.tls` is set, the operator makes the following changes automatically:
 
 * The console container switches to HTTPS (port 8443) and health probes use the HTTPS scheme.
 * The Kubernetes `Service` exposes port 443 and forwards traffic to port 8443 on the pod.
-* On plain Kubernetes, the `Ingress` sets the `nginx.ingress.kubernetes.io/backend-protocol` annotation to `HTTPS` and targets port 443 on the service.
-* On OpenShift, the `Route` uses `passthrough` TLS termination instead of `edge`, so the connection is encrypted end-to-end between the router and the console pod.
+* For plain Kubernetes clusters, the `Ingress` sets the `nginx.ingress.kubernetes.io/backend-protocol` annotation to `HTTPS` and targets port 443 on the service.
+* For OpenShift clusters, the `Route` uses `passthrough` TLS termination instead of `edge`, so the connection is encrypted end-to-end between the router and the console pod.
 
 TLS is an optional configuration.
-If `spec.tls` is not set the console continues to operate over plain HTTP, with TLS terminated at the edge by the ingress or route (edge termination with redirect).
+If `spec.tls` is not set, the console continues to operate over plain HTTP, with TLS terminated at the edge by the ingress or route (edge termination with redirect).
 
 == TLS properties
 
@@ -27,7 +27,7 @@ If `spec.tls` is not set the console continues to operate over plain HTTP, with 
 `spec.tls.certificate`:: The TLS certificate in PEM format, provided as a literal value or by reference to a `Secret` or `ConfigMap` entry.
 `spec.tls.key`:: The TLS private key in PEM format, provided as a literal value or by reference to a `Secret` or `ConfigMap` entry.
 
-Both `certificate` and `key` accept either a direct `value` string or a `valueFrom` reference.
+Both the `certificate` and `key` fields accept either a direct `value` string or a `valueFrom` reference.
 Storing keys and certificates in a `Secret` is strongly recommended for production environments.
 
 == Example TLS configuration

--- a/docs/sources/modules/deploying/ref-tls-configuration.adoc
+++ b/docs/sources/modules/deploying/ref-tls-configuration.adoc
@@ -1,0 +1,83 @@
+:_mod-docs-content-type: REFERENCE
+
+// Module included in the following assemblies:
+//
+// assembly-deploying.adoc
+
+[id='ref-tls-configuration-{context}']
+= Configuring TLS for the console server
+
+[role="_abstract"]
+By default, the console server listens on plain HTTP (port 8080) and the ingress or route terminates TLS at the edge.
+You can configure the console to terminate TLS itself by providing a certificate and private key in the `Console` custom resource under `spec.tls`.
+
+When `spec.tls` is set, the operator makes the following changes automatically:
+
+* The console container switches to HTTPS (port 8443) and health probes use the HTTPS scheme.
+* The Kubernetes `Service` exposes port 443 and forwards traffic to port 8443 on the pod.
+* On plain Kubernetes, the `Ingress` sets the `nginx.ingress.kubernetes.io/backend-protocol` annotation to `HTTPS` and targets port 443 on the service.
+* On OpenShift, the `Route` uses `passthrough` TLS termination instead of `edge`, so the connection is encrypted end-to-end between the router and the console pod.
+
+TLS is an optional configuration.
+If `spec.tls` is not set the console continues to operate over plain HTTP, with TLS terminated at the edge by the ingress or route (edge termination with redirect).
+
+== TLS properties
+
+`spec.tls`:: Optional TLS configuration for the console server.
+`spec.tls.certificate`:: The TLS certificate in PEM format, provided as a literal value or by reference to a `Secret` or `ConfigMap` entry.
+`spec.tls.key`:: The TLS private key in PEM format, provided as a literal value or by reference to a `Secret` or `ConfigMap` entry.
+
+Both `certificate` and `key` accept either a direct `value` string or a `valueFrom` reference.
+Storing keys and certificates in a `Secret` is strongly recommended for production environments.
+
+== Example TLS configuration
+
+The following example stores the PEM data in a Kubernetes `Secret` and references it from the `Console` resource.
+
+.Creating the TLS Secret
+[source,shell]
+----
+kubectl create secret generic my-console-tls \
+  --from-file=tls.crt=/path/to/tls.crt \
+  --from-file=tls.key=/path/to/tls.key \
+  -n console-namespace
+----
+
+.Console custom resource with TLS enabled
+[source,yaml]
+----
+apiVersion: console.streamshub.github.com/v1alpha1
+kind: Console
+metadata:
+  name: my-console
+spec:
+  hostname: my-console.<cluster_domain>
+  tls:
+    certificate:
+      valueFrom:
+        secretKeyRef:
+          name: my-console-tls
+          key: tls.crt
+    key:
+      valueFrom:
+        secretKeyRef:
+          name: my-console-tls
+          key: tls.key
+  kafkaClusters:
+    - name: console-kafka
+      namespace: kafka
+      listener: secure
+      credentials:
+        kafkaUser:
+          name: console-kafka-user1
+----
+
+* `tls.certificate.valueFrom.secretKeyRef.name` specifies the name of the `Secret` that stores the TLS certificate.
+* `tls.certificate.valueFrom.secretKeyRef.key` specifies the key within the `Secret` that holds the PEM-encoded certificate.
+* `tls.key.valueFrom.secretKeyRef.name` specifies the name of the `Secret` that stores the TLS private key.
+* `tls.key.valueFrom.secretKeyRef.key` specifies the key within the `Secret` that holds the PEM-encoded private key.
+
+NOTE: Plaintext values (`value: <pem_content>`) are supported but are not recommended for production environments.
+Prefer referencing a `Secret` via `valueFrom.secretKeyRef` to avoid embedding sensitive key material in the `Console` resource.
+
+When `spec.tls` is set, access the console over HTTPS using the hostname specified in `spec.hostname`.

--- a/examples/console/console-tls.yaml
+++ b/examples/console/console-tls.yaml
@@ -1,0 +1,45 @@
+#
+# This example demonstrates how to configure TLS for the StreamsHub Console server
+# using the `spec.tls` field of the Console custom resource.
+#
+# When `spec.tls` is set, the console container serves HTTPS on port 8443.
+# The operator automatically adjusts the Service (port 443 → 8443) and:
+#   - On plain Kubernetes: sets the Ingress backend-protocol annotation to HTTPS.
+#   - On OpenShift: switches the Route to passthrough TLS termination.
+#
+# This example stores the PEM certificate and key in a Secret. Create the Secret first:
+#
+#   kubectl create secret generic my-console-tls \
+#     --from-file=tls.crt=/path/to/tls.crt \
+#     --from-file=tls.key=/path/to/tls.key \
+#     -n console-namespace
+#
+# Replace <placeholders> with actual values specific to the environment.
+#
+---
+apiVersion: console.streamshub.github.com/v1alpha1
+kind: Console
+metadata:
+  name: example
+spec:
+  hostname: example-console.${CLUSTER_DOMAIN}
+
+  tls:
+    certificate:
+      valueFrom:
+        secretKeyRef:
+          name: my-console-tls  # Name of the Secret containing the TLS certificate
+          key: tls.crt          # Key within the Secret holding the PEM certificate
+    key:
+      valueFrom:
+        secretKeyRef:
+          name: my-console-tls  # Name of the Secret containing the TLS private key
+          key: tls.key          # Key within the Secret holding the PEM private key
+
+  kafkaClusters:
+    - name: console-kafka             # Name of the `Kafka` CR representing the cluster
+      namespace: ${KAFKA_NAMESPACE}   # Namespace where the `Kafka` CR is deployed
+      listener: secure                # Listener name from the `Kafka` CR to connect the console
+      credentials:
+        kafkaUser:
+          name: console-kafka-user1   # Name of the `KafkaUser` CR used to connect to the Kafka cluster

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/ConsoleSpec.java
@@ -28,6 +28,12 @@ public class ConsoleSpec {
     String hostname;
 
     @JsonPropertyDescription("""
+            TLS configuration for the Console server. Specifies the certificate \
+            and private key to use for HTTPS connections.
+            """)
+    Tls tls;
+
+    @JsonPropertyDescription("""
             Templates for Console instance containers. The templates allow \
             users to specify how the Kubernetes resources are generated.
             """)
@@ -61,6 +67,14 @@ public class ConsoleSpec {
 
     public void setHostname(String hostname) {
         this.hostname = hostname;
+    }
+
+    public Tls getTls() {
+        return tls;
+    }
+
+    public void setTls(Tls tls) {
+        this.tls = tls;
     }
 
     public Containers getContainers() {

--- a/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Tls.java
+++ b/operator/src/main/java/com/github/streamshub/console/api/v1alpha1/spec/Tls.java
@@ -1,0 +1,36 @@
+package com.github.streamshub.console.api.v1alpha1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(editableEnabled = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Tls {
+
+    @JsonProperty("certificate")
+    @JsonPropertyDescription("TLS certificate content (PEM format)")
+    private Value certificate;
+
+    @JsonProperty("key")
+    @JsonPropertyDescription("TLS private key content (PEM format)")
+    private Value key;
+
+    public Value getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(Value certificate) {
+        this.certificate = certificate;
+    }
+
+    public Value getKey() {
+        return key;
+    }
+
+    public void setKey(Value key) {
+        this.key = key;
+    }
+}

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConfigurationProcessor.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConfigurationProcessor.java
@@ -61,6 +61,7 @@ import com.github.streamshub.console.config.KafkaClusterConfig;
 import com.github.streamshub.console.config.KafkaConnectConfig;
 import com.github.streamshub.console.config.PrometheusConfig;
 import com.github.streamshub.console.config.SchemaRegistryConfig;
+import com.github.streamshub.console.config.TlsConfigBuilder;
 import com.github.streamshub.console.config.TrustStoreConfig;
 import com.github.streamshub.console.config.TrustStoreConfigBuilder;
 import com.github.streamshub.console.config.ValueBuilder;
@@ -289,6 +290,15 @@ public class ConfigurationProcessor implements DependentResource<HasMetadata, Co
      * access the secret entries.
      */
     private void buildClientSecrets(Console primary, Context<Console> context, Map<String, String> data) {
+        var tls = primary.getSpec().getTls();
+        if (tls != null) {
+            String namespace = primary.getMetadata().getNamespace();
+            maybePutSecretEntry(data, "console-tls-certificate.txt",
+                getValue(context, namespace, tls.getCertificate()));
+            maybePutSecretEntry(data, "console-tls-key.txt",
+                getValue(context, namespace, tls.getKey()));
+        }
+
         Optional.ofNullable(primary.getSpec().getSecurity())
             .map(GlobalSecurity::getOidc)
             .map(Oidc::getTrustStore)
@@ -458,6 +468,14 @@ public class ConfigurationProcessor implements DependentResource<HasMetadata, Co
 
     private ConsoleConfig buildConfig(Console primary, Context<Console> context, ConsoleConfig currentConfig) {
         ConsoleConfig config = new ConsoleConfig();
+
+        var tls = primary.getSpec().getTls();
+        if (tls != null) {
+            config.setTls(new TlsConfigBuilder()
+                .withCertificate(mapValue(tls.getCertificate(), "console-tls-certificate"))
+                .withKey(mapValue(tls.getKey(), "console-tls-key"))
+                .build());
+        }
 
         addSecurity(primary, config, currentConfig, context);
         addMetricsSources(primary, config, context);

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleDeployment.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleDeployment.java
@@ -18,6 +18,7 @@ import com.github.streamshub.console.api.v1alpha1.spec.containers.ContainerTempl
 import com.github.streamshub.console.api.v1alpha1.spec.containers.Containers;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -64,6 +65,11 @@ public class ConsoleDeployment extends BaseDeployment {
         envVars.addAll(coalesce(primary.getSpec().getEnv(), Collections::emptyList));
         envVars.addAll(templateAPI.map(ContainerSpec::getEnv).orElseGet(Collections::emptyList));
 
+        boolean tls = primary.getSpec().getTls() != null;
+        String portName = tls ? "https" : "http";
+        int containerPort = tls ? 8443 : 8080;
+        String probeScheme = tls ? "HTTPS" : "HTTP";
+
         return desired.edit()
             .editMetadata()
                 .withName(name)
@@ -88,12 +94,34 @@ public class ConsoleDeployment extends BaseDeployment {
                                 .withSecretName(configSecretName)
                             .endSecret()
                         .endVolume()
-                        // Set API container image options
+                        // Set API container image and port options
                         .editMatchingContainer(c -> "console-api".equals(c.getName()))
                             .withImage(imageAPI)
                             .withImagePullPolicy(pullPolicy(imageAPI))
                             .withResources(templateAPI.map(ContainerSpec::getResources).orElse(null))
                             .addAllToEnv(envVars)
+                            .editFirstPort()
+                                .withName(portName)
+                                .withContainerPort(containerPort)
+                            .endPort()
+                            .editStartupProbe()
+                                .editHttpGet()
+                                    .withPort(new IntOrString(portName))
+                                    .withScheme(probeScheme)
+                                .endHttpGet()
+                            .endStartupProbe()
+                            .editLivenessProbe()
+                                .editHttpGet()
+                                    .withPort(new IntOrString(portName))
+                                    .withScheme(probeScheme)
+                                .endHttpGet()
+                            .endLivenessProbe()
+                            .editReadinessProbe()
+                                .editHttpGet()
+                                    .withPort(new IntOrString(portName))
+                                    .withScheme(probeScheme)
+                                .endHttpGet()
+                            .endReadinessProbe()
                         .endContainer()
                     .endSpec()
                 .endTemplate()

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleIngress.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleIngress.java
@@ -43,12 +43,18 @@ public class ConsoleIngress extends CRUDKubernetesDependentResource<Ingress, Con
 
     @Override
     protected Ingress desired(Console primary, Context<Console> context) {
+        boolean tls = primary.getSpec().getTls() != null;
+        String backendProtocol = tls ? "HTTPS" : "HTTP";
+        int servicePort = tls ? 443 : 80;
+        String serviceName = service.instanceName(primary);
+
         return load(context, "console.ingress.yaml", Ingress.class)
             .edit()
             .editMetadata()
                 .withName(instanceName(primary))
                 .withNamespace(primary.getMetadata().getNamespace())
                 .withLabels(commonLabels("console"))
+                .addToAnnotations("nginx.ingress.kubernetes.io/backend-protocol", backendProtocol)
             .endMetadata()
             .editSpec()
                 // Plain Kubernetes (non-OCP) clusters don't need a class name; the
@@ -56,7 +62,10 @@ public class ConsoleIngress extends CRUDKubernetesDependentResource<Ingress, Con
                 .withIngressClassName(null)
                 .editDefaultBackend()
                     .editService()
-                        .withName(service.instanceName(primary))
+                        .withName(serviceName)
+                        .editPort()
+                            .withNumber(servicePort)
+                        .endPort()
                     .endService()
                 .endDefaultBackend()
                 .editFirstRule()
@@ -65,7 +74,10 @@ public class ConsoleIngress extends CRUDKubernetesDependentResource<Ingress, Con
                         .editFirstPath()
                             .editBackend()
                                 .editService()
-                                    .withName(service.instanceName(primary))
+                                    .withName(serviceName)
+                                    .editPort()
+                                        .withNumber(servicePort)
+                                    .endPort()
                                 .endService()
                             .endBackend()
                         .endPath()

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleRoute.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleRoute.java
@@ -15,6 +15,8 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.RouteIngress;
 import io.fabric8.openshift.api.model.RouteStatus;
+import io.fabric8.openshift.api.model.TLSConfig;
+import io.fabric8.openshift.api.model.TLSConfigBuilder;
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
@@ -54,6 +56,7 @@ public class ConsoleRoute extends CRUDKubernetesDependentResource<Route, Console
         // name, namespace, and cluster domain (issue #1471)
         String host = primary.getSpec().getHostname();
         String serviceName = service.instanceName(primary);
+        boolean tls = primary.getSpec().getTls() != null;
 
         return new RouteBuilder()
             .withNewMetadata()
@@ -69,12 +72,25 @@ public class ConsoleRoute extends CRUDKubernetesDependentResource<Route, Console
                     .withName(serviceName)
                     .withWeight(100)
                 .endTo()
-                .withNewTls()
-                    .withTermination("edge")
-                    .withInsecureEdgeTerminationPolicy("Redirect")
-                .endTls()
+                .withTls(buildTls(tls))
             .endSpec()
             .build();
+    }
+
+    private static TLSConfig buildTls(boolean tls) {
+        TLSConfigBuilder tlsBuilder = new TLSConfigBuilder();
+
+        if (tls) {
+            // The console terminates TLS itself; the router passes through the connection
+            tlsBuilder = tlsBuilder.withTermination("passthrough");
+        } else {
+            // The router terminates TLS at the edge and forwards plain HTTP to the console
+            tlsBuilder = tlsBuilder
+                .withTermination("edge")
+                .withInsecureEdgeTerminationPolicy("Redirect");
+        }
+
+        return tlsBuilder.build();
     }
 
     /**

--- a/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleService.java
+++ b/operator/src/main/java/com/github/streamshub/console/dependents/ConsoleService.java
@@ -5,7 +5,10 @@ import jakarta.inject.Inject;
 
 import com.github.streamshub.console.api.v1alpha1.Console;
 
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Service;
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @ApplicationScoped
@@ -24,5 +27,21 @@ public class ConsoleService extends BaseService {
     @Override
     protected String appName(Console primary) {
         return deployment.instanceName(primary);
+    }
+
+    @Override
+    protected Service desired(Console primary, Context<Console> context) {
+        boolean tls = primary.getSpec().getTls() != null;
+
+        return super.desired(primary, context)
+            .edit()
+            .editSpec()
+                .editFirstPort()
+                    .withName(tls ? "https" : "http")
+                    .withPort(tls ? 443 : 80)
+                    .withTargetPort(new IntOrString(tls ? 8443 : 8080))
+                .endPort()
+            .endSpec()
+            .build();
     }
 }

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
@@ -23,8 +23,8 @@ spec:
       - name: console-api
         image: quay.io/streamshub/console-api
         ports:
-        - containerPort: 8080
-          name: http
+        - containerPort: 0
+          name: placeholder
         volumeMounts:
         - name: config
           mountPath: /deployments/config
@@ -37,8 +37,8 @@ spec:
         startupProbe:
           httpGet:
             path: /health/started
-            port: http
-            scheme: HTTP
+            port: placeholder
+            scheme: placeholder
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 10
@@ -47,8 +47,8 @@ spec:
         livenessProbe:
           httpGet:
             path: /health/live
-            port: http
-            scheme: HTTP
+            port: placeholder
+            scheme: placeholder
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 10
@@ -57,8 +57,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: http
-            scheme: HTTP
+            port: placeholder
+            scheme: placeholder
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 10

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.ingress.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.ingress.yaml
@@ -3,13 +3,13 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: console-ui-ingress
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/backend-protocol: placeholder
 spec:
   defaultBackend:
     service:
       name: console-ui
       port:
-        number: 80
+        number: 0
   rules:
     - host: placeholder
       http:
@@ -19,4 +19,4 @@ spec:
               service:
                 name: console-ui
                 port:
-                  number: 80
+                  number: 0

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.service.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: console-ui
 spec:
   ports:
-  - port: 80
-    targetPort: 8080
+  - name: placeholder
+    port: 0
+    targetPort: 0
   selector: {}

--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTest.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTest.java
@@ -36,6 +36,7 @@ import com.github.streamshub.console.dependents.ConsoleClusterRoleBinding;
 import com.github.streamshub.console.dependents.ConsoleDeployment;
 import com.github.streamshub.console.dependents.ConsoleIngress;
 import com.github.streamshub.console.dependents.ConsoleResource;
+import com.github.streamshub.console.dependents.ConsoleRoute;
 import com.github.streamshub.console.dependents.ConsoleSecret;
 import com.github.streamshub.console.dependents.PrometheusClusterRole;
 import com.github.streamshub.console.dependents.PrometheusClusterRoleBinding;
@@ -73,6 +74,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1470,4 +1472,189 @@ class ConsoleReconcilerTest extends ConsoleReconcilerTestBase {
         assertEquals("test-console-operator-id", lease.getSpec().getHolderIdentity());
     }
 
+    @Test
+    void testConsoleReconciliationWithTlsIngressMode() {
+        String cert = "-----BEGIN CERTIFICATE-----\nMIIBcert\n-----END CERTIFICATE-----\n";
+        String key  = "-----BEGIN PRIVATE KEY-----\nMIIBkey\n-----END PRIVATE KEY-----\n";
+
+        Console consoleCR = createConsole(new ConsoleBuilder()
+                .withNewSpec()
+                    .withHostname("example.com")
+                    .withNewTls()
+                        .withNewCertificate()
+                            .withValue(cert)
+                        .endCertificate()
+                        .withNewKey()
+                            .withValue(key)
+                        .endKey()
+                    .endTls()
+                    .addNewKafkaCluster()
+                        .withName(kafkaCR.getMetadata().getName())
+                        .withNamespace(kafkaCR.getMetadata().getNamespace())
+                        .withListener(kafkaCR.getSpec().getKafka().getListeners().get(0).getName())
+                    .endKafkaCluster()
+                .endSpec());
+
+        awaitDependentsNotReady(consoleCR, "ConsoleDeployment", "PrometheusDeployment");
+        setDeploymentReady(consoleCR, PrometheusDeployment.NAME);
+        awaitDependentsNotReady(consoleCR, "ConsoleDeployment");
+        setDeploymentReady(consoleCR, ConsoleDeployment.NAME);
+        awaitDependentsNotReady(consoleCR, "ConsoleIngress");
+
+        // Verify the Ingress uses HTTPS backend protocol and port 443
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var ingress = client.network().v1().ingresses()
+                    .inNamespace(CONSOLE_NS)
+                    .withName(CONSOLE_NAME + '-' + ConsoleIngress.NAME)
+                    .get();
+            assertNotNull(ingress);
+            assertEquals("HTTPS", ingress.getMetadata().getAnnotations()
+                    .get("nginx.ingress.kubernetes.io/backend-protocol"));
+            assertEquals(443, ingress.getSpec().getDefaultBackend().getService().getPort().getNumber());
+            assertEquals(443, ingress.getSpec().getRules().get(0).getHttp()
+                    .getPaths().get(0).getBackend().getService().getPort().getNumber());
+        });
+
+        // Verify the Service exposes port 443 targeting 8443
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var service = client.services()
+                    .inNamespace(CONSOLE_NS)
+                    .withName(CONSOLE_NAME + "-console-service")
+                    .get();
+            assertNotNull(service);
+            var port = service.getSpec().getPorts().get(0);
+            assertEquals("https", port.getName());
+            assertEquals(443, port.getPort());
+            assertEquals(8443, port.getTargetPort().getIntVal());
+        });
+
+        // Verify the Deployment exposes port 8443 with HTTPS probes
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var deployment = client.apps().deployments()
+                    .inNamespace(CONSOLE_NS)
+                    .withName(CONSOLE_NAME + '-' + ConsoleDeployment.NAME)
+                    .get();
+            assertNotNull(deployment);
+            var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+            var containerPort = container.getPorts().get(0);
+            assertEquals("https", containerPort.getName());
+            assertEquals(8443, containerPort.getContainerPort());
+            assertEquals("HTTPS", container.getStartupProbe().getHttpGet().getScheme());
+            assertEquals("HTTPS", container.getLivenessProbe().getHttpGet().getScheme());
+            assertEquals("HTTPS", container.getReadinessProbe().getHttpGet().getScheme());
+        });
+
+        // Verify the ConsoleConfig YAML references the cert and key by file path
+        assertConsoleConfig(consoleConfig -> {
+            assertNotNull(consoleConfig.getTls());
+            assertEquals(
+                "/deployments/config/console-tls-certificate.txt",
+                consoleConfig.getTls().getCertificate().getValueFrom());
+            assertEquals(
+                "/deployments/config/console-tls-key.txt",
+                consoleConfig.getTls().getKey().getValueFrom());
+        });
+
+        // Verify the secret contains the raw cert and key bytes
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var secret = getConsoleSecret(consoleCR);
+            assertNotNull(secret);
+            assertArrayEquals(cert.getBytes(),
+                Base64.getDecoder().decode(secret.getData().get("console-tls-certificate.txt")));
+            assertArrayEquals(key.getBytes(),
+                Base64.getDecoder().decode(secret.getData().get("console-tls-key.txt")));
+        });
+    }
+
+    @Test
+    @Tag(REQUIRES_OPENSHIFT_ROUTE)
+    void testConsoleReconciliationWithTlsRouteMode() {
+        String cert = "-----BEGIN CERTIFICATE-----\nMIIBcert\n-----END CERTIFICATE-----\n";
+        String key  = "-----BEGIN PRIVATE KEY-----\nMIIBkey\n-----END PRIVATE KEY-----\n";
+
+        Console consoleCR = createConsole(new ConsoleBuilder()
+                .withNewSpec()
+                    .withHostname("example.com")
+                    .withNewTls()
+                        .withNewCertificate()
+                            .withValue(cert)
+                        .endCertificate()
+                        .withNewKey()
+                            .withValue(key)
+                        .endKey()
+                    .endTls()
+                    .addNewKafkaCluster()
+                        .withName(kafkaCR.getMetadata().getName())
+                        .withNamespace(kafkaCR.getMetadata().getNamespace())
+                        .withListener(kafkaCR.getSpec().getKafka().getListeners().get(0).getName())
+                    .endKafkaCluster()
+                .endSpec());
+
+        awaitDependentsNotReady(consoleCR, "ConsoleDeployment", "PrometheusDeployment");
+        setDeploymentReady(consoleCR, PrometheusDeployment.NAME);
+        awaitDependentsNotReady(consoleCR, "ConsoleDeployment");
+        setDeploymentReady(consoleCR, ConsoleDeployment.NAME);
+        awaitDependentsNotReady(consoleCR, ConsoleRoute.NAME);
+
+        // Verify the Route uses passthrough TLS termination (no insecureEdgeTerminationPolicy)
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var route = client.resources(Route.class)
+                    .inNamespace(CONSOLE_NS)
+                    .withName(CONSOLE_NAME + '-' + ConsoleRoute.NAME)
+                    .get();
+            assertNotNull(route);
+            assertEquals("passthrough", route.getSpec().getTls().getTermination());
+            assertNull(route.getSpec().getTls().getInsecureEdgeTerminationPolicy());
+        });
+
+        // Verify the Service exposes port 443 targeting 8443
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var service = client.services()
+                    .inNamespace(CONSOLE_NS)
+                    .withName(CONSOLE_NAME + "-console-service")
+                    .get();
+            assertNotNull(service);
+            var port = service.getSpec().getPorts().get(0);
+            assertEquals("https", port.getName());
+            assertEquals(443, port.getPort());
+            assertEquals(8443, port.getTargetPort().getIntVal());
+        });
+
+        // Verify the Deployment exposes port 8443 with HTTPS probes
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var deployment = client.apps().deployments()
+                    .inNamespace(CONSOLE_NS)
+                    .withName(CONSOLE_NAME + '-' + ConsoleDeployment.NAME)
+                    .get();
+            assertNotNull(deployment);
+            var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+            var containerPort = container.getPorts().get(0);
+            assertEquals("https", containerPort.getName());
+            assertEquals(8443, containerPort.getContainerPort());
+            assertEquals("HTTPS", container.getStartupProbe().getHttpGet().getScheme());
+            assertEquals("HTTPS", container.getLivenessProbe().getHttpGet().getScheme());
+            assertEquals("HTTPS", container.getReadinessProbe().getHttpGet().getScheme());
+        });
+
+        // Verify the ConsoleConfig YAML references the cert and key by file path
+        assertConsoleConfig(consoleConfig -> {
+            assertNotNull(consoleConfig.getTls());
+            assertEquals(
+                "/deployments/config/console-tls-certificate.txt",
+                consoleConfig.getTls().getCertificate().getValueFrom());
+            assertEquals(
+                "/deployments/config/console-tls-key.txt",
+                consoleConfig.getTls().getKey().getValueFrom());
+        });
+
+        // Verify the secret contains the raw cert and key bytes
+        await().ignoreException(NullPointerException.class).atMost(LIMIT).untilAsserted(() -> {
+            var secret = getConsoleSecret(consoleCR);
+            assertNotNull(secret);
+            assertArrayEquals(cert.getBytes(),
+                Base64.getDecoder().decode(secret.getData().get("console-tls-certificate.txt")));
+            assertArrayEquals(key.getBytes(),
+                Base64.getDecoder().decode(secret.getData().get("console-tls-key.txt")));
+        });
+    }
 }


### PR DESCRIPTION
Allow for custom TLS certificate and key to be configured for the Console server.

Closes #2654 

Assisted-by: IBM Bob

---

- [x] CRD model updates
- [x] Operator mapping (map configuration, service + ingress/route alterations when TLS)
- [x] Configuration model
- [x] Server updates (read config and enable TLS when available)
- [x] Documentation
