### PR TITLE
Fix OIDC logout redirection, rely on Quarkus OIDC logout support

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/security/OidcDiscoveryResponseFilter.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/OidcDiscoveryResponseFilter.java
@@ -1,7 +1,8 @@
 package com.github.streamshub.console.api.security;
 
+import java.util.function.Supplier;
+
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -12,11 +13,12 @@ import com.github.streamshub.console.api.support.Holder;
 
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcResponseFilter;
+import io.smallrye.mutiny.Uni;
 
 /**
  * This filter will be invoked when the OIDC discovery end point response is
  * returned from the identity provider. If the discovery response includes an
- * end session end point, it will be set in the {@link endSessionEndpoint}
+ * end session end point, it will be set in the {@link #endSessionEndpoint}
  * holder so that it can be used during the logout process to terminate the
  * user's session with the IdP.
  *
@@ -28,16 +30,29 @@ import io.quarkus.oidc.common.OidcResponseFilter;
 @OidcEndpoint(value = OidcEndpoint.Type.DISCOVERY)
 public class OidcDiscoveryResponseFilter implements OidcResponseFilter {
 
+    public static final String OIDC_END_SESSION_ENDPOINT = "oidcEndSessionEndpoint";
+
     @Inject
     Logger logger;
 
-    @Produces
-    @RequestScoped
-    @Named("oidcEndSessionEndpoint")
     Holder<String> endSessionEndpoint = Holder.empty();
 
+    /**
+     * Produces a {@link Supplier} rather than the {@link Holder} directly, so that
+     * every call to {@link Supplier#get()} re-reads the current field value from
+     * this bean. If the {@link Holder} itself were produced, CDI would capture the
+     * initial {@code Holder.empty()} instance at injection time and subsequent
+     * field reassignments in {@link #filter} would never be visible to consumers.
+     */
+    @Produces
+    @ApplicationScoped
+    @Named(OIDC_END_SESSION_ENDPOINT)
+    Supplier<Holder<String>> endSessionEndpointSupplier() {
+        return () -> this.endSessionEndpoint;
+    }
+
     @Override
