### PR TITLE
Escape commas in `like` searches from UI

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/model/FetchFilter.java
+++ b/api/src/main/java/com/github/streamshub/console/api/model/FetchFilter.java
@@ -1,6 +1,9 @@
 package com.github.streamshub.console.api.model;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import com.github.streamshub.console.api.support.FetchFilterPredicate;
 
 public class FetchFilter {
 
@@ -13,22 +16,51 @@ public class FetchFilter {
             return null;
         }
 
-        int operatorIdx = filter.indexOf(',');
         String operator;
         List<String> operands;
+        List<String> parts = split(filter);
 
-        if (operatorIdx > -1) {
-            operator = filter.substring(0, operatorIdx);
-            if (operator.isBlank()) {
-                operator = "eq";
-            }
-            operands = List.of(filter.substring(operatorIdx + 1).split(","));
+        if (parts.size() == 1) {
+            operator = FetchFilterPredicate.Operator.EQUAL_TO.value();
+            operands = parts; // the whole input is the operand
         } else {
-            operator = "eq";
-            operands = List.of(filter);
+            operator = parts.get(0);
+            if (operator.isBlank()) {
+                operator = FetchFilterPredicate.Operator.EQUAL_TO.value();
+            }
+            operands = parts.subList(1, parts.size());
         }
 
         return new FetchFilter(filter, operator, operands);
+    }
+
+    static List<String> split(String filter) {
+        List<String> elements = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escape = false;
+
+        for (int i = 0; i < filter.length(); i++) {
+            char c = filter.charAt(i);
+            if (escape) {
+                current.append(c);
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == ',') {
+                elements.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+
+        if (escape) {
+            // Dangling backslash — treat it as a literal backslash
+            current.append('\\');
+        }
+        elements.add(current.toString());
+
+        return elements;
     }
 
     public static String rawFilter(FetchFilter filter) {

--- a/api/src/main/java/com/github/streamshub/console/api/support/FetchFilterPredicate.java
+++ b/api/src/main/java/com/github/streamshub/console/api/support/FetchFilterPredicate.java
@@ -24,6 +24,10 @@ public class FetchFilterPredicate<B, F> implements Predicate<B> {
             this.value = value;
         }
 
+        public String value() {
+            return value;
+        }
+
         public static Operator fromValue(String value) {
             Objects.requireNonNull(value);
 

--- a/api/src/main/webui/src/api/hooks/useConnect.ts
+++ b/api/src/main/webui/src/api/hooks/useConnect.ts
@@ -3,6 +3,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import escape from '../utils/escape';
 import { apiClient } from '../client';
 import {
   ConnectorsResponse,
@@ -67,7 +68,7 @@ export function useConnectors(
       searchParams.set('filter[connectCluster.kafkaClusters]', `in,${kafkaId}`);
 
       if (params?.name) {
-        searchParams.set('filter[name]', `like,*${params.name}*`);
+        searchParams.set('filter[name]', `like,*${escape(params.name)}*`);
       }
 
       if (params?.pageSize) {
@@ -140,7 +141,7 @@ export function useConnectClusters(
       searchParams.set('filter[kafkaClusters]', `in,${kafkaId}`);
 
       if (params?.name) {
-        searchParams.set('filter[name]', `like,*${params.name}*`);
+        searchParams.set('filter[name]', `like,*${escape(params.name)}*`);
       }
 
       if (params?.pageSize) {

--- a/api/src/main/webui/src/api/hooks/useGroups.ts
+++ b/api/src/main/webui/src/api/hooks/useGroups.ts
@@ -3,6 +3,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import escape from '../utils/escape';
 import { apiClient } from '../client';
 import {
   GroupsResponse,
@@ -56,7 +57,7 @@ export function useGroups(
       );
 
       if (params?.id) {
-        searchParams.set('filter[id]', `like,*${params.id}*`);
+        searchParams.set('filter[id]', `like,*${escape(params.id)}*`);
       }
 
       if (params?.type && params.type.length > 0) {

--- a/api/src/main/webui/src/api/hooks/useRebalances.ts
+++ b/api/src/main/webui/src/api/hooks/useRebalances.ts
@@ -3,6 +3,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import escape from '../utils/escape';
 import { apiClient } from '../client';
 import {
   RebalancesResponse,
@@ -66,7 +67,7 @@ export function useRebalances(
       }
 
       if (params?.name) {
-        searchParams.set('filter[name]', `like,*${params.name}*`);
+        searchParams.set('filter[name]', `like,*${escape(params.name)}*`);
       }
 
       if (params?.status && params.status.length > 0) {

--- a/api/src/main/webui/src/api/hooks/useResourceList.ts
+++ b/api/src/main/webui/src/api/hooks/useResourceList.ts
@@ -3,6 +3,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import escape from '../utils/escape';
 import { apiClient } from '../client';
 import { ListResponse, Resource } from '../types';
 
@@ -100,7 +101,7 @@ export function useResourceList<T extends Resource>(
           }
 
           if (typeof value === 'string') {
-            searchParams.set(`filter[${key}]`, `like,*${value}*`);
+            searchParams.set(`filter[${key}]`, `like,*${escape(value)}*`);
             return;
           }
 

--- a/api/src/main/webui/src/api/hooks/useUsers.ts
+++ b/api/src/main/webui/src/api/hooks/useUsers.ts
@@ -3,6 +3,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import escape from '../utils/escape';
 import { apiClient } from '../client';
 import { UsersResponse, UserResponse } from '../types';
 
@@ -57,7 +58,7 @@ export function useUsers(
       }
 
       if (params?.username) {
-        searchParams.set('filter[username]', `like,*${params.username}*`);
+        searchParams.set('filter[username]', `like,*${escape(params.username)}*`);
       }
 
       if (params?.fields) {

--- a/api/src/main/webui/src/api/utils/escape.ts
+++ b/api/src/main/webui/src/api/utils/escape.ts
@@ -1,0 +1,3 @@
+export default function escape(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/,/g, '\\,');
+}

--- a/api/src/test/java/com/github/streamshub/console/api/GroupsResourceIT.java
+++ b/api/src/test/java/com/github/streamshub/console/api/GroupsResourceIT.java
@@ -94,6 +94,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -229,6 +230,40 @@ class GroupsResourceIT {
                 .statusCode(is(Status.OK.getStatusCode()))
                 .body("data.size()", is(2))
                 .body("data.attributes.groupId", everyItem(matchesPattern(compile("^grp-\\d{2}-FLAG-.*$"))));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // Exact match with all commas escaped
+        "'like,group\\,name\\,with\\,commas', true",
+        // Wildcard around an escaped comma substring
+        "'like,*name\\,with*',               true",
+        // Wildcard with no commas — matches the non-comma portion
+        "'like,*name*',                      true",
+        // Unescaped commas are parsed as additional operands, splitting the group name;
+        // none of the resulting operands matches the full group id
+        "'like,group,name,with,commas',      false",
+        // Exact match with all commas escaped, but with invalid trailing backslash
+        "'like,group\\,name\\,with\\,commas\\', false",
+    })
+    void testListGroupsWithCommaInId(String filterValue, boolean expectMatch) {
+        String groupId = "group,name,with,commas";
+        String topic = "t-" + UUID.randomUUID().toString();
+        String clientId = "c-" + UUID.randomUUID().toString();
+
+        try (var consumer = groupUtils.consume(groupId, topic, clientId, 2, false)) {
+            var req = whenRequesting(r -> r
+                    .param("filter[id]", filterValue)
+                    .get("", clusterId1))
+                .assertThat()
+                .statusCode(is(Status.OK.getStatusCode()));
+
+            if (expectMatch) {
+                req.body("data.attributes.groupId", hasItem(groupId));
+            } else {
+                req.body("data.attributes.groupId", not(hasItem(groupId)));
+            }
         }
     }
 

--- a/systemtests/src/test/java/com/github/streamshub/systemtests/consumers/GroupsST.java
+++ b/systemtests/src/test/java/com/github/streamshub/systemtests/consumers/GroupsST.java
@@ -112,7 +112,7 @@ public class GroupsST extends AbstractST {
             Map.entry("Hyphenated", "group-hyphen--name-"),
             Map.entry("With slash", "group/with//slash/"),
             Map.entry("Equals sign", "group=equals==two"),
-            // Map.entry("Comma separated", "group,comma,separated,,"),
+            Map.entry("Comma separated", "group,comma,separated,,"),
             Map.entry("With spaces", "group space allowed"),
             Map.entry("Pipe symbol", "group|pipe||secondpipe"),
             Map.entry("Tilde", "group~tilde~~name"),


### PR DESCRIPTION
Allow commas to be used in search forms. This requires escaping the `,` character in the parameter sent from the UI to the API so that it is not used as a delimiter in the API's query parsing.

Fixes #2733

Assisted-by: IBM Bob