### PR TITLE
fix: remove attempt to run system tests from ref

### DIFF
--- a/.github/actions/systemtests/parse-pr-comment-params.sh
+++ b/.github/actions/systemtests/parse-pr-comment-params.sh
@@ -32,6 +32,3 @@ echo "RETRY_COUNT=$retry_count" >> $GITHUB_ENV
 # Export current PR branch latest commit sha
 commit_sha=$(gh pr view $PR_NUMBER --json headRefOid -q '.headRefOid')
 echo "COMMIT_SHA=$commit_sha" >> $GITHUB_ENV
-
-merge_sha=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.merge_commit_sha')
-echo "MERGE_COMMIT_SHA=$merge_sha" >> "$GITHUB_ENV"

--- a/.github/workflows/pre-systemtest.yml
+++ b/.github/workflows/pre-systemtest.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           token: ${{ secrets.BOT_ORG_SCOPED_TOKEN }}
           workflow: systemtests.yml
-          ref: "${{ env.MERGE_COMMIT_SHA }}"
           inputs: >
             {
               "commit_sha": "${{ env.COMMIT_SHA }}",


### PR DESCRIPTION
Attempts to run the version of systemtests.yml from a PR failed. This reverts to the old way of using the version from `main`.