-    public void filter(OidcResponseContext responseContext) {
+    public Uni<Void> filter(OidcResponseFilterContext responseContext) {
         String contentType = responseContext.responseHeaders().get("Content-Type");
 
         if ("application/json".equals(contentType)) {
@@ -51,5 +66,7 @@ public class OidcDiscoveryResponseFilter implements OidcResponseFilter {
                 this.endSessionEndpoint = Holder.empty();
             }
         }
+
+        return Uni.createFrom().voidItem();
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/security/OidcTenantConfigResolver.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/OidcTenantConfigResolver.java
@@ -3,13 +3,16 @@ package com.github.streamshub.console.api.security;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import org.jboss.logging.Logger;
 
+import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.api.support.TrustStoreSupport;
 import com.github.streamshub.console.config.ConsoleConfig;
 
@@ -40,6 +43,10 @@ public class OidcTenantConfigResolver implements TenantConfigResolver {
 
     OidcTenantConfig oidcConfig;
 
+    @Inject
+    @Named(OidcDiscoveryResponseFilter.OIDC_END_SESSION_ENDPOINT)
+    Supplier<Holder<String>> endSessionEndpoint;
+
     @PostConstruct
     void initialize() {
         var oidc = consoleConfig.getSecurity().getOidc();
@@ -60,6 +67,7 @@ public class OidcTenantConfigResolver implements TenantConfigResolver {
                     // Do not redirect to the IdP for JavaScript requests. They are identified by
                     // requests from the React UI with header `X-Requested-With: JavaScript`.
                     .javaScriptAutoRedirect(false)
+                    .addOpenidScope(false)
                     .scopes(Optional
                             .ofNullable(oidc.getScopes())
                             .map(scopes -> scopes.split("\\s+"))
@@ -83,7 +91,27 @@ public class OidcTenantConfigResolver implements TenantConfigResolver {
     @Override
     public Uni<OidcTenantConfig> resolve(RoutingContext routingContext,
             OidcRequestContext<OidcTenantConfig> requestContext) {
-        return Uni.createFrom().item(oidcConfig);
+
+        OidcTenantConfig config;
+
+        if (endSessionEndpoint.get().isPresent()) {
+            /*
+             * When the provider supports RP-initiated logout, configure
+             * Quarkus OIDC to use it. Note, in this case our SessionResource logout
+             * endpoint is NOT used, although the URL path is the same. This makes
+             * the back-end logout functionality opaque to the front-end.
+             */
+            config = OidcTenantConfig.builder(oidcConfig)
+                .logout()
+                    .path("/api/session/logout")
+                    .postLogoutPath("/")
+                .end()
+                .build();
+        } else {
+            config = oidcConfig;
+        }
+
+        return Uni.createFrom().item(config);
     }
 
 }

--- a/api/src/main/java/com/github/streamshub/console/api/security/RedirectUriValidator.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/RedirectUriValidator.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 
 import org.jboss.logging.Logger;
 
@@ -17,6 +19,28 @@ public class RedirectUriValidator {
 
     private static final Logger LOGGER = Logger.getLogger(RedirectUriValidator.class);
     private static final String DEFAULT_REDIRECT = "/";
+
+    /**
+     * Validates and sanitizes {@code redirectUri}, then combines the resulting safe
+     * path with the scheme, host, and port taken from {@code uriInfo} to produce a
+     * fully-qualified redirect {@link URI} that stays within the application.
+     *
+     * @param redirectUri the caller-supplied redirect path to validate; may be
+     *                    {@code null} or blank, in which case {@code "/"} is used
+     * @param uriInfo     the JAX-RS {@link UriInfo} of the current request, used to
+     *                    inherit scheme, host, and port for the returned URI
+     * @return a safe, fully-qualified {@link URI} suitable for use in a redirect
+     *         response
+     */
+    public URI safeRedirectUri(String redirectUri, UriInfo uriInfo) {
+        String safePath = validateAndSanitize(redirectUri);
+
+        return UriBuilder.fromUri(uriInfo.getRequestUri())
+            .replacePath(safePath)
+            .replaceQuery(null)
+            .fragment(null)
+            .build();
+    }
 
     /**
      * Validates that a redirect URI is safe to use.

--- a/api/src/main/java/com/github/streamshub/console/api/security/SessionResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/SessionResource.java
@@ -1,29 +1,24 @@
 package com.github.streamshub.console.api.security;
 
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
-import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.config.ConsoleConfig;
 
 import io.quarkus.oidc.OidcSession;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
 
 @Path("session")
 public class SessionResource {
@@ -36,10 +31,6 @@ public class SessionResource {
 
     @Inject
     SecurityIdentity identity;
-
-    @Inject
-    @Named("oidcEndSessionEndpoint")
-    Holder<String> endSessionEndpoint;
 
     @Inject
     RedirectUriValidator redirectValidator;
@@ -64,7 +55,7 @@ public class SessionResource {
     @GET
     @Path("login")
     public Response login(@QueryParam("redirect_uri") String redirectUri, UriInfo uriInfo) {
-        return Response.seeOther(safeRedirectUri(redirectUri, uriInfo)).build();
+        return Response.seeOther(redirectValidator.safeRedirectUri(redirectUri, uriInfo)).build();
     }
 
     @GET
@@ -92,53 +83,27 @@ public class SessionResource {
         return Response.ok(properties).build();
     }
 
+    /**
+     * Logout of the application and redirect to the root URL. Note,
+     * this endpoint is overridden by the OIDC RP-initiated logout handled
+     * by Quarkus OIDC when the OIDC provider advertises an `end_session_endpoint`
+     * URI.
+     */
     @GET
     @Path("logout")
-    public Response logout(@QueryParam("redirect_uri") String redirectUri, UriInfo uriInfo) {
-        // Validate and sanitize the redirect URI to prevent open redirect vulnerabilities
-        URI safeRedirectUri = safeRedirectUri(redirectUri, uriInfo);
+    public Uni<Response> logout(UriInfo uriInfo) {
+        var response = Response
+                .seeOther(redirectValidator.safeRedirectUri("/", uriInfo))
+                .build();
 
         if (oidcEnabled()) {
-            oidcSession.logout().await().indefinitely();
+            return oidcSession.logout().replaceWith(response);
         }
 
-        URI logoutUri = endSessionEndpoint
-            .map(endpoint -> {
-                /*
-                 * If the end_session_endpoint is available, redirect to allow the IdP
-                 * to terminate the session fully.
-                 */
-                String redirectEncoded = URLEncoder.encode(
-                        safeRedirectUri.toString(),
-                        StandardCharsets.UTF_8
-                );
-                var builder = UriBuilder.fromUri(endpoint);
-                builder.queryParam("post_logout_redirect_uri", redirectEncoded);
-                // ID token won't be present for service calls, only web-app interactions
-                // where session is maintained via cookie.
-                Optional.ofNullable(oidcSession.getIdToken().getRawToken())
-                    .ifPresent(t -> builder.queryParam("id_token_hint", t));
-                return builder.build();
-            })
-            .orElse(safeRedirectUri);
-
-        return Response.seeOther(logoutUri).build();
+        return Uni.createFrom().item(response);
     }
 
     private Optional<String> nameClaim(JsonWebToken token) {
         return token.claim("name");
-    }
-
-    private URI safeRedirectUri(String redirectUri, UriInfo uriInfo) {
-        // Validate and sanitize the redirect URI to prevent open redirect vulnerabilities
-        String safePath = redirectValidator.validateAndSanitize(redirectUri);
-
-        // Use the sanitized path together with the scheme, host, and port of the
-        // request to this resource.
-        return UriBuilder.fromUri(uriInfo.getRequestUri())
-            .replacePath(safePath)
-            .replaceQuery(null)
-            .fragment(null)
-            .build();
     }
 }

--- a/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResource.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResource.java
@@ -1,6 +1,5 @@
 package com.github.streamshub.console.api.security.kafka;
 
-import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -9,9 +8,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -53,23 +50,8 @@ public class KafkaSessionResource {
 
     @GET
     @Path("logout")
-    public Response kafkaLogout(@QueryParam("redirect_uri") String redirectUri, UriInfo uriInfo) {
-        // Validate and sanitize the redirect URI to prevent open redirect vulnerabilities
-        URI safeRedirectUri = safeRedirectUri(redirectUri, uriInfo);
+    public Response kafkaLogout(UriInfo uriInfo) {
         FormAuthenticationMechanism.logout(identity);
-        return Response.seeOther(safeRedirectUri).build();
-    }
-
-    private URI safeRedirectUri(String redirectUri, UriInfo uriInfo) {
-        // Validate and sanitize the redirect URI to prevent open redirect vulnerabilities
-        String safePath = redirectValidator.validateAndSanitize(redirectUri);
-
-        // Use the sanitized path together with the scheme, host, and port of the
-        // request to this resource.
-        return UriBuilder.fromUri(uriInfo.getRequestUri())
-            .replacePath(safePath)
-            .replaceQuery(null)
-            .fragment(null)
-            .build();
+        return Response.seeOther(redirectValidator.safeRedirectUri("/", uriInfo)).build();
     }
 }

--- a/api/src/main/webui/src/components/app/UserDropdown.tsx
+++ b/api/src/main/webui/src/components/app/UserDropdown.tsx
@@ -59,12 +59,12 @@ export function UserDropdown({ username, clusterId, anonymous, picture }: UserDr
               let sessionPath;
 
               if (clusterId) {
-                sessionPath = `/api/kafkas/${clusterId}/session`;
+                sessionPath = `/api/kafkas/${clusterId}/session/logout`;
               } else {
-                sessionPath = `/api/session`;
+                sessionPath = '/api/session/logout';
               }
 
-              window.location.href = `${sessionPath}/logout?redirect_uri=${encodeURIComponent('/')}`;
+              window.location.href = sessionPath;
             }}>
             {t('user.logout')}
           </DropdownItem>

--- a/api/src/test/java/com/github/streamshub/console/api/security/SessionResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/security/SessionResourceIT.java
@@ -6,7 +6,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.literal.NamedLiteral;
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import com.github.streamshub.console.api.support.Holder;
 import com.github.streamshub.console.config.ConsoleConfig;
 import com.github.streamshub.console.kafka.systemtest.TestPlainProfile;
 import com.github.streamshub.console.kafka.systemtest.utils.TokenUtils;
@@ -24,15 +28,16 @@ import com.github.streamshub.console.test.TestHelper;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 import static com.github.streamshub.console.test.TestHelper.whenRequesting;
 import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
@@ -148,29 +153,66 @@ class SessionResourceIT {
 
     @Test
     @Tag(OIDC_TAG)
-    void testLogoutOIDC() {
+    void testLogoutOIDCWithRPInitiatedFlow() throws Exception {
         var authEndpoint = UriBuilder
                 .fromUri(URI.create(config.getValue("console.test.oidc-url", String.class)))
                 .port(8443)
                 .build()
                 .toString();
+        var expectedPostLogoutUri = UriBuilder.fromUri(testUri)
+                .replacePath("/")
+                .build()
+                .toString();
+
+        // Perform the full OIDC Authorization Code flow so that Quarkus sets a
+        // session cookie. The RP-initiated logout endpoint only works for
+        // session-authenticated users, not for stateless Bearer token callers.
+        var loginUri = UriBuilder.fromUri(testUri).replacePath("/api/session/login").build();
+        var sessionCookies = tokens.performOidcLogin(loginUri, "alice", "alice-password");
+
+        whenRequesting(req -> req
+                .cookies(sessionCookies)
+                .redirects().follow(false)
+                .get("logout"))
+            .assertThat()
+            .statusCode(is(Status.FOUND.getStatusCode()))
+            .header("Location", startsWith(authEndpoint))
+            .header("Location", this::queryParams, hasEntry(is("post_logout_redirect_uri"), is(expectedPostLogoutUri)))
+            // id_token_hint is included because we used the authorization code flow and
+            // Quarkus holds the id_token server-side in the session.
+            .header("Location", this::queryParams, hasKey("id_token_hint"));
+    }
+
+    @Test
+    @Tag(OIDC_TAG)
+    void testLogoutOIDCWithLocalOnlyFlow() throws Exception {
+        QuarkusMock.installMockForType(
+                Holder::empty,
+                new TypeLiteral<Supplier<Holder<String>>>() {
+                    // used for type signature
+                },
+                NamedLiteral.of(OidcDiscoveryResponseFilter.OIDC_END_SESSION_ENDPOINT));
+
+        // Perform the full OIDC Authorization Code flow so that Quarkus sets a
+        // session cookie. The RP-initiated logout endpoint only works for
+        // session-authenticated users, not for stateless Bearer token callers.
+        var loginUri = UriBuilder.fromUri(testUri).replacePath("/api/session/login").build();
+        var sessionCookies = tokens.performOidcLogin(loginUri, "alice", "alice-password");
+
+        // Logout is local only. Client is redirected to the root URL
         var expectedLocation = UriBuilder.fromUri(testUri)
-                .replacePath("/some/path")
+                .replacePath("/")
                 .build()
                 .toString();
 
         whenRequesting(req -> req
-                .queryParam("redirect_uri", "/some/path")
-                .auth().oauth2(tokens.getToken("alice"))
+                .cookies(sessionCookies)
                 .redirects().follow(false)
                 .get("logout"))
             .assertThat()
             .statusCode(is(Status.SEE_OTHER.getStatusCode()))
-            .header("Location", startsWith(authEndpoint))
-            .header("Location", this::queryParams, hasEntry(is("post_logout_redirect_uri"), is(expectedLocation)))
-            // hint is only available when OIDC authorization code flow is used,
-            // not when tokens retrieved directly by the client like is done in this test.
-            .header("Location", this::queryParams, not(hasKey("id_token_hint")));
+            .header("Location", is(expectedLocation))
+            .header("Location", this::queryParams, is(anEmptyMap()));
     }
 
     @Test

--- a/api/src/test/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/security/kafka/KafkaSessionResourceIT.java
@@ -133,12 +133,11 @@ class KafkaSessionResourceIT {
     @Tag(AUTHN_SCRAM_TAG)
     void testLogoutSCRAM() {
         var expectedLocation = UriBuilder.fromUri(testUri)
-                .replacePath("/some/path")
+                .replacePath("/")
                 .build()
                 .toString();
 
         whenRequesting(req -> req
-                .queryParam("redirect_uri", "/some/path")
                 .cookies(sessionCookies)
                 .redirects().follow(false)
                 .get("logout", clusterId))

--- a/api/src/test/java/com/github/streamshub/console/kafka/systemtest/utils/TokenUtils.java
+++ b/api/src/test/java/com/github/streamshub/console/kafka/systemtest/utils/TokenUtils.java
@@ -2,12 +2,21 @@ package com.github.streamshub.console.kafka.systemtest.utils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.CookieManager;
+import java.net.HttpCookie;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 
@@ -16,6 +25,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriBuilder;
 
 import org.eclipse.microprofile.config.Config;
 
@@ -31,8 +41,11 @@ public class TokenUtils {
     final String tokenEndpointHost;
     final SSLContext tls;
 
+    final String oidcUrl;
+
     public TokenUtils(Config config) {
-        this.tokenEndpoint = config.getValue("console.test.oidc-url", String.class) + "/protocol/openid-connect/token";
+        this.oidcUrl = config.getValue("console.test.oidc-url", String.class);
+        this.tokenEndpoint = oidcUrl + "/protocol/openid-connect/token";
         this.tokenEndpointHost = config.getValue("console.test.oidc-host", String.class);
 
         var tlsRegistry = CDI.current().select(TlsConfigurationRegistry.class).get();
@@ -96,5 +109,114 @@ public class TokenUtils {
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Drives the OIDC Authorization Code flow against the real Keycloak container,
+     * returning the Quarkus session cookies ({@code q_session*}) so callers can make
+     * session-authenticated requests.
+     *
+     * <p>The flow is:
+     * <ol>
+     *   <li>GET {@code loginUri} → 302 to Keycloak /auth (Quarkus sets a state cookie)</li>
+     *   <li>GET the Keycloak login page to obtain the form action URL</li>
+     *   <li>POST credentials to the form action → 302 back to the app callback</li>
+     *   <li>GET the app callback → Quarkus exchanges the code and sets the session cookie</li>
+     * </ol>
+     *
+     * <p>A raw {@link HttpClient} is used instead of RestAssured because the redirect
+     * chain crosses origins (app port ↔ Keycloak port) and RestAssured's automatic
+     * redirect following does not carry cookies across different hosts.
+     *
+     * @param loginUri  the absolute URI of the app's login endpoint (e.g. {@code /session/login})
+     * @param username  Keycloak username
+     * @param password  Keycloak password
+     * @return map of session cookie name → value for the app origin
+     */
+    public Map<String, String> performOidcLogin(URI loginUri, String username, String password) throws Exception {
+        var cookieManager = new CookieManager();
+
+        HttpClient client = HttpClient.newBuilder()
+                .sslContext(tls)
+                .followRedirects(Redirect.NEVER)
+                .version(Version.HTTP_1_1)
+                .cookieHandler(cookieManager)
+                .build();
+
+        // Step 1: trigger the OIDC redirect from the Quarkus app.
+        var step1 = client.send(
+                HttpRequest.newBuilder(loginUri).GET().build(),
+                BodyHandlers.ofString());
+        var kcAuthLocation = step1.headers().firstValue("Location")
+                .orElseThrow(() -> new IllegalStateException(
+                        "Expected redirect to Keycloak, got: " + step1.statusCode()));
+
+        // Keycloak advertises its internal port in the Location URL; translate it to
+        // the externally mapped port that the test container host can actually reach.
+        var kcAuthUri = translateKcUri(URI.create(kcAuthLocation));
+
+        // Step 2: fetch the Keycloak login page and extract the form action URL.
+        var step2 = client.send(
+                HttpRequest.newBuilder(kcAuthUri)
+                        .header("Host", tokenEndpointHost)
+                        .GET()
+                        .build(),
+                BodyHandlers.ofString());
+        var formAction = parseFormAction(step2.body());
+
+        // Step 3: POST the credentials to Keycloak.
+        var formBody = "username=" + URLEncoder.encode(username, StandardCharsets.UTF_8)
+                + "&password=" + URLEncoder.encode(password, StandardCharsets.UTF_8)
+                + "&credentialId=";
+
+        var step3 = client.send(
+                HttpRequest.newBuilder(translateKcUri(URI.create(formAction)))
+                        .header("Host", tokenEndpointHost)
+                        .header("Content-Type", "application/x-www-form-urlencoded")
+                        .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                        .build(),
+                BodyHandlers.ofString());
+        var callbackLocation = step3.headers().firstValue("Location")
+                .orElseThrow(() -> new IllegalStateException(
+                        "Expected redirect to app callback, got: " + step3.statusCode()));
+
+        // Step 4: complete the code exchange — Quarkus handles this internally and
+        // sets the session cookie on the response.
+        client.send(
+                HttpRequest.newBuilder(URI.create(callbackLocation)).GET().build(),
+                BodyHandlers.ofString());
+
+        // Collect all q_session* cookies stored by the cookie manager for the app origin.
+        var appOrigin = URI.create(loginUri.getScheme() + "://" + loginUri.getAuthority());
+        return cookieManager.getCookieStore()
+                .get(appOrigin)
+                .stream()
+                .filter(c -> c.getName().startsWith("q_session"))
+                .collect(Collectors.toMap(HttpCookie::getName, HttpCookie::getValue));
+    }
+
+    /**
+     * Keycloak advertises URLs using its internal container port (8443) in the
+     * well-known discovery document. Translate those to the externally mapped port
+     * so the test container host can be reached.
+     */
+    private URI translateKcUri(URI uri) {
+        var kc = URI.create(oidcUrl);
+        return UriBuilder.fromUri(uri)
+                .host(kc.getHost())
+                .port(kc.getPort())
+                .build();
+    }
+
+    /**
+     * Extracts the {@code action} attribute value from the first {@code <form>}
+     * element in a Keycloak login page.
+     */
+    private String parseFormAction(String html) {
+        var matcher = Pattern.compile("action=\"([^\"]+)\"").matcher(html);
+        if (matcher.find()) {
+            return matcher.group(1).replace("&amp;", "&");
+        }
+        throw new IllegalStateException("Could not find form action in Keycloak login page");
     }
 }

--- a/api/src/test/java/com/github/streamshub/console/test/TestHelper.java
+++ b/api/src/test/java/com/github/streamshub/console/test/TestHelper.java
@@ -203,6 +203,12 @@ public class TestHelper {
                 .withClientSecret("console-client-secret")
                 .withAuthServerUrl(config.getValue("console.test.oidc-url", String.class))
                 .withIssuer(config.getValue("console.test.oidc-issuer", String.class))
+                // PKCE adds a code_verifier that must be carried through the redirect
+                // chain; disable it in tests to simplify the auth-code flow helper.
+                .withPkceRequired(false)
+                // A stable secret prevents state-cookie verification failures when the
+                // OidcTenantConfig is re-initialised between the redirect and callback.
+                .withStateSecret("streamshub-console-test-state-secret-32b")
                 .withNewTrustStore()
                     .withType(TrustStoreConfig.Type.valueOf(config.getValue("console.test.oidc-trust-store.type", String.class)))
                     .withNewPassword()

--- a/api/src/test/resources/keycloak/console-realm.json
+++ b/api/src/test/resources/keycloak/console-realm.json
@@ -5,6 +5,95 @@
   "ssoSessionMaxLifespan": 864000,
   "enabled": true,
   "sslRequired": "external",
+  "clientScopes": [
+    {
+      "name": "openid",
+      "protocol": "openid-connect"
+    },
+    {
+      "name": "email",
+      "protocol": "openid-connect",
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "name": "profile",
+      "protocol": "openid-connect",
+      "protocolMappers": [
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "name": "groups",
+      "protocol": "openid-connect"
+    }
+  ],
   "roles": {
     "realm": [
       {
@@ -108,12 +197,15 @@
       "secret": "console-client-secret",
       "bearerOnly": false,
       "consentRequired": false,
-      "standardFlowEnabled": false,
+      "standardFlowEnabled": true,
+      "redirectUris": ["http://localhost/*", "https://localhost/*"],
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": false,
       "publicClient": true,
       "fullScopeAllowed": true,
+      "defaultClientScopes": ["openid", "email", "profile"],
+      "optionalClientScopes": ["groups"],
       "protocolMappers": [{
         "name": "Groups Mapper",
         "protocol": "openid-connect",
@@ -150,6 +242,8 @@
       "serviceAccountsEnabled": true,
       "publicClient": false,
       "fullScopeAllowed": true,
+      "defaultClientScopes": ["openid", "email", "profile"],
+      "optionalClientScopes": ["groups"],
       "protocolMappers": [{
         "name": "Groups Mapper",
         "protocol": "openid-connect",


### PR DESCRIPTION
Remove custom `/api/session/logout` REST handler for OIDC logout and utilize the Quarkus OIDC built-in support. This requires changes to the existing logout test to first login using the authorization code OIDC flow via KeyCloak's authentication form.

Fixes #2701 

Assisted-by: IBM Bob