### PR TITLE
fix: remove `console-ui` from operatorless install, align operator YAMLs

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -244,7 +244,7 @@ jobs:
           mkdir ./resources
           kubectl get all,catalogsources,operatorgroups -n olm -o yaml > ./resources/olm.yaml
           kubectl get all,subscriptions,csv,operatorgroups,installplans -n operators -o yaml > ./resources/operators.yaml
-          kubectl get all -n ${TARGET_NAMESPACE} -o yaml > ./resources/${TARGET_NAMESPACE}.yaml
+          kubectl get all,consoles,kafkas -n ${TARGET_NAMESPACE} -o yaml > ./resources/${TARGET_NAMESPACE}.yaml
 
       - name: Archive Resource Backup
         uses: actions/upload-artifact@v7

--- a/install/operatorless/040-Deployment-console.yaml
+++ b/install/operatorless/040-Deployment-console.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: console-server
       volumes:
-      - name: cache
+      - name: work
         emptyDir: {}
       - name: config
         secret:
@@ -29,46 +29,43 @@ spec:
         - containerPort: 8080
         volumeMounts:
         - name: config
-          mountPath: /deployments/console-config.yaml
-          subPath: console-config.yaml
+          mountPath: /deployments/config
           readOnly: true
+        - name: work
+          mountPath: /tmp
         env:
         - name: CONSOLE_CONFIG_PATH
-          value: /deployments/console-config.yaml
-        securityContext:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-      ### User Interface
-      - name: console-ui
-        image: quay.io/streamshub/console-ui:latest
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 3000
-        volumeMounts:
-        - name: cache
-          mountPath: /app/.next/cache
-        - name: config
-          mountPath: /deployments/console-config.yaml
-          subPath: console-config.yaml
-          readOnly: true
-        env:
-        - name: NEXTAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: console-ui-secrets
-              key: NEXTAUTH_SECRET
-        - name: NEXTAUTH_URL
-          value: 'https://${CONSOLE_HOSTNAME}'
-        - name: BACKEND_URL
-          value: 'http://127.0.0.1:8080'
-        - name: CONSOLE_CONFIG_PATH
-          value: /deployments/console-config.yaml
+          value: /deployments/config/console-config.yaml
+        startupProbe:
+          httpGet:
+            path: /health/started
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 10
+          successThreshold: 1
+          failureThreshold: 24
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/install/operatorless/050-Service-console-ui.yaml
+++ b/install/operatorless/050-Service-console-ui.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 3000
+    targetPort: 8080
   selector:
     app: console

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -209,7 +209,7 @@ rules:
   - nonResourceURLs: [ /metrics ]
     verbs: [ get ]
 
-  # Used directly by operator and granted to Console instances
+  # Used directly by operator and/or granted to Console instances
   - verbs:
       - get
       - watch
@@ -218,12 +218,13 @@ rules:
       - kafka.strimzi.io
     resources:
       - kafkas
+      - kafkaconnectors
+      - kafkaconnects
+      - kafkamirrormaker2s
       - kafkanodepools
       - kafkarebalances
       - kafkatopics
       - kafkausers
-      - kafkaconnects
-      - kafkamirrormaker2s
 
   # Granted to Console instances
   - verbs:

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.clusterrole.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.clusterrole.yaml
@@ -11,11 +11,12 @@ rules:
       - kafka.strimzi.io
     resources:
       - kafkas
+      - kafkaconnectors
+      - kafkaconnects
+      - kafkamirrormaker2s
       - kafkanodepools
       - kafkarebalances
       - kafkatopics
-      - kafkaconnects
-      - kafkamirrormaker2s
       - kafkausers
   - verbs:
       - patch
@@ -24,6 +25,7 @@ rules:
     resources:
       - kafkas
       - kafkarebalances
+  # API must list pods to obtain the Kafka version annotation set by Strimzi
   - verbs:
       - get
       - list
@@ -31,6 +33,7 @@ rules:
       - ""
     resources:
       - pods
+  # API may read the ClusterVersion to fetch the OpenShift version for display
   - verbs:
       - get
     apiGroups:

--- a/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
+++ b/operator/src/main/resources/com/github/streamshub/console/dependents/console.deployment.yaml
@@ -28,6 +28,7 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /deployments/config
+          readOnly: true
         - name: work
           mountPath: /tmp
         env:
@@ -72,69 +73,3 @@ spec:
           capabilities:
             drop:
             - ALL
-#      ### User Interface
-#      - name: console-ui
-#        image: quay.io/streamshub/console-ui
-#        volumeMounts:
-#        - name: config
-#          mountPath: /deployments/config
-#        - name: work
-#          mountPath: /app/.next/cache
-#        ports:
-#        - containerPort: 3000
-#          name: http
-#        env:
-#        - name: NEXTAUTH_SECRET
-#          valueFrom:
-#            secretKeyRef:
-#              name: placeholder
-#              key: NEXTAUTH_SECRET
-#        - name: NEXTAUTH_URL
-#          value: 'https://${CONSOLE_HOSTNAME}'
-#        - name: BACKEND_URL
-#          value: 'http://127.0.0.1:8080'
-#        - name: CONSOLE_CONFIG_PATH
-#          value: /deployments/config/console-config.yaml
-#        - name: CONSOLE_MODE
-#          value: read-only
-#        - name: LOG_LEVEL
-#          value: info
-#        startupProbe:
-#          httpGet:
-#            path: /healthz
-#            port: http
-#            scheme: HTTP
-#          initialDelaySeconds: 5
-#          periodSeconds: 10
-#          timeoutSeconds: 10
-#          successThreshold: 1
-#          failureThreshold: 3
-#        livenessProbe:
-#          httpGet:
-#            path: /healthz
-#            port: http
-#            scheme: HTTP
-#          initialDelaySeconds: 5
-#          periodSeconds: 10
-#          timeoutSeconds: 10
-#          successThreshold: 1
-#          failureThreshold: 3
-#        readinessProbe:
-#          httpGet:
-#            path: /healthz
-#            port: http
-#            scheme: HTTP
-#          initialDelaySeconds: 5
-#          periodSeconds: 10
-#          timeoutSeconds: 10
-#          successThreshold: 1
-#          failureThreshold: 3
-#        securityContext:
-#          readOnlyRootFilesystem: true
-#          allowPrivilegeEscalation: false
-#          seccompProfile:
-#            type: RuntimeDefault
-#          runAsNonRoot: true
-#          capabilities:
-#            drop:
-#            - ALL


### PR DESCRIPTION
- Updates the operatorless deployment YAML to remove old `console-ui` container and align further with the deployment created by the operator
- Update operatorless service's port to 8080