### PR TITLE
Topic message table fixes and alignment with previous Next.js version

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -73,6 +73,8 @@ quarkus.rest.path=/api
 # See https://vertx.io/docs/vertx-core/java/#classpath
 quarkus.quinoa.enable-spa-routing=true
 quarkus.quinoa.dev-server.direct-forwarding=true
+# Frozen package-lock.json, fail if updates needed
+quarkus.quinoa.ci=true
 
 console.meta.version=${quarkus.application.version}
 console.meta.platform=

--- a/api/src/main/webui/package-lock.json
+++ b/api/src/main/webui/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^17.0.8",
+        "react-json-view-lite": "^2.5.0",
         "react-router-dom": "^7.18.1",
         "victory": "^37.3.6",
         "zustand": "^5.0.14"
@@ -996,9 +997,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,9 +1014,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,9 +1031,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,9 +1048,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,9 +1065,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1096,9 +1082,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3386,6 +3369,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-json-view-lite": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+      "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-jss": {
       "version": "10.10.0",

--- a/api/src/main/webui/package.json
+++ b/api/src/main/webui/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
+    "react-json-view-lite": "^2.5.0",
     "react-router-dom": "^7.18.1",
     "victory": "^37.3.6",
     "zustand": "^5.0.14"

--- a/api/src/main/webui/src/api/hooks/useMessages.ts
+++ b/api/src/main/webui/src/api/hooks/useMessages.ts
@@ -3,8 +3,8 @@
  */
 
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { apiClient } from '../client';
-import { KafkaRecord, KafkaRecordsResponse, ErrorObject } from '../types';
+import { apiClient, ApiError } from '../client';
+import { KafkaRecord, KafkaRecordsResponse } from '../types';
 
 interface GetMessagesParams {
   kafkaId: string;
@@ -110,7 +110,7 @@ export async function getMessage(
  */
 export function useMessages(
   params: GetMessagesParams,
-  options?: Omit<UseQueryOptions<KafkaRecord[], ErrorObject>, 'queryKey' | 'queryFn'>
+  options?: Omit<UseQueryOptions<KafkaRecord[], ApiError>, 'queryKey' | 'queryFn'>
 ) {
   return useQuery({
     queryKey: [
@@ -138,7 +138,7 @@ export function useMessage(
   topicId: string,
   partition: number | undefined,
   offset: number | undefined,
-  options?: Omit<UseQueryOptions<KafkaRecord | undefined, ErrorObject>, 'queryKey' | 'queryFn'>
+  options?: Omit<UseQueryOptions<KafkaRecord | undefined, ApiError>, 'queryKey' | 'queryFn'>
 ) {
   return useQuery({
     queryKey: ['message', kafkaId, topicId, partition, offset],

--- a/api/src/main/webui/src/components/kafka/topics/AdvancedSearch.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/AdvancedSearch.tsx
@@ -3,7 +3,7 @@
  * Provides filtering options for Kafka messages
  */
 
-import { useState, useCallback, useTransition, useRef, useEffect } from 'react';
+import { useState, useCallback, useTransition, useRef, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { toDatetimeLocal, toISOWithLocalOffset } from '@/utils/dateTime';
@@ -195,7 +195,7 @@ export function AdvancedSearch({
     }
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isExpanded) return;
     updatePanelPosition();
     window.addEventListener('scroll', updatePanelPosition, true);

--- a/api/src/main/webui/src/components/kafka/topics/AdvancedSearch.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/AdvancedSearch.tsx
@@ -3,8 +3,10 @@
  * Provides filtering options for Kafka messages
  */
 
-import { useState, useCallback, useTransition } from 'react';
+import { useState, useCallback, useTransition, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
+import { toDatetimeLocal, toISOWithLocalOffset } from '@/utils/dateTime';
 import {
   SearchInput,
   Button,
@@ -73,7 +75,9 @@ export function AdvancedSearch({
     filterEpoch !== undefined ? 'epoch' : 'latest'
   );
   const [fromOffset, setFromOffset] = useState<number | undefined>(filterOffset);
-  const [fromTimestamp, setFromTimestamp] = useState<string | undefined>(filterTimestamp);
+  const [fromTimestamp, setFromTimestamp] = useState<string | undefined>(
+    filterTimestamp ? toDatetimeLocal(filterTimestamp) : undefined
+  );
   const [fromEpoch, setFromEpoch] = useState<number | undefined>(filterEpoch);
   const [isFromOpen, setIsFromOpen] = useState(false);
   const [, startTransition] = useTransition();
@@ -101,7 +105,7 @@ export function AdvancedSearch({
       } else if (fromCategory === 'epoch' && fromEpoch !== undefined) {
         return { type: 'epoch', value: fromEpoch };
       } else if (fromCategory === 'timestamp' && fromTimestamp) {
-        return { type: 'timestamp', value: fromTimestamp };
+        return { type: 'timestamp', value: toISOWithLocalOffset(fromTimestamp) };
       }
       return { type: 'latest' };
     })();
@@ -172,8 +176,38 @@ export function AdvancedSearch({
   const searchString = buildSearchInputValue();
   const [searchInputValue, setSearchInputValue] = useState(searchString);
 
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [panelStyle, setPanelStyle] = useState<React.CSSProperties>({});
+
+  const updatePanelPosition = useCallback(() => {
+    if (anchorRef.current) {
+      const rect = anchorRef.current.getBoundingClientRect();
+      const top = rect.bottom + 8;
+      setPanelStyle({
+        position: 'fixed',
+        top,
+        left: rect.left,
+        width: rect.width,
+        maxHeight: `calc(100vh - ${top}px - 16px)`,
+        overflowY: 'auto',
+        zIndex: 9999,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    updatePanelPosition();
+    window.addEventListener('scroll', updatePanelPosition, true);
+    window.addEventListener('resize', updatePanelPosition);
+    return () => {
+      window.removeEventListener('scroll', updatePanelPosition, true);
+      window.removeEventListener('resize', updatePanelPosition);
+    };
+  }, [isExpanded, updatePanelPosition]);
+
   return (
-    <div style={{ position: 'relative', width: '100%' }}>
+    <div ref={anchorRef} style={{ position: 'relative', width: '100%' }}>
       <SearchInput
         placeholder={t('common.search')}
         value={searchInputValue}
@@ -191,16 +225,9 @@ export function AdvancedSearch({
         onToggleAdvancedSearch={() => setIsExpanded(!isExpanded)}
         isAdvancedSearchOpen={isExpanded}
       />
-      {isExpanded && <Panel
+      {isExpanded && createPortal(<Panel
         variant="raised"
-        style={{
-          position: 'absolute',
-          top: '100%',
-          left: 0,
-          right: 0,
-          zIndex: 1000,
-          marginTop: '0.5rem',
-        }}
+        style={panelStyle}
       >
         <PanelMain>
           <PanelMainBody>
@@ -471,7 +498,7 @@ export function AdvancedSearch({
             </Form>
           </PanelMainBody>
         </PanelMain>
-      </Panel>}
+      </Panel>, document.body)}
     </div>
   );
 }

--- a/api/src/main/webui/src/components/kafka/topics/MessageDetails.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/MessageDetails.tsx
@@ -14,12 +14,14 @@ import {
   Tabs,
   Tab,
   TabTitleText,
-  CodeBlock,
-  CodeBlockCode,
+  ClipboardCopy,
   Title,
 } from '@patternfly/react-core';
+import { allExpanded, darkStyles, defaultStyles, JsonView } from 'react-json-view-lite';
+import 'react-json-view-lite/dist/index.css';
 import { KafkaRecord } from '@/api/types';
 import { formatDateTime } from '@/utils/dateTime';
+import { useTheme } from '@/components/app/ThemeProvider';
 
 interface MessageDetailsProps {
   message: KafkaRecord;
@@ -27,6 +29,8 @@ interface MessageDetailsProps {
 
 export function MessageDetails({ message }: MessageDetailsProps) {
   const { t } = useTranslation();
+  const { isDarkMode } = useTheme();
+  const jsonStyles = isDarkMode ? darkStyles : defaultStyles;
   const [activeTabKey, setActiveTabKey] = useState<string | number>('value');
 
   const formatTimestampLocal = (timestamp: string): string => {
@@ -57,19 +61,22 @@ export function MessageDetails({ message }: MessageDetailsProps) {
     }
   };
 
-  const tryFormatJSON = (value: string | null): { formatted: string; isJSON: boolean } => {
-    if (!value) return { formatted: '-', isJSON: false };
+  const maybeJson = (value: string | null): { parsed: object; isJSON: boolean } => {
+    if (!value) return { parsed: {}, isJSON: false };
     try {
       const parsed = JSON.parse(value);
-      return { formatted: JSON.stringify(parsed, null, 2), isJSON: true };
+      if (typeof parsed === 'object' && parsed !== null) {
+        return { parsed, isJSON: true };
+      }
     } catch {
-      return { formatted: value, isJSON: false };
+      // not JSON
     }
+    return { parsed: {}, isJSON: false };
   };
 
-  const keyFormatted = tryFormatJSON(message.attributes.key);
-  const valueFormatted = tryFormatJSON(message.attributes.value);
-  const headersFormatted = JSON.stringify(message.attributes.headers, null, 2);
+  const keyJson = maybeJson(message.attributes.key);
+  const valueJson = maybeJson(message.attributes.value);
+  const headers = Object.entries(message.attributes.headers ?? {});
 
   return (
     <DrawerPanelBody>
@@ -141,9 +148,19 @@ export function MessageDetails({ message }: MessageDetailsProps) {
             title={<TabTitleText>{t('topics.messages.field.value')}</TabTitleText>}
           >
             <div style={{ padding: '1rem' }}>
-              <CodeBlock>
-                <CodeBlockCode>{valueFormatted.formatted}</CodeBlockCode>
-              </CodeBlock>
+              <ClipboardCopy
+                isCode
+                isReadOnly
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant={valueJson.isJSON ? 'inline' : 'expansion'}
+                isExpanded={!valueJson.isJSON}
+              >
+                {message.attributes.value ?? '-'}
+              </ClipboardCopy>
+              {valueJson.isJSON && (
+                <JsonView data={valueJson.parsed} shouldExpandNode={allExpanded} style={jsonStyles} />
+              )}
               {message.relationships.valueSchema?.meta?.name && (
                 <div style={{ marginTop: '1rem' }}>
                   <Title headingLevel="h4" size="md">
@@ -160,9 +177,19 @@ export function MessageDetails({ message }: MessageDetailsProps) {
             title={<TabTitleText>{t('topics.messages.field.key')}</TabTitleText>}
           >
             <div style={{ padding: '1rem' }}>
-              <CodeBlock>
-                <CodeBlockCode>{keyFormatted.formatted}</CodeBlockCode>
-              </CodeBlock>
+              <ClipboardCopy
+                isCode
+                isReadOnly
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant={keyJson.isJSON ? 'inline' : 'expansion'}
+                isExpanded={!keyJson.isJSON}
+              >
+                {message.attributes.key ?? '-'}
+              </ClipboardCopy>
+              {keyJson.isJSON && (
+                <JsonView data={keyJson.parsed} shouldExpandNode={allExpanded} style={jsonStyles} />
+              )}
               {message.relationships.keySchema?.meta?.name && (
                 <div style={{ marginTop: '1rem' }}>
                   <Title headingLevel="h4" size="md">
@@ -179,9 +206,18 @@ export function MessageDetails({ message }: MessageDetailsProps) {
             title={<TabTitleText>{t('topics.messages.field.headers')}</TabTitleText>}
           >
             <div style={{ padding: '1rem' }}>
-              <CodeBlock>
-                <CodeBlockCode>{headersFormatted}</CodeBlockCode>
-              </CodeBlock>
+              {headers.length === 0 ? (
+                <span>-</span>
+              ) : (
+                <DescriptionList isHorizontal isCompact>
+                  {headers.map(([k, v]) => (
+                    <DescriptionListGroup key={k}>
+                      <DescriptionListTerm>{k}</DescriptionListTerm>
+                      <DescriptionListDescription>{String(v)}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                  ))}
+                </DescriptionList>
+              )}
             </div>
           </Tab>
         </Tabs>

--- a/api/src/main/webui/src/components/kafka/topics/MessagesTable.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/MessagesTable.tsx
@@ -3,12 +3,14 @@
  * Displays Kafka messages in a virtualized table
  */
 
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   EmptyState,
   EmptyStateBody,
   Button,
   Title,
+  Content,
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
@@ -20,6 +22,7 @@ interface MessagesTableProps {
   messages: KafkaRecord[];
   selectedMessage?: KafkaRecord;
   chosenColumns: Column[];
+  hasFilters: boolean;
   onSelectMessage: (message: KafkaRecord) => void;
   onReset: () => void;
   topicName: string;
@@ -29,23 +32,34 @@ export function MessagesTable({
   messages,
   selectedMessage,
   chosenColumns,
+  hasFilters,
   onSelectMessage,
   onReset,
 }: MessagesTableProps) {
   const { t } = useTranslation();
   const columnLabels = useColumnLabels();
 
-  const formatValue = (value: string | null, maxLength = 100): string => {
+  const truncate = (value: string | null): React.ReactNode => {
     if (!value) return '-';
-    if (value.length <= maxLength) return value;
-    return value.substring(0, maxLength) + '...';
+    return (
+      <span style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {value}
+      </span>
+    );
   };
 
-  const formatHeaders = (headers: Record<string, unknown>): string => {
-    const keys = Object.keys(headers);
-    if (keys.length === 0) return '-';
-    if (keys.length === 1) return `${keys[0]}: ${headers[keys[0]]}`;
-    return `${keys.length} headers`;
+  const renderHeaders = (headers: Record<string, unknown>) => {
+    const entries = Object.entries(headers);
+    if (entries.length === 0) return '-';
+    return (
+      <div>
+        {entries.map(([k, v]) => (
+          <div key={k} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <strong>{k}</strong>: {String(v)}
+          </div>
+        ))}
+      </div>
+    );
   };
 
   const formatTimestampUTC = (timestamp: string): string => {
@@ -81,11 +95,17 @@ export function MessagesTable({
       <EmptyState>
         <SearchIcon />
         <Title headingLevel="h2" size="lg">
-          {t('topics.messages.noResultsTitle')}
+          {t('topics.messages.noDataTitle')}
         </Title>
-        <EmptyStateBody>{t('topics.messages.noResultsBody')}</EmptyStateBody>
+        <EmptyStateBody>
+          {hasFilters
+            ? t('topics.messages.noResultsBody')
+            : t('topics.messages.noDataBody')}
+        </EmptyStateBody>
         <Button variant="primary" onClick={onReset}>
-          {t('topics.messages.noResultsReset')}
+          {hasFilters
+            ? t('topics.messages.noResultsReset')
+            : t('topics.messages.noDataRefresh')}
         </Button>
       </EmptyState>
     );
@@ -97,9 +117,11 @@ export function MessagesTable({
         return (
           <div>
             <strong>{message.attributes.offset}</strong>
-            <div style={{ fontSize: '0.875rem', color: 'var(--pf-v5-global--Color--200)' }}>
-              Partition {message.attributes.partition}
-            </div>
+            <Content>
+              <Content component="small">
+                Partition {message.attributes.partition}
+              </Content>
+            </Content>
           </div>
         );
       case 'timestampUTC':
@@ -107,11 +129,11 @@ export function MessagesTable({
       case 'timestamp':
         return formatTimestampLocal(message.attributes.timestamp);
       case 'key':
-        return formatValue(message.attributes.key);
+        return truncate(message.attributes.key);
       case 'headers':
-        return formatHeaders(message.attributes.headers);
+        return renderHeaders(message.attributes.headers);
       case 'value':
-        return formatValue(message.attributes.value);
+        return truncate(message.attributes.value);
       case 'size':
         return formatBytes(message.attributes.size);
       default:
@@ -121,8 +143,8 @@ export function MessagesTable({
 
   return (
     <>
-      <div style={{ flex: 1, overflow: 'auto' }}>
-        <Table aria-label={t('topics.messages.tableAriaLabel')} variant="compact">
+      <div style={{ flex: 1, overflow: 'auto', minWidth: 0 }}>
+        <Table aria-label={t('topics.messages.tableAriaLabel')} variant="compact" style={{ tableLayout: 'fixed', width: '100%' }}>
           <Thead>
             <Tr>
               {chosenColumns.map((column) => {
@@ -163,7 +185,6 @@ export function MessagesTable({
                   <Td
                     key={column}
                     dataLabel={columnLabels[column]}
-                    modifier={column === 'key' || column === 'headers' || column === 'value' ? 'truncate' : undefined}
                   >
                     {renderCell(column, message)}
                   </Td>

--- a/api/src/main/webui/src/components/kafka/topics/parseSearchInput.ts
+++ b/api/src/main/webui/src/components/kafka/topics/parseSearchInput.ts
@@ -7,17 +7,15 @@ export function parseSearchInput({ value }: { value: string }): SearchParams {
     },
     limit: 50,
     partition: undefined,
-    query: {
-      where: "everywhere",
-      value: "",
-    },
+    query: undefined,
   };
+  let queryWhere: ReturnType<typeof parseWhere> = "everywhere";
   const parts = value.split(" ");
   const queryParts: string[] = [];
   parts.forEach((p) => {
     if (p.indexOf(`where=`) === 0) {
       const [, where] = p.split("=");
-      sp.query!.where = parseWhere(where);
+      queryWhere = parseWhere(where);
     } else if (p.indexOf(`messages=`) === 0) {
       const [, from] = p.split("=");
       if (from === "latest") {
@@ -80,7 +78,7 @@ export function parseSearchInput({ value }: { value: string }): SearchParams {
   const query = queryParts.join(" ").trim();
 
   if (query.length > 0) {
-    sp.query!.value = query;
+    sp.query = { value: query, where: queryWhere };
   }
 
   return sp;

--- a/api/src/main/webui/src/pages/kafka/topics/detail/TopicMessagesTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/detail/TopicMessagesTab.tsx
@@ -9,6 +9,7 @@ import {
   PageSection,
   Drawer,
   DrawerContent,
+  DrawerContentBody,
   DrawerPanelContent,
   DrawerHead,
   DrawerActions,
@@ -24,9 +25,10 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
-import { SearchIcon, ExclamationCircleIcon, ColumnsIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, ColumnsIcon } from '@patternfly/react-icons';
 import { useMessages } from '@/api/hooks/useMessages';
 import { useTopic } from '@/api/hooks/useTopics';
+import { ApiError } from '@/api/client';
 import { KafkaRecord, SearchParams } from '@/api/types';
 import { MessagesTable } from '@/components/kafka/topics/MessagesTable';
 import { MessageDetails } from '@/components/kafka/topics/MessageDetails';
@@ -97,25 +99,21 @@ export function TopicMessagesTab() {
   );
 
   const selectedMessageId = useMemo(() => searchParams.get('selected'), [searchParams]);
-  // Handle message selection from URL
-  const urlSelectedMessage = useMemo(() => {
-    if (selectedMessageId && messages.length > 0) {
-      const [partStr, offsetStr] = selectedMessageId.split(':');
-      const part = parseInt(partStr);
-      const off = parseInt(offsetStr);
-      return messages.find(
-        m => m.attributes.partition === part && m.attributes.offset === off
-      );
-    } else if (!selectedMessageId) {
-      return undefined;
-    }
+  // Derive selected message directly from URL + messages — no separate state needed.
+  const selectedMessage = useMemo(() => {
+    if (!selectedMessageId) return undefined;
+    const [partStr, offsetStr] = selectedMessageId.split(':');
+    const part = parseInt(partStr);
+    const off = parseInt(offsetStr);
+    return messages.find(
+      m => m.attributes.partition === part && m.attributes.offset === off
+    );
   }, [selectedMessageId, messages]);
-  const [selectedMessage, setSelectedMessage] = useState<KafkaRecord | undefined>(urlSelectedMessage);
 
   const handleSearch = useCallback((params: SearchParams) => {
     const newParams = new URLSearchParams();
     
-    if (params.query) {
+    if (params.query?.value) {
       newParams.set('query', params.query.value);
       if (params.query.where !== 'everywhere') {
         newParams.set('where', params.query.where);
@@ -141,21 +139,22 @@ export function TopicMessagesTab() {
     }
     
     setSearchParams(newParams, { replace: true });
-  }, [setSearchParams]);
+    // Always refetch explicitly — if the params haven't changed the query key
+    // is identical and TanStack Query won't issue a new request otherwise.
+    refetch();
+  }, [setSearchParams, refetch]);
 
   const handleSelectMessage = useCallback((message: KafkaRecord) => {
-    setSelectedMessage(message);
     const newParams = new URLSearchParams(searchParams);
     newParams.set('selected', `${message.attributes.partition}:${message.attributes.offset}`);
     setSearchParams(newParams, { replace: true });
-  }, [setSelectedMessage, searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams]);
 
   const handleDeselectMessage = useCallback(() => {
-    setSelectedMessage(undefined);
     const newParams = new URLSearchParams(searchParams);
     newParams.delete('selected');
     setSearchParams(newParams, { replace: true });
-  }, [setSelectedMessage, searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams]);
 
   const handleReset = useCallback(() => {
     setSearchParams(new URLSearchParams());
@@ -203,116 +202,97 @@ export function TopicMessagesTab() {
     );
   }
 
-  // Error state
-  if (messagesError) {
-    return (
-      <PageSection isFilled>
-        <EmptyState>
-          <ExclamationCircleIcon />
-          <Title headingLevel="h2" size="lg">
-            {t('topics.messages.noDataTitle')}
-          </Title>
-          <EmptyStateBody>
-            {messagesError.title || t('common.error')}
-          </EmptyStateBody>
-          <Button variant="primary" onClick={() => refetch()}>
-            {t('common.retry')}
-          </Button>
-        </EmptyState>
-      </PageSection>
-    );
-  }
-
-  // No data state (no filters applied)
   const hasFilters = partition !== undefined || offset !== undefined ||
                      timestamp !== undefined || epoch !== undefined || query !== undefined;
-  
-  if (messages.length === 0 && !hasFilters) {
-    return (
-      <PageSection isFilled>
-        <EmptyState>
-          <SearchIcon />
-          <Title headingLevel="h2" size="lg">
-            {t('topics.messages.noDataTitle')}
-          </Title>
-          <EmptyStateBody>
-            {t('topics.messages.noDataBody')}
-          </EmptyStateBody>
-          <Button variant="primary" onClick={() => refetch()}>
-            {t('topics.messages.noDataRefresh')}
-          </Button>
-        </EmptyState>
-      </PageSection>
-    );
-  }
 
   return (
     <>
-    <PageSection isFilled>
-      <Drawer isExpanded={!!selectedMessage} isInline>
-        <DrawerContent
-          panelContent={
-            selectedMessage && (
-              <DrawerPanelContent isResizable minSize="400px">
-                <DrawerHead>
-                  <span>{t('topics.messages.message')}</span>
-                  <DrawerActions>
-                    <DrawerCloseButton onClick={handleDeselectMessage} />
-                  </DrawerActions>
-                </DrawerHead>
-                <MessageDetails message={selectedMessage} />
-              </DrawerPanelContent>
-            )
-          }
-        >
-            
-          {limit === 'continuously' && (
-            <Alert
-              variant="info"
-              isInline
-              title={t('topics.messages.continuousMode.title')}
-            />
-          )}
+    <Drawer isExpanded={!!selectedMessage}>
+      <DrawerContent
+        panelContent={
+          selectedMessage && (
+            <DrawerPanelContent isResizable minSize="400px">
+              <DrawerHead>
+                <span>{t('topics.messages.message')}</span>
+                <DrawerActions>
+                  <DrawerCloseButton onClick={handleDeselectMessage} />
+                </DrawerActions>
+              </DrawerHead>
+              <MessageDetails message={selectedMessage} />
+            </DrawerPanelContent>
+          )
+        }
+      >
+        <DrawerContentBody>
+          <PageSection isFilled>
+            {limit === 'continuously' && (
+              <Alert
+                variant="info"
+                isInline
+                title={t('topics.messages.continuousMode.title')}
+              />
+            )}
 
-          <Toolbar>
-            <ToolbarContent>
-              <ToolbarItem style={{ flex: 1, maxWidth: '700px' }}>
-                <AdvancedSearch
-                  partitions={partitions}
-                  filterQuery={query}
-                  filterWhere={where}
-                  filterPartition={partition}
-                  filterOffset={offset}
-                  filterTimestamp={timestamp}
-                  filterEpoch={epoch}
-                  filterLimit={limit}
-                  onSearch={handleSearch}
-                />
-              </ToolbarItem>
-              <ToolbarItem>
-                <Tooltip content={t('topics.messages.manage_columns')}>
-                  <Button
-                    variant="plain"
-                    icon={<ColumnsIcon />}
-                    onClick={() => setShowColumnsModal(true)}
-                    aria-label={t('topics.messages.manage_columns')}
+            <Toolbar>
+              <ToolbarContent>
+                <ToolbarItem style={{ flex: 1, maxWidth: '700px' }}>
+                  <AdvancedSearch
+                    partitions={partitions}
+                    filterQuery={query}
+                    filterWhere={where}
+                    filterPartition={partition}
+                    filterOffset={offset}
+                    filterTimestamp={timestamp}
+                    filterEpoch={epoch}
+                    filterLimit={limit}
+                    onSearch={handleSearch}
                   />
-                </Tooltip>
-              </ToolbarItem>
-            </ToolbarContent>
-          </Toolbar>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Tooltip content={t('topics.messages.manage_columns')}>
+                    <Button
+                      variant="plain"
+                      icon={<ColumnsIcon />}
+                      onClick={() => setShowColumnsModal(true)}
+                      aria-label={t('topics.messages.manage_columns')}
+                    />
+                  </Tooltip>
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
 
-          <MessagesTable
-            messages={messages}
-            selectedMessage={selectedMessage}
-            chosenColumns={chosenColumns}
-            onSelectMessage={handleSelectMessage}
-            onReset={handleReset}
-            topicName={topicData?.attributes?.name || topicId || ''}
-          />
-        </DrawerContent>
-      </Drawer>
-    </PageSection>
+            {messagesError ? (
+              <EmptyState>
+                <ExclamationCircleIcon />
+                <Title headingLevel="h2" size="lg">
+                  {messagesError instanceof ApiError && messagesError.errors?.[0]?.title
+                    ? messagesError.errors[0].title
+                    : t('topics.messages.noDataTitle')}
+                </Title>
+                <EmptyStateBody>
+                  {messagesError instanceof ApiError && messagesError.errors?.[0]?.detail
+                    ? messagesError.errors[0].detail
+                    : messagesError.message}
+                </EmptyStateBody>
+                <Button variant="primary" onClick={() => refetch()}>
+                  {t('common.retry')}
+                </Button>
+              </EmptyState>
+            ) : (
+              <MessagesTable
+                messages={messages}
+                selectedMessage={selectedMessage}
+                chosenColumns={chosenColumns}
+                hasFilters={hasFilters}
+                onSelectMessage={handleSelectMessage}
+                onReset={handleReset}
+                topicName={topicData?.attributes?.name || topicId || ''}
+              />
+            )}
+          </PageSection>
+        </DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
 
     {showColumnsModal && (
       <ColumnsModal

--- a/api/src/main/webui/src/utils/dateTime.ts
+++ b/api/src/main/webui/src/utils/dateTime.ts
@@ -4,6 +4,29 @@
 
 import { formatInTimeZone } from 'date-fns-tz';
 
+/**
+ * Convert an ISO 8601 string to the "YYYY-MM-DDTHH:mm" format required by
+ * <input type="datetime-local">, expressed in the user's local timezone.
+ */
+export function toDatetimeLocal(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return formatInTimeZone(d, localTz, "yyyy-MM-dd'T'HH:mm");
+}
+
+/**
+ * Convert a "YYYY-MM-DDTHH:mm" datetime-local string to a full ISO 8601
+ * string with the local timezone offset (e.g. "2024-06-15T14:30:00.000+02:00").
+ * Preserves the user's intent rather than silently converting to UTC.
+ */
+export function toISOWithLocalOffset(datetimeLocal: string): string {
+  const d = new Date(datetimeLocal);
+  if (isNaN(d.getTime())) return datetimeLocal;
+  const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return formatInTimeZone(d, localTz, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
+}
+
 export function formatDateTime({
   value,
   timeZone,

--- a/api/src/main/webui/vite.config.ts
+++ b/api/src/main/webui/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       '@patternfly/react-icons',
       '@patternfly/react-user-feedback',
       '@patternfly/react-data-view',
+      'react-json-view-lite',
     ]
   }
 });


### PR DESCRIPTION
Fixes #2716
Fixes #2717

- Do not hide search form for fetch errors or no messages
- Fix handling of timestamp search criterion
- Fix message drawer to overlay table and not scroll when table scrolls. This allows messages further down in the table to be selected and viewed.
- Fix position and size of the advanced message search box
- Display message headers as key/value pair rather than as a JSON object
- Add back advanced JSON display for key and value shown in the message drawer. Add support for dark mode which was not present in the old Next.js version

Assisted-by: IBM Bob