### PR TITLE
fix system test commit SHA reference

### DIFF
--- a/.github/workflows/pre-systemtest.yml
+++ b/.github/workflows/pre-systemtest.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
           workflow: systemtests.yml
-          ref: "${{ env.COMMIT_SHA }}"
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
           inputs: >
             {
               "commit_sha": "${{ env.COMMIT_SHA }}",


### PR DESCRIPTION
Correct the `ref` for running system tests from an open PR.

> Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the test merge commit.

[1] https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#get-a-pull-request