### PR TITLE
[Cluster][Discussion] Local cluster setup on MacOs- minikube and kind

### DIFF
--- a/systemtests/cluster-setup/README.md
+++ b/systemtests/cluster-setup/README.md
@@ -8,12 +8,26 @@ a minikube node's IP — used by CI's `$(minikube ip).nip.io` — isn't
 reachable from the host), but the scripts themselves are OS-agnostic and
 work on Linux too.
 
-**Container engine**: auto-detected — prefers `podman`, falls back to
-`docker` if podman isn't installed. Override explicitly with
-`CONTAINER_ENGINE=podman` or `CONTAINER_ENGINE=docker`. The podman-machine
-VM setup (`ensure_podman_machine` in `lib/env.sh`) only runs on macOS,
-where podman needs a VM to run containers at all — it's a no-op on native
-Linux, which doesn't need one.
+**Container engine / driver**: auto-detected, and `kind/` and `minikube/`
+pick differently:
+
+- `kind/` only ever supports `docker` or `podman` — prefers `docker`,
+  falls back to `podman`. Override with `CONTAINER_ENGINE=docker` or
+  `CONTAINER_ENGINE=podman`.
+- `minikube/` also considers VM-based drivers, per
+  [minikube's own driver docs](https://minikube.sigs.k8s.io/docs/drivers/):
+  `docker` → the platform's VM driver (`vfkit` on macOS, `kvm2` on Linux)
+  → `podman` as a last resort (still marked experimental upstream on both
+  OSes). Override with `CONTAINER_ENGINE=docker`, `vfkit`, `kvm2`, or
+  `podman`.
+
+Podman works as a fallback on both, but avoid it if you have another
+option — in practice it's needed real workarounds (the `ip_tables` kernel
+module requirement on Linux, PID-limit crashes under a full
+Kafka+Console workload, and rootless-mode failures reported directly
+against minikube). The podman-machine VM setup (`ensure_podman_machine`
+in `lib/env.sh`) only runs on macOS, where podman needs a VM to run
+containers at all — it's a no-op on Linux, which doesn't need one.
 
 ## Use kind
 
@@ -28,6 +42,15 @@ instead, which isn't reliably reachable from macOS. That means either a
 that requires a one-time sudo prompt — more moving parts either way. Use
 `minikube/` only if you specifically need it (e.g. closer parity with CI's
 tooling); otherwise `kind/` is simpler and more reliable.
+
+**macOS reality check**: `kind/` with the `docker` driver is the path
+that's actually been verified working reliably. `minikube/` with the
+`vfkit` driver has hit VM-networking failures in practice that are still
+being root-caused, and rootless podman is a recurring source of pain on
+both cluster types (see the driver notes above) — don't reach for `podman`
+or `vfkit` as your first choice on macOS. If you need `minikube/`, prefer
+`docker` as the driver; only try `vfkit`/`podman` if you're specifically
+debugging that path.
 
 ## Layout
 

--- a/systemtests/cluster-setup/README.md
+++ b/systemtests/cluster-setup/README.md
@@ -1,0 +1,384 @@
+# Cluster setup (macOS-safe local Kubernetes for systemtests)
+
+Provisions a local Kubernetes cluster for running the `console-operator`
+systemtests outside CI, on macOS where `systemtests/scripts/setup-minikube.sh`
+doesn't work reliably: Docker Desktop / Podman Desktop / Colima all run the
+container engine inside a hidden VM, so a minikube node's IP (used by CI's
+`$(minikube ip).nip.io`) isn't routable from the host.
+
+Two options, kept fully independent of each other (`kind/` doesn't touch or
+depend on `minikube/`'s scripts, or vice versa):
+
+- **`kind/` — recommended.** Reliable, few moving parts, portless URLs out
+  of the box, no sudo ever needed.
+- **`minikube/`** — works too, but needs either a `:8443`-suffixed URL or an
+  extra sudo-gated step for portless access, and hit a real podman PID-limit
+  bug under a full Kafka-heavy stack (documented below, fixed, but a real
+  wrinkle kind never had).
+
+**Recommendation: default to `kind/` for day-to-day work.** Minikube's only
+edge is closer parity with CI's tooling, which doesn't matter much for local
+dev/Playwright testing since `common/`'s scripts are pure kubectl/helm and
+don't care which cluster distro they're talking to (proven — see below).
+Keep `minikube/` around for when you specifically need it.
+
+Full narrative — every dead end, root-caused with evidence (the Strimzi API
+version mismatch, the OLM `Route` CRD quirk, the SSL-passthrough crash, the
+loopback-collision bug, the finalizer race, the podman PID limit) — is in
+`~/claude-docs/streamshub-local-sts/README.md`.
+
+## Layout
+
+```
+cluster-setup/
+  kind/                    # recommended: kind-based cluster
+    create-cluster.sh      # create/reuse cluster + ingress-nginx, verify with a smoke test
+    delete-cluster.sh      # teardown (full, or --keep-cluster)
+    lib/env.sh             # shared config + podman-machine helpers
+  minikube/                # alternative: minikube-based cluster
+    create-cluster.sh      # create/reuse cluster + ingress addon, verify with a smoke test
+    delete-cluster.sh      # teardown (full, or --keep-cluster)
+    enable-tunnel.sh       # switch to portless access (needs sudo once)
+    lib/env.sh             # shared config + podman-machine helpers
+  common/                  # cluster-agnostic — works against either
+    setup-catalogsource.sh       # install OLM + a CatalogSource
+    deploy-example-console.sh    # Strimzi + Kafka + Console operator + Console instance
+```
+
+`common/` scripts have zero kind/minikube-specific logic (pure
+kubectl/helm/envsubst against whatever cluster context is currently active)
+— confirmed by running them unmodified against both cluster types.
+
+## Quick start
+
+### kind
+
+```sh
+./kind/create-cluster.sh
+source kind/.cluster-env
+../common/setup-catalogsource.sh --image <catalog-image> [--namespace olm] [--name strimzi-source]
+../common/deploy-example-console.sh --catalog-image <catalog-image>
+```
+(run the `common/` scripts from inside `kind/`, or adjust the relative path —
+they just need to be invoked with a cluster context already active)
+
+Ends with a working, portless Console UI at
+`https://example-console.127.0.0.1.nip.io/`, backed by a real Kafka cluster.
+
+Teardown: `./kind/delete-cluster.sh` (or `--keep-cluster`).
+
+### minikube
+
+```sh
+./minikube/create-cluster.sh
+source minikube/.cluster-env
+../common/setup-catalogsource.sh --image <catalog-image> [--namespace olm] [--name strimzi-source]
+../common/deploy-example-console.sh --catalog-image <catalog-image>
+```
+
+By default, access URLs need the port suffix printed by `create-cluster.sh`
+(e.g. `https://example-console.127.0.0.1.nip.io:8443/`). For portless URLs
+(e.g. OIDC/auth flows that assume no port in the redirect URI), run
+`./minikube/enable-tunnel.sh` instead (prompts for your sudo password once).
+
+Teardown: `./minikube/delete-cluster.sh` (or `--keep-cluster`).
+
+All scripts in both directories are idempotent — safe to re-run.
+
+## `kind/create-cluster.sh`
+
+Creates (or reuses) a kind cluster with ports 80/443 mapped to the host at
+cluster-creation time (`extraPortMappings`), installs ingress-nginx bound
+via `hostPort` on the node, patches in `--enable-ssl-passthrough` (required
+once a Kafka cluster's TLS-terminating `secure` listener shows up —
+otherwise ingress-nginx's worker processes crash: `exited with fatal code 2
+and cannot be respawned`), then **verifies the whole exposure path with a
+smoke test** (deploys a throwaway echo-server behind an Ingress, curls it
+over HTTP/HTTPS, cleans up) before declaring the cluster ready. If the
+smoke test fails, the script exits non-zero rather than claiming success.
+
+Cluster domain is `127.0.0.1.nip.io` (public wildcard DNS), so any
+`<name>.127.0.0.1.nip.io` hostname resolves to `127.0.0.1` on this machine
+and reaches whatever ingress-nginx routes it to by Host header/SNI —
+Console, Kafka's TLS-passthrough listener, Apicurio, all through the same
+two exposed ports, portlessly, no sudo ever required.
+
+Env vars (all optional, see `kind/lib/env.sh`):
+
+- `CONTAINER_ENGINE` — `podman` (default) or `docker`
+- `CLUSTER_NAME` — default `console-local`
+- `INGRESS_HTTP_PORT` / `INGRESS_HTTPS_PORT` — default `80`/`443`
+- `CONSOLE_CLUSTER_DOMAIN` — default `127.0.0.1.nip.io`
+- `PODMAN_MACHINE_CPUS` / `PODMAN_MACHINE_MEMORY` (MB) — podman only;
+  default to (host CPUs − 1) / (host memory − 4GB headroom), auto-detected
+  via `sysctl`. **Only applied when a podman machine is created for the
+  first time** — if one already exists with different sizing, the script
+  warns and prints the manual resize command rather than restarting your
+  machine (a resize requires stop/start, which would kill anything already
+  running in it, including the cluster).
+
+## `minikube/create-cluster.sh`
+
+Creates (or reuses) a minikube cluster with the `ingress` addon, patches in
+`--enable-ssl-passthrough` (same reason as kind), then exposes it and
+**verifies with the same smoke test pattern** before declaring success.
+
+Why not the same hostPort approach as kind? Confirmed empirically:
+
+- minikube's `ingress` addon creates a **`NodePort`** Service, not
+  hostPort-bound like kind's. Direct NodePort access from macOS to the
+  minikube node IP (e.g. `curl 192.168.49.2:30674`) times out — reproduces
+  a long-standing upstream minikube/docker-driver-on-macOS issue, confirmed
+  on this actual machine, not just taken from GitHub issues on faith.
+- `minikube tunnel` **can** give portless (`127.0.0.1`) access, but only
+  after patching the Service to `LoadBalancer` (tunnel only manages
+  LoadBalancer services, not NodePort — patching alone does nothing:
+  without a running tunnel, the Service just reports `EXTERNAL-IP:
+  127.0.0.1` cosmetically while nothing is actually listening). Binding
+  ports 80/443 additionally needs an **interactive sudo password** —
+  minikube's own tunnel process prints "sudo permission will be asked for
+  it" for privileged ports.
+
+So by default, `create-cluster.sh` exposes ingress-nginx via a persistent
+background `kubectl port-forward` on non-privileged local ports (default
+`8080`/`8443`, override via `LOCAL_HTTP_PORT`/`LOCAL_HTTPS_PORT`) — no sudo
+needed, fully scriptable, but URLs need the port suffix. If the
+port-forward process dies (less durable than kind's container-level port
+mapping over long sessions), just re-run `create-cluster.sh` — it detects
+the dead PID and restarts it.
+
+Same `CONTAINER_ENGINE`/`PODMAN_MACHINE_CPUS`/`PODMAN_MACHINE_MEMORY` env
+vars and podman-machine auto-sizing as kind (duplicated in `lib/env.sh`,
+not shared, so `kind/` and `minikube/` stay fully independent).
+
+### `minikube/enable-tunnel.sh` — portless access
+
+Switches from the port-forward to `minikube tunnel`: stops the
+port-forward, patches `ingress-nginx-controller` to `LoadBalancer`, then
+runs the tunnel itself as a background process it manages (PID tracked in
+`.tunnel.pid`, log in `.tunnel.log`) — not something you run in a separate
+terminal.
+
+The one thing it can't avoid: binding ports 80/443 needs `sudo`. The script
+calls `sudo -v` right before starting the tunnel — **run it directly**
+(`./enable-tunnel.sh`, not `sudo ./enable-tunnel.sh`), and you'll be
+prompted for your password exactly once, right there. Everything after
+that (starting the tunnel, waiting for it to actually bind, confirming
+`EXTERNAL-IP` becomes `127.0.0.1`) runs unattended. Confirmed working.
+
+```sh
+./minikube/enable-tunnel.sh
+# prompts for sudo password once, then:
+# "Portless access ready: https://<name>.127.0.0.1.nip.io/"
+```
+
+To switch back to the port-forward approach: stop the tunnel
+(`sudo kill $(cat minikube/.tunnel.pid)`) and re-run `create-cluster.sh` —
+it detects no running tunnel and starts a fresh port-forward instead.
+`delete-cluster.sh` stops whichever of the two (port-forward or tunnel) is
+currently running automatically, including the `sudo -n kill` needed for a
+root-owned tunnel process.
+
+### Prerequisite for minikube: raise podman's PID limit (Kafka-heavy workloads)
+
+minikube's docker/podman driver runs the **entire K8s node** (kubelet,
+containerd, and every pod's processes) as a single podman container.
+podman's default per-container PID limit is **2048**, which a full
+Strimzi + multi-broker Kafka + Console + Prometheus stack can exhaust —
+hit this in testing: the Console pod failed to start with `runc create
+failed: ... fork/exec: resource temporarily unavailable` while
+`podman inspect <container> --format '{{.HostConfig.PidsLimit}}'` showed
+exactly `2048` and `podman stats` showed 2040 PIDs already in use. This
+looks like a networking/LoadBalancer problem at first glance (a pod not
+coming up) but isn't — check `podman inspect`/`podman stats` first if you
+hit unexplained container start failures on minikube.
+
+Fix (one-time, requires `sudo` inside the podman machine VM, so not
+automated by these scripts):
+
+```sh
+podman machine ssh -- 'sudo mkdir -p /etc/containers && printf "[containers]\npids_limit = 8192\n" | sudo tee /etc/containers/containers.conf'
+podman machine stop && podman machine start   # required — the running podman service caches config at boot
+```
+
+Two gotchas: editing `~/.config/containers/containers.conf` on the **macOS
+host** does nothing (the real container runtime is inside the VM); and the
+VM's default `/usr/share/containers/containers.conf` shouldn't be edited
+directly — create the override at `/etc/containers/containers.conf`
+instead. Verify with `podman inspect <minikube-container> --format
+'{{.HostConfig.PidsLimit}}'` after recreating the cluster. kind hasn't hit
+this (different container architecture per node), but there's no
+fundamental reason it couldn't under a big enough workload — keep it in
+mind either way.
+
+## `common/setup-catalogsource.sh --image <image> [--namespace olm] [--name strimzi-source]`
+
+Installs OLM v0.45.0 (same version/hash CI pins), then applies
+`install/operator/olm/010-CatalogSource-console-operator-catalog.yaml`
+patched with your `--name`/`--image`, and waits for it to report `READY`.
+
+The "already installed" check goes beyond just checking a CRD exists — it
+verifies `olm-operator`/`catalog-operator` are actually `Available`. A CRD
+(or the `olm` namespace) can be left behind by a previous install that got
+interrupted or crash-looped; skipping reinstall based on presence alone
+would leave a broken OLM that fails confusingly much later (Subscriptions
+never resolving, CatalogSources never reaching `READY`). If it detects a
+prior install exists but isn't healthy, it uninstalls first (upstream's
+`install.sh` refuses to touch an existing install, so a repair needs an
+uninstall+reinstall, not just a re-run) — via `operator-sdk olm uninstall`
+if available, otherwise it errors out with instructions (install
+`operator-sdk`, or run `delete-cluster.sh` for a fresh cluster).
+
+Tested this by deliberately breaking OLM (scaling `olm-operator` to 0
+replicas): detection correctly triggered repair, and when the repair itself
+timed out (a fully-dead `olm-operator` can't clear its own `CSV`
+finalizers, so even `operator-sdk olm uninstall` can get stuck) the script
+gave a clear "run delete-cluster.sh" message instead of falling through to
+upstream's confusing "OLM is already installed... Exiting" error.
+
+Note: the `--image` must be pullable by the cluster's containerd — a public
+registry image works out of the box; a locally-built image needs
+`kind load docker-image`/`kind load image-archive` (kind) or `minikube
+image load` (minikube) first (not yet scripted here).
+
+## `common/deploy-example-console.sh --catalog-image <image> [options]`
+
+Deploys everything else in one shot: Strimzi (Helm), the Console operator
+(OperatorGroup + Subscription against the CatalogSource from
+`setup-catalogsource.sh`), a Kafka cluster, and a Console instance — using
+the project's own `examples/kafka/*.yaml` and
+`examples/console/010-Console-example.yaml` quickstart manifests (applied
+the same documented `envsubst` way the repo README describes), patched
+with a local-dev-only fix (see below).
+
+Options (all have sensible defaults):
+```
+--catalog-image        (required)
+--catalog-namespace    default: olm
+--catalog-name         default: strimzi-source
+--channel              default: alpha
+--operator-namespace   default: co-namespace   (Strimzi + Console operator)
+--strimzi-version      default: 0.51.0         (must match your console-operator build — see below)
+--kafka-namespace      default: kafka          (Kafka cluster + Console instance)
+--listener             default: scramplain     (internal listener Console uses)
+```
+
+**Version note:** Strimzi's version must match whatever console-operator
+build you're using — `0.51.0` is what `console-operator-catalog:0.12.0` was
+actually built against (confirmed by inspecting its bundled
+`io.strimzi.api-0.51.0.jar`). A newer Strimzi (e.g. `1.0.0`, which GA'd the
+Kafka `v1` CRD and dropped `v1beta2`) with an older console-operator build
+causes a silent "No such Kafka resource" failure even though the Kafka CR
+exists and is healthy — see the claude-docs writeup's "Layer 1" section.
+
+**Why it patches listeners:** the example manifests only define the
+`secure` (external, ingress+TLS) Kafka listener — correct for a real
+cluster with a real routable domain, but broken on this local nip.io setup:
+the Console **API pod runs inside the cluster**, and that listener's
+external hostname resolves to `127.0.0.1` from inside a pod too — which is
+the pod's own loopback, not the ingress controller. That produces
+`Connection refused` → Kafka admin client timeouts → the UI showing "Timed
+out waiting for backend service" for every data call. The script adds an
+internal `scramplain` listener (SCRAM-SHA-512, no TLS, in-cluster Service
+DNS) and points Console at it instead — a local-dev-only necessity, not a
+product bug (CI's `$(minikube ip)`-based `nip.io` doesn't hit this loopback
+collision).
+
+## `kind/delete-cluster.sh` / `minikube/delete-cluster.sh` `[--keep-cluster]`
+
+- Default: full delete (`kind delete cluster` / `minikube delete`) —
+  deletes everything in one shot.
+- `--keep-cluster`: removes just the deployed resources (Console/Kafka,
+  Console operator, Strimzi, OLM) but leaves the cluster + ingress-nginx
+  running, so a re-run of the `common/` scripts skips cluster creation and
+  ingress image pulls. Requires `operator-sdk` to cleanly uninstall OLM
+  (only for this mode — full teardown doesn't need it).
+
+  Deletes the Strimzi/Console custom resources (`Console`, `KafkaTopic`,
+  `KafkaUser`, `Kafka`, `KafkaNodePool`) *before* the namespace, because
+  deleting the namespace first can tear down the entity-operator pod before
+  it finishes clearing a `KafkaTopic`'s `strimzi.io/topic-operator`
+  finalizer — a real race hit during testing that leaves the namespace
+  stuck in `Terminating` forever. Falls back to force-clearing finalizers
+  if the namespace still doesn't terminate in time.
+
+  `minikube/delete-cluster.sh` also always stops the background
+  port-forward or tunnel first (the tunnel is root-owned via sudo, so a
+  plain `kill` can't touch it — tries `sudo -n kill` with cached
+  credentials, falls back to telling you to do it manually).
+
+## ⚠️ Known issue: the *real* systemtests always need the listener patch too
+
+`common/deploy-example-console.sh` patches its own example Console CR to
+use an internal listener (see above for why). **The real systemtests hit
+the exact same problem, every run** — their `ConsoleInstanceSetup.java`
+always creates the Console CR pointed at the external `secure` listener by
+default, and there's currently no env var to change that. Since the
+Console API pod runs inside the cluster, that produces the same
+`Connection refused` → Kafka admin client timeout → UI shows "Timed out
+waiting for backend service" for every data call, even though the UI
+itself loads fine (it's served statically; only the backend API calls that
+need Kafka fail).
+
+This is **not fixed by these scripts** — it has to be done manually, every
+time the real tests create a fresh Console instance (new hash-suffixed
+name each run):
+
+```sh
+kubectl -n <kafka-namespace> get kafka <kafka-name> -o jsonpath='{.status.listeners}'  # find the internal SCRAM listener name (e.g. scramplain)
+kubectl -n <kafka-namespace> patch console <console-name> --type='json' \
+  -p='[{"op": "replace", "path": "/spec/kafkaClusters/0/listener", "value": "<internal-listener-name>"}]'
+```
+
+Confirmed this is independent of the exposure mechanism — hit it and fixed
+it identically on both the port-forward and the tunnel/LoadBalancer paths.
+A watcher script that auto-patches any new Console CR as soon as it
+appears would remove the need to do this by hand; not written yet.
+
+## ⚠️ Known issue: orphaned `minikube tunnel` process across cluster recreations
+
+If `delete-cluster.sh` can't stop a running tunnel (no cached sudo
+credentials for the non-interactive `sudo -n kill`), it now **deliberately
+leaves `.tunnel.pid` in place** rather than silently dropping the only
+record of it (an earlier version of this script removed the file
+regardless — don't do that again if editing this). A root-owned tunnel
+process left running across a cluster delete+recreate cycle keeps holding
+ports 80/443 on the host while routing to a cluster that no longer
+exists, which:
+
+- blocks anything else (e.g. `kind/create-cluster.sh`) from binding those
+  same ports (`address already in use`)
+- can make a *freshly recreated* minikube cluster's Console instance look
+  broken from the browser/Playwright side, when the real cause is a stale
+  tunnel serving nothing useful — this happened once already and looked
+  exactly like a networking regression until traced back to `ps aux | grep
+  minikube tunnel` showing a process from hours earlier.
+
+If you ever see `create-cluster.sh` or `enable-tunnel.sh` behaving oddly
+right after a full teardown+recreate, check for stray tunnel processes
+first: `ps aux | grep "[m]inikube tunnel"`, then `sudo kill` any with a
+suspiciously old start time before re-running anything.
+
+## Status
+
+Full stack confirmed working end-to-end (2026-07-12), via scripts alone, on
+both cluster types: cluster → ingress → OLM → Strimzi → Console operator →
+Kafka → Console instance → UI reachable and functional (shows live Kafka
+nodes/topics, confirmed via clean `console-api` logs with no timeout
+errors). All scripts are idempotent, and all teardown paths (full,
+`--keep-cluster`, the finalizer-race fallback) are verified working on
+both.
+
+Minikube's `enable-tunnel.sh` portless path is **confirmed working** by the
+user in practice, including against a real systemtests run (Kafka +
+Console instance created by the actual test framework, not
+`deploy-example-console.sh`) — reachable at
+`https://<console-name>.127.0.0.1.nip.io/` with no port suffix, once the
+listener patch above is applied and no orphaned tunnel is interfering.
+
+Not yet scripted / open items: Apicurio Registry, OIDC/Keycloak variants,
+loading a locally-built (not published-registry) console/operator image
+into either cluster type, wiring up Playwright to consume
+`CONSOLE_CLUSTER_DOMAIN`/the printed Console URL automatically, and a
+watcher to auto-patch new Console CRs to an internal listener (see known
+issue above).

--- a/systemtests/cluster-setup/README.md
+++ b/systemtests/cluster-setup/README.md
@@ -1,41 +1,43 @@
-# Cluster setup (macOS-safe local Kubernetes for systemtests)
+# Cluster setup (local Kubernetes for systemtests)
 
 Provisions a local Kubernetes cluster for running the `console-operator`
-systemtests outside CI, on macOS where `systemtests/scripts/setup-minikube.sh`
-doesn't work reliably: Docker Desktop / Podman Desktop / Colima all run the
-container engine inside a hidden VM, so a minikube node's IP (used by CI's
-`$(minikube ip).nip.io`) isn't routable from the host.
+systemtests outside CI. Built primarily for macOS, where
+`systemtests/scripts/setup-minikube.sh` doesn't work (Docker Desktop /
+Podman Desktop / Colima all run the container engine inside a hidden VM, so
+a minikube node's IP — used by CI's `$(minikube ip).nip.io` — isn't
+reachable from the host), but the scripts themselves are OS-agnostic and
+work on Linux too.
 
-Two options, kept fully independent of each other (`kind/` doesn't touch or
-depend on `minikube/`'s scripts, or vice versa):
+**Container engine**: auto-detected — prefers `podman`, falls back to
+`docker` if podman isn't installed. Override explicitly with
+`CONTAINER_ENGINE=podman` or `CONTAINER_ENGINE=docker`. The podman-machine
+VM setup (`ensure_podman_machine` in `lib/env.sh`) only runs on macOS,
+where podman needs a VM to run containers at all — it's a no-op on native
+Linux, which doesn't need one.
 
-- **`kind/` — recommended.** Reliable, few moving parts, portless URLs out
-  of the box, no sudo ever needed.
-- **`minikube/`** — works too, but needs either a `:8443`-suffixed URL or an
-  extra sudo-gated step for portless access, and hit a real podman PID-limit
-  bug under a full Kafka-heavy stack (documented below, fixed, but a real
-  wrinkle kind never had).
+## Use kind
 
-**Recommendation: default to `kind/` for day-to-day work.** Minikube's only
-edge is closer parity with CI's tooling, which doesn't matter much for local
-dev/Playwright testing since `common/`'s scripts are pure kubectl/helm and
-don't care which cluster distro they're talking to (proven — see below).
-Keep `minikube/` around for when you specifically need it.
+**Default to `kind/`.** kind maps ports 80/443 straight to the host at
+cluster-creation time and binds ingress-nginx via `hostPort` on the node —
+so `https://<name>.127.0.0.1.nip.io/` just works, portlessly, with no sudo
+and no background process to manage.
 
-Full narrative — every dead end, root-caused with evidence (the Strimzi API
-version mismatch, the OLM `Route` CRD quirk, the SSL-passthrough crash, the
-loopback-collision bug, the finalizer race, the podman PID limit) — is in
-`~/claude-docs/streamshub-local-sts/README.md`.
+`minikube/` works too, but its `ingress` addon uses a `NodePort` Service
+instead, which isn't reliably reachable from macOS. That means either a
+`kubectl port-forward` (URLs need a `:8443` suffix) or a `minikube tunnel`
+that requires a one-time sudo prompt — more moving parts either way. Use
+`minikube/` only if you specifically need it (e.g. closer parity with CI's
+tooling); otherwise `kind/` is simpler and more reliable.
 
 ## Layout
 
 ```
 cluster-setup/
-  kind/                    # recommended: kind-based cluster
+  kind/                    # recommended
     create-cluster.sh      # create/reuse cluster + ingress-nginx, verify with a smoke test
     delete-cluster.sh      # teardown (full, or --keep-cluster)
     lib/env.sh             # shared config + podman-machine helpers
-  minikube/                # alternative: minikube-based cluster
+  minikube/                # alternative
     create-cluster.sh      # create/reuse cluster + ingress addon, verify with a smoke test
     delete-cluster.sh      # teardown (full, or --keep-cluster)
     enable-tunnel.sh       # switch to portless access (needs sudo once)
@@ -44,10 +46,6 @@ cluster-setup/
     setup-catalogsource.sh       # install OLM + a CatalogSource
     deploy-example-console.sh    # Strimzi + Kafka + Console operator + Console instance
 ```
-
-`common/` scripts have zero kind/minikube-specific logic (pure
-kubectl/helm/envsubst against whatever cluster context is currently active)
-— confirmed by running them unmodified against both cluster types.
 
 ## Quick start
 
@@ -59,8 +57,6 @@ source kind/.cluster-env
 ../common/setup-catalogsource.sh --image <catalog-image> [--namespace olm] [--name strimzi-source]
 ../common/deploy-example-console.sh --catalog-image <catalog-image>
 ```
-(run the `common/` scripts from inside `kind/`, or adjust the relative path —
-they just need to be invoked with a cluster context already active)
 
 Ends with a working, portless Console UI at
 `https://example-console.127.0.0.1.nip.io/`, backed by a real Kafka cluster.
@@ -71,314 +67,91 @@ Teardown: `./kind/delete-cluster.sh` (or `--keep-cluster`).
 
 ```sh
 ./minikube/create-cluster.sh
+./minikube/enable-tunnel.sh    # portless access — prompts for your sudo password once
 source minikube/.cluster-env
 ../common/setup-catalogsource.sh --image <catalog-image> [--namespace olm] [--name strimzi-source]
 ../common/deploy-example-console.sh --catalog-image <catalog-image>
 ```
 
-By default, access URLs need the port suffix printed by `create-cluster.sh`
-(e.g. `https://example-console.127.0.0.1.nip.io:8443/`). For portless URLs
-(e.g. OIDC/auth flows that assume no port in the redirect URI), run
-`./minikube/enable-tunnel.sh` instead (prompts for your sudo password once).
+`enable-tunnel.sh` is optional — skip it and URLs just need the port suffix
+`create-cluster.sh` prints instead (e.g.
+`https://example-console.127.0.0.1.nip.io:8443/`). Run it if you want
+portless URLs, e.g. to match kind's behavior or for OIDC/auth flows that
+assume no port in the redirect URI.
 
 Teardown: `./minikube/delete-cluster.sh` (or `--keep-cluster`).
 
 All scripts in both directories are idempotent — safe to re-run.
 
-## `kind/create-cluster.sh`
+## What each script does
 
-Creates (or reuses) a kind cluster with ports 80/443 mapped to the host at
-cluster-creation time (`extraPortMappings`), installs ingress-nginx bound
-via `hostPort` on the node, patches in `--enable-ssl-passthrough` (required
-once a Kafka cluster's TLS-terminating `secure` listener shows up —
-otherwise ingress-nginx's worker processes crash: `exited with fatal code 2
-and cannot be respawned`), then **verifies the whole exposure path with a
-smoke test** (deploys a throwaway echo-server behind an Ingress, curls it
-over HTTP/HTTPS, cleans up) before declaring the cluster ready. If the
-smoke test fails, the script exits non-zero rather than claiming success.
+### `kind/create-cluster.sh`
 
-Cluster domain is `127.0.0.1.nip.io` (public wildcard DNS), so any
-`<name>.127.0.0.1.nip.io` hostname resolves to `127.0.0.1` on this machine
-and reaches whatever ingress-nginx routes it to by Host header/SNI —
-Console, Kafka's TLS-passthrough listener, Apicurio, all through the same
-two exposed ports, portlessly, no sudo ever required.
+Creates (or reuses) a kind cluster with ports 80/443 mapped to the host,
+installs ingress-nginx bound via `hostPort`, and patches in
+`--enable-ssl-passthrough` (needed for Kafka's TLS-terminating `secure`
+listener). Finishes by deploying a throwaway echo-server behind an Ingress
+and curling it over HTTP/HTTPS to confirm the whole path actually works
+before declaring the cluster ready — if that check fails, the script exits
+non-zero instead of claiming success.
 
-Env vars (all optional, see `kind/lib/env.sh`):
+Env vars (all optional, see `kind/lib/env.sh`): `CONTAINER_ENGINE`
+(`podman`/`docker`), `CLUSTER_NAME`, `INGRESS_HTTP_PORT`/`INGRESS_HTTPS_PORT`,
+`CONSOLE_CLUSTER_DOMAIN`, `PODMAN_MACHINE_CPUS`/`PODMAN_MACHINE_MEMORY`
+(podman only, auto-sized from host resources on first-time machine init).
 
-- `CONTAINER_ENGINE` — `podman` (default) or `docker`
-- `CLUSTER_NAME` — default `console-local`
-- `INGRESS_HTTP_PORT` / `INGRESS_HTTPS_PORT` — default `80`/`443`
-- `CONSOLE_CLUSTER_DOMAIN` — default `127.0.0.1.nip.io`
-- `PODMAN_MACHINE_CPUS` / `PODMAN_MACHINE_MEMORY` (MB) — podman only;
-  default to (host CPUs − 1) / (host memory − 4GB headroom), auto-detected
-  via `sysctl`. **Only applied when a podman machine is created for the
-  first time** — if one already exists with different sizing, the script
-  warns and prints the manual resize command rather than restarting your
-  machine (a resize requires stop/start, which would kill anything already
-  running in it, including the cluster).
-
-## `minikube/create-cluster.sh`
+### `minikube/create-cluster.sh`
 
 Creates (or reuses) a minikube cluster with the `ingress` addon, patches in
-`--enable-ssl-passthrough` (same reason as kind), then exposes it and
-**verifies with the same smoke test pattern** before declaring success.
+`--enable-ssl-passthrough`, then exposes it via a persistent background
+`kubectl port-forward` on non-privileged local ports (default
+`8080`/`8443`, override via `LOCAL_HTTP_PORT`/`LOCAL_HTTPS_PORT`) and
+verifies it the same way as kind's script. If the port-forward process
+dies, just re-run `create-cluster.sh` — it detects the dead PID and
+restarts it. Same env vars as kind's script.
 
-Why not the same hostPort approach as kind? Confirmed empirically:
+### `minikube/enable-tunnel.sh`
 
-- minikube's `ingress` addon creates a **`NodePort`** Service, not
-  hostPort-bound like kind's. Direct NodePort access from macOS to the
-  minikube node IP (e.g. `curl 192.168.49.2:30674`) times out — reproduces
-  a long-standing upstream minikube/docker-driver-on-macOS issue, confirmed
-  on this actual machine, not just taken from GitHub issues on faith.
-- `minikube tunnel` **can** give portless (`127.0.0.1`) access, but only
-  after patching the Service to `LoadBalancer` (tunnel only manages
-  LoadBalancer services, not NodePort — patching alone does nothing:
-  without a running tunnel, the Service just reports `EXTERNAL-IP:
-  127.0.0.1` cosmetically while nothing is actually listening). Binding
-  ports 80/443 additionally needs an **interactive sudo password** —
-  minikube's own tunnel process prints "sudo permission will be asked for
-  it" for privileged ports.
+Switches minikube's exposure from the port-forward to `minikube tunnel` for
+portless access: stops the port-forward, patches `ingress-nginx-controller`
+to `LoadBalancer`, then runs the tunnel itself as a managed background
+process. The one thing it can't avoid is the sudo prompt needed to bind
+ports 80/443 — run it directly (not `sudo`-prefixed) and you'll be asked
+for your password exactly once, right there; everything else runs
+unattended.
 
-So by default, `create-cluster.sh` exposes ingress-nginx via a persistent
-background `kubectl port-forward` on non-privileged local ports (default
-`8080`/`8443`, override via `LOCAL_HTTP_PORT`/`LOCAL_HTTPS_PORT`) — no sudo
-needed, fully scriptable, but URLs need the port suffix. If the
-port-forward process dies (less durable than kind's container-level port
-mapping over long sessions), just re-run `create-cluster.sh` — it detects
-the dead PID and restarts it.
+### `kind/delete-cluster.sh` / `minikube/delete-cluster.sh [--keep-cluster]`
 
-Same `CONTAINER_ENGINE`/`PODMAN_MACHINE_CPUS`/`PODMAN_MACHINE_MEMORY` env
-vars and podman-machine auto-sizing as kind (duplicated in `lib/env.sh`,
-not shared, so `kind/` and `minikube/` stay fully independent).
+- Default: full delete (`kind delete cluster` / `minikube delete`).
+- `--keep-cluster`: removes just the deployed resources (Console, Kafka,
+  Console operator, Strimzi, OLM) but leaves the cluster + ingress-nginx
+  running, so a re-run of the `common/` scripts skips cluster creation and
+  image pulls. Requires `operator-sdk` to cleanly uninstall OLM in this
+  mode.
 
-### `minikube/enable-tunnel.sh` — portless access
+`minikube/delete-cluster.sh` also stops whichever exposure mechanism
+(port-forward or tunnel) is currently running.
 
-Switches from the port-forward to `minikube tunnel`: stops the
-port-forward, patches `ingress-nginx-controller` to `LoadBalancer`, then
-runs the tunnel itself as a background process it manages (PID tracked in
-`.tunnel.pid`, log in `.tunnel.log`) — not something you run in a separate
-terminal.
+### `common/setup-catalogsource.sh --image <image> [--namespace olm] [--name strimzi-source]`
 
-The one thing it can't avoid: binding ports 80/443 needs `sudo`. The script
-calls `sudo -v` right before starting the tunnel — **run it directly**
-(`./enable-tunnel.sh`, not `sudo ./enable-tunnel.sh`), and you'll be
-prompted for your password exactly once, right there. Everything after
-that (starting the tunnel, waiting for it to actually bind, confirming
-`EXTERNAL-IP` becomes `127.0.0.1`) runs unattended. Confirmed working.
+Installs OLM v0.45.0 if needed, then creates a `CatalogSource` pointed at
+`--image` and waits for it to report `READY`. Cluster-agnostic — works
+against whatever context is currently active.
 
-```sh
-./minikube/enable-tunnel.sh
-# prompts for sudo password once, then:
-# "Portless access ready: https://<name>.127.0.0.1.nip.io/"
-```
-
-To switch back to the port-forward approach: stop the tunnel
-(`sudo kill $(cat minikube/.tunnel.pid)`) and re-run `create-cluster.sh` —
-it detects no running tunnel and starts a fresh port-forward instead.
-`delete-cluster.sh` stops whichever of the two (port-forward or tunnel) is
-currently running automatically, including the `sudo -n kill` needed for a
-root-owned tunnel process.
-
-### Prerequisite for minikube: raise podman's PID limit (Kafka-heavy workloads)
-
-minikube's docker/podman driver runs the **entire K8s node** (kubelet,
-containerd, and every pod's processes) as a single podman container.
-podman's default per-container PID limit is **2048**, which a full
-Strimzi + multi-broker Kafka + Console + Prometheus stack can exhaust —
-hit this in testing: the Console pod failed to start with `runc create
-failed: ... fork/exec: resource temporarily unavailable` while
-`podman inspect <container> --format '{{.HostConfig.PidsLimit}}'` showed
-exactly `2048` and `podman stats` showed 2040 PIDs already in use. This
-looks like a networking/LoadBalancer problem at first glance (a pod not
-coming up) but isn't — check `podman inspect`/`podman stats` first if you
-hit unexplained container start failures on minikube.
-
-Fix (one-time, requires `sudo` inside the podman machine VM, so not
-automated by these scripts):
-
-```sh
-podman machine ssh -- 'sudo mkdir -p /etc/containers && printf "[containers]\npids_limit = 8192\n" | sudo tee /etc/containers/containers.conf'
-podman machine stop && podman machine start   # required — the running podman service caches config at boot
-```
-
-Two gotchas: editing `~/.config/containers/containers.conf` on the **macOS
-host** does nothing (the real container runtime is inside the VM); and the
-VM's default `/usr/share/containers/containers.conf` shouldn't be edited
-directly — create the override at `/etc/containers/containers.conf`
-instead. Verify with `podman inspect <minikube-container> --format
-'{{.HostConfig.PidsLimit}}'` after recreating the cluster. kind hasn't hit
-this (different container architecture per node), but there's no
-fundamental reason it couldn't under a big enough workload — keep it in
-mind either way.
-
-## `common/setup-catalogsource.sh --image <image> [--namespace olm] [--name strimzi-source]`
-
-Installs OLM v0.45.0 (same version/hash CI pins), then applies
-`install/operator/olm/010-CatalogSource-console-operator-catalog.yaml`
-patched with your `--name`/`--image`, and waits for it to report `READY`.
-
-The "already installed" check goes beyond just checking a CRD exists — it
-verifies `olm-operator`/`catalog-operator` are actually `Available`. A CRD
-(or the `olm` namespace) can be left behind by a previous install that got
-interrupted or crash-looped; skipping reinstall based on presence alone
-would leave a broken OLM that fails confusingly much later (Subscriptions
-never resolving, CatalogSources never reaching `READY`). If it detects a
-prior install exists but isn't healthy, it uninstalls first (upstream's
-`install.sh` refuses to touch an existing install, so a repair needs an
-uninstall+reinstall, not just a re-run) — via `operator-sdk olm uninstall`
-if available, otherwise it errors out with instructions (install
-`operator-sdk`, or run `delete-cluster.sh` for a fresh cluster).
-
-Tested this by deliberately breaking OLM (scaling `olm-operator` to 0
-replicas): detection correctly triggered repair, and when the repair itself
-timed out (a fully-dead `olm-operator` can't clear its own `CSV`
-finalizers, so even `operator-sdk olm uninstall` can get stuck) the script
-gave a clear "run delete-cluster.sh" message instead of falling through to
-upstream's confusing "OLM is already installed... Exiting" error.
-
-Note: the `--image` must be pullable by the cluster's containerd — a public
-registry image works out of the box; a locally-built image needs
-`kind load docker-image`/`kind load image-archive` (kind) or `minikube
-image load` (minikube) first (not yet scripted here).
-
-## `common/deploy-example-console.sh --catalog-image <image> [options]`
+### `common/deploy-example-console.sh --catalog-image <image> [options]`
 
 Deploys everything else in one shot: Strimzi (Helm), the Console operator
-(OperatorGroup + Subscription against the CatalogSource from
-`setup-catalogsource.sh`), a Kafka cluster, and a Console instance — using
-the project's own `examples/kafka/*.yaml` and
-`examples/console/010-Console-example.yaml` quickstart manifests (applied
-the same documented `envsubst` way the repo README describes), patched
-with a local-dev-only fix (see below).
+(via the CatalogSource from `setup-catalogsource.sh`), a Kafka cluster, and
+a Console instance — using the project's own `examples/kafka/*.yaml` and
+`examples/console/010-Console-example.yaml` quickstart manifests. Options:
 
-Options (all have sensible defaults):
 ```
 --catalog-image        (required)
 --catalog-namespace    default: olm
 --catalog-name         default: strimzi-source
 --channel              default: alpha
---operator-namespace   default: co-namespace   (Strimzi + Console operator)
---strimzi-version      default: 0.51.0         (must match your console-operator build — see below)
---kafka-namespace      default: kafka          (Kafka cluster + Console instance)
---listener             default: scramplain     (internal listener Console uses)
+--operator-namespace   default: co-namespace
+--strimzi-version      default: 0.51.0   (must match your console-operator build)
+--kafka-namespace      default: kafka
+--listener             default: scramplain
 ```
-
-**Version note:** Strimzi's version must match whatever console-operator
-build you're using — `0.51.0` is what `console-operator-catalog:0.12.0` was
-actually built against (confirmed by inspecting its bundled
-`io.strimzi.api-0.51.0.jar`). A newer Strimzi (e.g. `1.0.0`, which GA'd the
-Kafka `v1` CRD and dropped `v1beta2`) with an older console-operator build
-causes a silent "No such Kafka resource" failure even though the Kafka CR
-exists and is healthy — see the claude-docs writeup's "Layer 1" section.
-
-**Why it patches listeners:** the example manifests only define the
-`secure` (external, ingress+TLS) Kafka listener — correct for a real
-cluster with a real routable domain, but broken on this local nip.io setup:
-the Console **API pod runs inside the cluster**, and that listener's
-external hostname resolves to `127.0.0.1` from inside a pod too — which is
-the pod's own loopback, not the ingress controller. That produces
-`Connection refused` → Kafka admin client timeouts → the UI showing "Timed
-out waiting for backend service" for every data call. The script adds an
-internal `scramplain` listener (SCRAM-SHA-512, no TLS, in-cluster Service
-DNS) and points Console at it instead — a local-dev-only necessity, not a
-product bug (CI's `$(minikube ip)`-based `nip.io` doesn't hit this loopback
-collision).
-
-## `kind/delete-cluster.sh` / `minikube/delete-cluster.sh` `[--keep-cluster]`
-
-- Default: full delete (`kind delete cluster` / `minikube delete`) —
-  deletes everything in one shot.
-- `--keep-cluster`: removes just the deployed resources (Console/Kafka,
-  Console operator, Strimzi, OLM) but leaves the cluster + ingress-nginx
-  running, so a re-run of the `common/` scripts skips cluster creation and
-  ingress image pulls. Requires `operator-sdk` to cleanly uninstall OLM
-  (only for this mode — full teardown doesn't need it).
-
-  Deletes the Strimzi/Console custom resources (`Console`, `KafkaTopic`,
-  `KafkaUser`, `Kafka`, `KafkaNodePool`) *before* the namespace, because
-  deleting the namespace first can tear down the entity-operator pod before
-  it finishes clearing a `KafkaTopic`'s `strimzi.io/topic-operator`
-  finalizer — a real race hit during testing that leaves the namespace
-  stuck in `Terminating` forever. Falls back to force-clearing finalizers
-  if the namespace still doesn't terminate in time.
-
-  `minikube/delete-cluster.sh` also always stops the background
-  port-forward or tunnel first (the tunnel is root-owned via sudo, so a
-  plain `kill` can't touch it — tries `sudo -n kill` with cached
-  credentials, falls back to telling you to do it manually).
-
-## ⚠️ Known issue: the *real* systemtests always need the listener patch too
-
-`common/deploy-example-console.sh` patches its own example Console CR to
-use an internal listener (see above for why). **The real systemtests hit
-the exact same problem, every run** — their `ConsoleInstanceSetup.java`
-always creates the Console CR pointed at the external `secure` listener by
-default, and there's currently no env var to change that. Since the
-Console API pod runs inside the cluster, that produces the same
-`Connection refused` → Kafka admin client timeout → UI shows "Timed out
-waiting for backend service" for every data call, even though the UI
-itself loads fine (it's served statically; only the backend API calls that
-need Kafka fail).
-
-This is **not fixed by these scripts** — it has to be done manually, every
-time the real tests create a fresh Console instance (new hash-suffixed
-name each run):
-
-```sh
-kubectl -n <kafka-namespace> get kafka <kafka-name> -o jsonpath='{.status.listeners}'  # find the internal SCRAM listener name (e.g. scramplain)
-kubectl -n <kafka-namespace> patch console <console-name> --type='json' \
-  -p='[{"op": "replace", "path": "/spec/kafkaClusters/0/listener", "value": "<internal-listener-name>"}]'
-```
-
-Confirmed this is independent of the exposure mechanism — hit it and fixed
-it identically on both the port-forward and the tunnel/LoadBalancer paths.
-A watcher script that auto-patches any new Console CR as soon as it
-appears would remove the need to do this by hand; not written yet.
-
-## ⚠️ Known issue: orphaned `minikube tunnel` process across cluster recreations
-
-If `delete-cluster.sh` can't stop a running tunnel (no cached sudo
-credentials for the non-interactive `sudo -n kill`), it now **deliberately
-leaves `.tunnel.pid` in place** rather than silently dropping the only
-record of it (an earlier version of this script removed the file
-regardless — don't do that again if editing this). A root-owned tunnel
-process left running across a cluster delete+recreate cycle keeps holding
-ports 80/443 on the host while routing to a cluster that no longer
-exists, which:
-
-- blocks anything else (e.g. `kind/create-cluster.sh`) from binding those
-  same ports (`address already in use`)
-- can make a *freshly recreated* minikube cluster's Console instance look
-  broken from the browser/Playwright side, when the real cause is a stale
-  tunnel serving nothing useful — this happened once already and looked
-  exactly like a networking regression until traced back to `ps aux | grep
-  minikube tunnel` showing a process from hours earlier.
-
-If you ever see `create-cluster.sh` or `enable-tunnel.sh` behaving oddly
-right after a full teardown+recreate, check for stray tunnel processes
-first: `ps aux | grep "[m]inikube tunnel"`, then `sudo kill` any with a
-suspiciously old start time before re-running anything.
-
-## Status
-
-Full stack confirmed working end-to-end (2026-07-12), via scripts alone, on
-both cluster types: cluster → ingress → OLM → Strimzi → Console operator →
-Kafka → Console instance → UI reachable and functional (shows live Kafka
-nodes/topics, confirmed via clean `console-api` logs with no timeout
-errors). All scripts are idempotent, and all teardown paths (full,
-`--keep-cluster`, the finalizer-race fallback) are verified working on
-both.
-
-Minikube's `enable-tunnel.sh` portless path is **confirmed working** by the
-user in practice, including against a real systemtests run (Kafka +
-Console instance created by the actual test framework, not
-`deploy-example-console.sh`) — reachable at
-`https://<console-name>.127.0.0.1.nip.io/` with no port suffix, once the
-listener patch above is applied and no orphaned tunnel is interfering.
-
-Not yet scripted / open items: Apicurio Registry, OIDC/Keycloak variants,
-loading a locally-built (not published-registry) console/operator image
-into either cluster type, wiring up Playwright to consume
-`CONSOLE_CLUSTER_DOMAIN`/the printed Console URL automatically, and a
-watcher to auto-patch new Console CRs to an internal listener (see known
-issue above).

--- a/systemtests/cluster-setup/common/deploy-example-console.sh
+++ b/systemtests/cluster-setup/common/deploy-example-console.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Deploys Strimzi + a Kafka cluster + the Console operator + a Console
+# instance, using the project's own examples/kafka and examples/console
+# quickstart manifests. Everything is idempotent (safe to re-run).
+#
+# Cluster-agnostic — works against whatever cluster context is currently
+# active (kind, minikube, or anything else), since it's pure
+# kubectl/helm/envsubst.
+#
+# Requires a CatalogSource to already exist (see setup-catalogsource.sh).
+#
+# Usage:
+#   ./deploy-example-console.sh --catalog-image <image> [options]
+#
+# Options (all have defaults matching the real systemtests / repo examples):
+#   --catalog-image        (required) CatalogSource image, e.g.
+#                           quay.io/streamshub/console-operator-catalog:0.12.0
+#   --catalog-namespace    default: olm
+#   --catalog-name         default: strimzi-source
+#   --channel              default: alpha
+#   --operator-namespace   default: co-namespace  (Strimzi + Console operator)
+#   --strimzi-version      default: 0.51.0        (MUST match the console-operator
+#                           build behind --catalog-image — see
+#                           ~/claude-docs/streamshub-local-sts/README.md)
+#   --kafka-namespace      default: kafka         (Kafka cluster + Console instance)
+#   --listener             default: scramplain    (internal listener Console uses)
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+CATALOG_IMAGE=""
+CATALOG_NAMESPACE="olm"
+CATALOG_NAME="strimzi-source"
+CHANNEL="alpha"
+OPERATOR_NAMESPACE="co-namespace"
+STRIMZI_VERSION="0.51.0"
+KAFKA_NAMESPACE="kafka"
+KAFKA_NAME="console-kafka"
+CONSOLE_NAME="example"
+LISTENER="scramplain"
+CONSOLE_CLUSTER_DOMAIN="${CONSOLE_CLUSTER_DOMAIN:-127.0.0.1.nip.io}"
+
+usage() {
+  echo "Usage: $0 --catalog-image <image> [--catalog-namespace olm] [--catalog-name strimzi-source]" >&2
+  echo "          [--channel alpha] [--operator-namespace co-namespace] [--strimzi-version 0.51.0]" >&2
+  echo "          [--kafka-namespace kafka] [--listener scramplain]" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --catalog-image) CATALOG_IMAGE="$2"; shift 2 ;;
+    --catalog-namespace) CATALOG_NAMESPACE="$2"; shift 2 ;;
+    --catalog-name) CATALOG_NAME="$2"; shift 2 ;;
+    --channel) CHANNEL="$2"; shift 2 ;;
+    --operator-namespace) OPERATOR_NAMESPACE="$2"; shift 2 ;;
+    --strimzi-version) STRIMZI_VERSION="$2"; shift 2 ;;
+    --kafka-namespace) KAFKA_NAMESPACE="$2"; shift 2 ;;
+    --listener) LISTENER="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "${CATALOG_IMAGE}" ] || usage
+
+# --- 1. CatalogSource (OLM install if needed) ------------------------------
+./setup-catalogsource.sh --image "${CATALOG_IMAGE}" --namespace "${CATALOG_NAMESPACE}" --name "${CATALOG_NAME}"
+
+# --- 2. Strimzi via Helm ----------------------------------------------------
+kubectl create namespace "${OPERATOR_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+if helm status strimzi-cluster-operator -n "${OPERATOR_NAMESPACE}" >/dev/null 2>&1; then
+  echo "Strimzi already installed in '${OPERATOR_NAMESPACE}', skipping"
+else
+  echo "Installing Strimzi ${STRIMZI_VERSION} into '${OPERATOR_NAMESPACE}'..."
+  helm install strimzi-cluster-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+    --version "${STRIMZI_VERSION}" \
+    --namespace "${OPERATOR_NAMESPACE}" \
+    --set watchAnyNamespace=true \
+    --wait
+fi
+kubectl -n "${OPERATOR_NAMESPACE}" wait --for=condition=available deployment/strimzi-cluster-operator --timeout=180s
+
+# --- 3. Console operator: OperatorGroup + Subscription ----------------------
+cat <<EOF | kubectl apply -n "${OPERATOR_NAMESPACE}" -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: streamshub-operators
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: console-sub
+spec:
+  channel: ${CHANNEL}
+  installPlanApproval: Automatic
+  name: streamshub-console-operator
+  source: ${CATALOG_NAME}
+  sourceNamespace: ${CATALOG_NAMESPACE}
+EOF
+
+echo "Waiting for Subscription to resolve a CSV..."
+csv=""
+for i in $(seq 1 60); do
+  csv=$(kubectl -n "${OPERATOR_NAMESPACE}" get subscription console-sub -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+  [ -n "${csv}" ] && break
+  sleep 5
+done
+[ -n "${csv}" ] || { echo "Timed out waiting for Subscription to resolve a CSV" >&2; exit 1; }
+
+echo "Waiting for CSV '${csv}' to succeed..."
+phase=""
+for i in $(seq 1 60); do
+  phase=$(kubectl -n "${OPERATOR_NAMESPACE}" get csv "${csv}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  [ "${phase}" = "Succeeded" ] && break
+  if [ "${phase}" = "Failed" ]; then echo "CSV '${csv}' failed" >&2; exit 1; fi
+  sleep 5
+done
+[ "${phase}" = "Succeeded" ] || { echo "Timed out waiting for CSV '${csv}' (last phase: ${phase:-unknown})" >&2; exit 1; }
+echo "Console operator installed: ${csv}"
+
+# --- 4. Kafka cluster (examples/kafka/*.yaml + internal listener) ----------
+kubectl create namespace "${KAFKA_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+export CLUSTER_DOMAIN="${CONSOLE_CLUSTER_DOMAIN}"
+export NAMESPACE="${KAFKA_NAMESPACE}"
+export LISTENER_TYPE="ingress"
+
+echo "Applying examples/kafka/*.yaml (cluster domain: ${CLUSTER_DOMAIN})..."
+cat ../../../examples/kafka/*.yaml | envsubst | kubectl apply -n "${KAFKA_NAMESPACE}" -f -
+
+echo "Adding internal '${LISTENER}' listener for in-cluster consumers (e.g. Console)..."
+kubectl -n "${KAFKA_NAMESPACE}" patch kafka "${KAFKA_NAME}" --type=json \
+  -p="[{\"op\": \"add\", \"path\": \"/spec/kafka/listeners/-\", \"value\": {\"name\": \"${LISTENER}\", \"port\": 9095, \"type\": \"internal\", \"tls\": false, \"authentication\": {\"type\": \"scram-sha-512\"}}}]" \
+  2>/dev/null || echo "(listener already present, skipping)"
+
+echo "Waiting for Kafka '${KAFKA_NAME}' to become Ready (can take a few minutes)..."
+kubectl -n "${KAFKA_NAMESPACE}" wait --for=condition=Ready "kafka/${KAFKA_NAME}" --timeout=600s
+
+# --- 5. Console instance (examples/console/*.yaml, internal listener) ------
+export KAFKA_NAMESPACE
+
+echo "Applying examples/console/010-Console-example.yaml..."
+cat ../../../examples/console/010-Console-example.yaml | envsubst | kubectl apply -n "${KAFKA_NAMESPACE}" -f -
+
+echo "Pointing Console at the internal '${LISTENER}' listener (not the example's default 'secure')..."
+kubectl -n "${KAFKA_NAMESPACE}" patch console "${CONSOLE_NAME}" --type=json \
+  -p="[{\"op\": \"replace\", \"path\": \"/spec/kafkaClusters/0/listener\", \"value\": \"${LISTENER}\"}]"
+
+echo "Waiting for Console '${CONSOLE_NAME}' to become Ready (can take a minute or two)..."
+kubectl -n "${KAFKA_NAMESPACE}" wait --for=condition=Ready "console/${CONSOLE_NAME}" --timeout=300s
+
+echo ""
+echo "Done. Console ready: https://${CONSOLE_NAME}-console.${CONSOLE_CLUSTER_DOMAIN}"

--- a/systemtests/cluster-setup/common/setup-catalogsource.sh
+++ b/systemtests/cluster-setup/common/setup-catalogsource.sh
@@ -106,7 +106,14 @@ else
   echo "Installing OLM ${OLM_VERSION}..."
   curl --proto "=https" -o "${OLM_INSTALL_SCRIPT}" -sL \
     "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh"
-  ACTUAL_SHA256=$(shasum -a 256 "${OLM_INSTALL_SCRIPT}" | awk '{print $1}')
+  # Prefer sha256sum (GNU coreutils, native on Linux); fall back to shasum
+  # (macOS's default, not guaranteed present on every Linux distro). Both
+  # print "<hash>  <filename>", so the awk extraction is the same either way.
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(sha256sum "${OLM_INSTALL_SCRIPT}" | awk '{print $1}')
+  else
+    ACTUAL_SHA256=$(shasum -a 256 "${OLM_INSTALL_SCRIPT}" | awk '{print $1}')
+  fi
   [ "${ACTUAL_SHA256}" = "${OLM_SCRIPT_SHA256}" ] \
     || { echo "OLM install script hash verification failed (got ${ACTUAL_SHA256})" >&2; exit 1; }
   chmod +x "${OLM_INSTALL_SCRIPT}"

--- a/systemtests/cluster-setup/common/setup-catalogsource.sh
+++ b/systemtests/cluster-setup/common/setup-catalogsource.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Installs OLM (if not already present) and deploys the Console operator's
+# CatalogSource, so a Subscription created by the systemtests' OlmConfig.java
+# (or by hand) has something to resolve against.
+#
+# Mirrors the "Deploy OLM CatalogSource" step in
+# .github/workflows/systemtests.yml and the OLM install in
+# systemtests/scripts/setup-minikube.sh, parameterized for local use.
+#
+# Cluster-agnostic — works against whatever cluster context is currently
+# active (kind, minikube, or anything else), since it's pure kubectl/OLM.
+#
+# Usage:
+#   ./setup-catalogsource.sh --image <catalog-image> [--namespace olm] [--name console-source]
+#
+# If you go on to run the systemtests from IntelliJ against this catalog,
+# make sure to set (matching whatever --namespace/--name you used here):
+#   CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE=<namespace>
+#   CONSOLE_OLM_CATALOG_SOURCE_NAME=<name>
+#   CONSOLE_INSTALL_TYPE=olm
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+NAMESPACE="olm"
+CATALOG_NAME="console-source"
+IMAGE=""
+
+usage() {
+  echo "Usage: $0 --image <catalog-image> [--namespace <ns>] [--name <catalog-source-name>]" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --name) CATALOG_NAME="$2"; shift 2 ;;
+    --image) IMAGE="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "${IMAGE}" ] || usage
+
+OLM_VERSION="v0.45.0"
+OLM_SCRIPT_SHA256="1e8065cb503d2ee94ce82dd2591618022852f53a43df908b9f8c7d314cff3532"
+OLM_INSTALL_SCRIPT=$(mktemp)
+trap 'rm -f "${OLM_INSTALL_SCRIPT}"' EXIT
+
+# True if ANY trace of a prior OLM install exists — the "olm" namespace or
+# any of its CRDs. Checked broadly (not just one CRD) because a partial
+# install/uninstall can leave some CRDs/namespaces behind and others gone;
+# install.sh's own "already installed" guard looks at more than just
+# catalogsources, so our detection needs to be at least as broad or we'll
+# wrongly take the "fresh install" path into a state install.sh then
+# refuses to touch, producing a confusing "already installed" error.
+olm_present() {
+  kubectl get namespace olm >/dev/null 2>&1 && return 0
+  for crd in catalogsources clusterserviceversions installplans olmconfigs \
+             operatorconditions operatorgroups operators subscriptions; do
+    kubectl get crd "${crd}.operators.coreos.com" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+# Checks a prior install exists *and* OLM's own core deployments are
+# actually Available — not just present. Traces of a previous install can
+# exist from one that got interrupted or crash-looped, which would make a
+# presence-only check wrongly skip (re)installing, leaving a broken OLM
+# that fails confusingly much later (Subscriptions never resolving,
+# CatalogSources never READY).
+olm_healthy() {
+  olm_present || return 1
+  for deploy in olm-operator catalog-operator; do
+    kubectl -n olm get deployment "${deploy}" >/dev/null 2>&1 || return 1
+    [ "$(kubectl -n olm get deployment "${deploy}" -o jsonpath='{.status.availableReplicas}' 2>/dev/null)" = "1" ] || return 1
+  done
+  return 0
+}
+
+if olm_healthy; then
+  echo "OLM already installed and healthy, skipping"
+else
+  # The upstream install.sh refuses to touch OLM if it thinks it's already
+  # installed (its own "already installed" guard) — it can't repair a
+  # broken install, only create a fresh one. So if any trace of a prior
+  # install exists but the health check failed, uninstall first.
+  if olm_present; then
+    echo "OLM CRDs are present but core deployments aren't healthy — repairing..."
+    if command -v operator-sdk >/dev/null 2>&1; then
+      if ! operator-sdk olm uninstall; then
+        echo "Automatic OLM repair (uninstall) failed or timed out — likely because a" >&2
+        echo "broken olm-operator can't clean up its own finalizers (e.g. on CSVs)." >&2
+        echo "Run delete-cluster.sh (for whichever cluster you're using) to start over." >&2
+        exit 1
+      fi
+    else
+      echo "OLM appears broken (CRDs exist but olm-operator/catalog-operator aren't Available)" >&2
+      echo "and 'operator-sdk' isn't available to cleanly repair it." >&2
+      echo "Install it (e.g. 'brew install operator-sdk') and re-run, or run" >&2
+      echo "delete-cluster.sh (for whichever cluster you're using) to start over." >&2
+      exit 1
+    fi
+  fi
+
+  echo "Installing OLM ${OLM_VERSION}..."
+  curl --proto "=https" -o "${OLM_INSTALL_SCRIPT}" -sL \
+    "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh"
+  ACTUAL_SHA256=$(shasum -a 256 "${OLM_INSTALL_SCRIPT}" | awk '{print $1}')
+  [ "${ACTUAL_SHA256}" = "${OLM_SCRIPT_SHA256}" ] \
+    || { echo "OLM install script hash verification failed (got ${ACTUAL_SHA256})" >&2; exit 1; }
+  chmod +x "${OLM_INSTALL_SCRIPT}"
+  "${OLM_INSTALL_SCRIPT}" "${OLM_VERSION}"
+
+  echo "Waiting for OLM core deployments to become available..."
+  kubectl -n olm wait --for=condition=available deployment/olm-operator --timeout=180s
+  kubectl -n olm wait --for=condition=available deployment/catalog-operator --timeout=180s
+
+  olm_healthy || { echo "OLM install completed but health check still fails" >&2; exit 1; }
+fi
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Deploying CatalogSource '${CATALOG_NAME}' in namespace '${NAMESPACE}' (image=${IMAGE})..."
+yq ea ".metadata.name = \"${CATALOG_NAME}\" | .spec.image = \"${IMAGE}\"" \
+  ../../../install/operator/olm/010-CatalogSource-console-operator-catalog.yaml \
+  | kubectl apply -n "${NAMESPACE}" -f -
+
+echo "Waiting for CatalogSource to become READY..."
+kubectl wait "catalogsource/${CATALOG_NAME}" -n "${NAMESPACE}" \
+  --for=jsonpath='{.status.connectionState.lastObservedState}'=READY \
+  --timeout=180s
+
+echo ""
+echo "CatalogSource ready: ${CATALOG_NAME} (namespace: ${NAMESPACE}, image: ${IMAGE})"
+echo "For systemtests via IntelliJ, set:"
+echo "  CONSOLE_INSTALL_TYPE=olm"
+echo "  CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE=${NAMESPACE}"
+echo "  CONSOLE_OLM_CATALOG_SOURCE_NAME=${CATALOG_NAME}"

--- a/systemtests/cluster-setup/kind/.gitignore
+++ b/systemtests/cluster-setup/kind/.gitignore
@@ -1,0 +1,1 @@
+.cluster-env

--- a/systemtests/cluster-setup/kind/create-cluster.sh
+++ b/systemtests/cluster-setup/kind/create-cluster.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 source ./lib/env.sh
 
+check_linux_rootless_podman_ip_tables
+
 if [ "${CONTAINER_ENGINE}" = "podman" ]; then
   ensure_podman_machine
 fi

--- a/systemtests/cluster-setup/kind/create-cluster.sh
+++ b/systemtests/cluster-setup/kind/create-cluster.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Creates (or reuses) a local kind cluster with ports 80/443 mapped to the
+# host, installs ingress-nginx bound via hostPort on the node, and verifies
+# the whole exposure path actually works with a throwaway smoke test before
+# declaring success.
+#
+# This is the macOS-safe alternative to systemtests/scripts/setup-minikube.sh:
+# Docker Desktop / Podman Desktop / Colima all run the container engine
+# inside a VM, so a minikube node's IP (used by CI's `$(minikube ip).nip.io`)
+# isn't routable from the host. kind's extraPortMappings + ingress-nginx
+# hostPort sidesteps that by riding on the same host-port-forwarding Docker
+# Desktop/Podman machine already do reliably. See
+# ~/claude-docs/streamshub-local-sts/README.md for the full writeup and the
+# fallback strategy if this ever stops working on a given machine.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./lib/env.sh
+
+if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+  ensure_podman_machine
+fi
+
+KIND_CONFIG=$(mktemp)
+
+cat > "${KIND_CONFIG}" <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ${CLUSTER_NAME}
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: ${INGRESS_HTTP_PORT}
+        protocol: TCP
+      - containerPort: 443
+        hostPort: ${INGRESS_HTTPS_PORT}
+        protocol: TCP
+EOF
+
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  echo "kind cluster '${CLUSTER_NAME}' already exists, skipping create"
+else
+  echo "Creating kind cluster '${CLUSTER_NAME}' (engine=${CONTAINER_ENGINE}, ports ${INGRESS_HTTP_PORT}/${INGRESS_HTTPS_PORT})..."
+  kind create cluster --config "${KIND_CONFIG}"
+fi
+rm -f "${KIND_CONFIG}"
+
+kubectl config use-context "${KIND_CONTEXT}" >/dev/null
+kubectl wait --for=condition=Ready node --all --timeout=120s
+
+if kubectl get deployment -n ingress-nginx ingress-nginx-controller >/dev/null 2>&1; then
+  echo "ingress-nginx already installed, skipping"
+else
+  echo "Installing ingress-nginx (kind provider manifest)..."
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+fi
+
+echo "Waiting for ingress-nginx controller (first-time image pulls can take several minutes)..."
+kubectl -n ingress-nginx wait --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller --timeout=600s
+
+# Strimzi's TLS-terminating "secure" Kafka listener needs SSL passthrough on
+# the ingress controller (matches systemtests/scripts/setup-minikube.sh) —
+# without it, ingress-nginx's worker processes crash once a Kafka secure
+# listener Ingress shows up (nginx.conf becomes invalid: "worker process
+# exited with fatal code 2 and cannot be respawned").
+if [ "$(kubectl get deployment -n ingress-nginx ingress-nginx-controller -ojson | \
+        jq -r '.spec.template.spec.containers[0].args | index("--enable-ssl-passthrough")')" = "null" ]; then
+  echo "Enabling SSL passthrough on ingress-nginx (required for Kafka's secure listener)..."
+  kubectl patch deployment -n ingress-nginx ingress-nginx-controller \
+    --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
+  kubectl -n ingress-nginx rollout status deployment/ingress-nginx-controller --timeout=120s
+fi
+
+cat > "${CLUSTER_ENV_FILE}" <<EOF
+export CONSOLE_CLUSTER_DOMAIN=${CONSOLE_CLUSTER_DOMAIN}
+export KUBECONTEXT=${KIND_CONTEXT}
+EOF
+
+# --- Verify the exposure path actually works end to end --------------------
+# Deploys a throwaway echo server behind an Ingress, curls it over HTTP and
+# HTTPS, then cleans up. If this fails, the cluster isn't actually usable
+# yet — don't declare success.
+echo ""
+echo "Verifying exposure path with a smoke test..."
+SMOKE_NAMESPACE="default"
+SMOKE_HOST="echo.${CONSOLE_CLUSTER_DOMAIN}"
+SMOKE_MANIFEST=$(mktemp)
+cleanup_smoke_test() {
+  kubectl delete -f "${SMOKE_MANIFEST}" --ignore-not-found >/dev/null 2>&1 || true
+  rm -f "${SMOKE_MANIFEST}"
+}
+trap cleanup_smoke_test EXIT
+
+cat > "${SMOKE_MANIFEST}" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-setup-smoke-test
+  namespace: ${SMOKE_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: cluster-setup-smoke-test}
+  template:
+    metadata:
+      labels: {app: cluster-setup-smoke-test}
+    spec:
+      containers:
+        - name: echo-server
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          args: ["netexec", "--http-port=8080"]
+          ports: [{containerPort: 8080}]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-setup-smoke-test
+  namespace: ${SMOKE_NAMESPACE}
+spec:
+  selector: {app: cluster-setup-smoke-test}
+  ports: [{port: 80, targetPort: 8080}]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cluster-setup-smoke-test
+  namespace: ${SMOKE_NAMESPACE}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ${SMOKE_HOST}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cluster-setup-smoke-test
+                port: {number: 80}
+EOF
+
+# ingress-nginx reloads its config asynchronously, so a freshly-created
+# Ingress can 404/503/refuse connections for up to ~30s before routing works.
+wait_for_http() {
+  local url="$1"
+  local curl_opts="$2"
+  local attempt
+  for attempt in $(seq 1 30); do
+    if curl -fsS ${curl_opts} --max-time 5 "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for ${url} to become reachable" >&2
+  return 1
+}
+
+kubectl apply -f "${SMOKE_MANIFEST}"
+kubectl wait --for=condition=ready pod -l app=cluster-setup-smoke-test --timeout=180s -n "${SMOKE_NAMESPACE}"
+
+echo "Checking http://${SMOKE_HOST}/ (ingress-nginx reload can take up to ~30s)..."
+wait_for_http "http://${SMOKE_HOST}/" ""
+echo "Checking https://${SMOKE_HOST}/ ..."
+wait_for_http "https://${SMOKE_HOST}/" "-k"
+echo "Smoke test passed: macOS -> ${CONTAINER_ENGINE} VM -> kind node -> ingress-nginx -> pod is working."
+
+cleanup_smoke_test
+trap - EXIT
+
+echo ""
+echo "Cluster ready. To use it in this shell:"
+echo "  source ${CLUSTER_ENV_FILE}"
+echo ""
+echo "CONSOLE_CLUSTER_DOMAIN=${CONSOLE_CLUSTER_DOMAIN}"
+echo "kubectl context: ${KIND_CONTEXT}"
+if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+  echo "podman machine sizing: PODMAN_MACHINE_CPUS=${PODMAN_MACHINE_CPUS} PODMAN_MACHINE_MEMORY=${PODMAN_MACHINE_MEMORY}MB (only applied on first-time machine init)"
+fi

--- a/systemtests/cluster-setup/kind/create-cluster.sh
+++ b/systemtests/cluster-setup/kind/create-cluster.sh
@@ -165,7 +165,22 @@ wait_for_http() {
   return 1
 }
 
-kubectl apply -f "${SMOKE_MANIFEST}"
+# The SSL-passthrough patch above replaces the ingress-nginx-controller pod
+# (hostPorts 80/443 can't coexist on one node, so it's a full kill-then-
+# recreate, not a smooth rolling update). `kubectl rollout status` only
+# confirms the new pod passed its /healthz readiness probe — it says
+# nothing about kube-proxy having programmed the new pod's IP into the
+# ingress-nginx-controller-admission Service's dataplane yet. Applying this
+# Ingress (which goes through that validating webhook) can land in that gap
+# and get "connection refused". Retry instead of guessing a fixed delay —
+# the apply is idempotent.
+for attempt in $(seq 1 15); do
+  if kubectl apply -f "${SMOKE_MANIFEST}"; then
+    break
+  fi
+  [ "${attempt}" -eq 15 ] && { echo "Failed to apply smoke test manifest after retries" >&2; exit 1; }
+  sleep 2
+done
 kubectl wait --for=condition=ready pod -l app=cluster-setup-smoke-test --timeout=180s -n "${SMOKE_NAMESPACE}"
 
 echo "Checking http://${SMOKE_HOST}:${INGRESS_HTTP_PORT}/ (ingress-nginx reload can take up to ~30s)..."

--- a/systemtests/cluster-setup/kind/create-cluster.sh
+++ b/systemtests/cluster-setup/kind/create-cluster.sh
@@ -166,10 +166,10 @@ wait_for_http() {
 kubectl apply -f "${SMOKE_MANIFEST}"
 kubectl wait --for=condition=ready pod -l app=cluster-setup-smoke-test --timeout=180s -n "${SMOKE_NAMESPACE}"
 
-echo "Checking http://${SMOKE_HOST}/ (ingress-nginx reload can take up to ~30s)..."
-wait_for_http "http://${SMOKE_HOST}/" ""
-echo "Checking https://${SMOKE_HOST}/ ..."
-wait_for_http "https://${SMOKE_HOST}/" "-k"
+echo "Checking http://${SMOKE_HOST}:${INGRESS_HTTP_PORT}/ (ingress-nginx reload can take up to ~30s)..."
+wait_for_http "http://${SMOKE_HOST}:${INGRESS_HTTP_PORT}/" ""
+echo "Checking https://${SMOKE_HOST}:${INGRESS_HTTPS_PORT}/ ..."
+wait_for_http "https://${SMOKE_HOST}:${INGRESS_HTTPS_PORT}/" "-k"
 echo "Smoke test passed: macOS -> ${CONTAINER_ENGINE} VM -> kind node -> ingress-nginx -> pod is working."
 
 cleanup_smoke_test

--- a/systemtests/cluster-setup/kind/delete-cluster.sh
+++ b/systemtests/cluster-setup/kind/delete-cluster.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tears down the local setup. Default: deletes the entire kind cluster
+# (fastest, cleanest full reset — matches how the environment has been reset
+# between test runs so far). Pass --keep-cluster to instead remove just the
+# deployed resources (Kafka, Console, Console operator, Strimzi, OLM) while
+# leaving the kind cluster + ingress-nginx running, so a subsequent
+# common/ script run skips cluster creation and ingress image pulls.
+#
+# Usage:
+#   ./delete-cluster.sh                    # delete the whole cluster
+#   ./delete-cluster.sh --keep-cluster      # remove deployed resources only
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./lib/env.sh
+
+KEEP_CLUSTER=false
+KAFKA_NAMESPACE="kafka"
+OPERATOR_NAMESPACE="co-namespace"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep-cluster) KEEP_CLUSTER=true; shift ;;
+    --kafka-namespace) KAFKA_NAMESPACE="$2"; shift 2 ;;
+    --operator-namespace) OPERATOR_NAMESPACE="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 [--keep-cluster] [--kafka-namespace kafka] [--operator-namespace co-namespace]" >&2
+      exit 1
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ "${KEEP_CLUSTER}" = false ]; then
+  echo "Deleting kind cluster '${CLUSTER_NAME}' (full teardown)..."
+  kind delete cluster --name "${CLUSTER_NAME}"
+  rm -f "${CLUSTER_ENV_FILE}"
+  echo "Done."
+  exit 0
+fi
+
+echo "Partial teardown: removing deployed resources, keeping cluster + ingress-nginx..."
+
+# Delete Strimzi/Console custom resources *before* the namespace: if the
+# namespace delete tears down the entity-operator pod before it finishes
+# clearing a KafkaTopic's `strimzi.io/topic-operator` finalizer, the
+# namespace gets stuck in Terminating forever (hit this in testing).
+# Deleting the CRs first, while their operator is still running, avoids the
+# race.
+echo "Deleting Kafka/Console custom resources in '${KAFKA_NAMESPACE}' (avoids a finalizer race with namespace deletion)..."
+kubectl delete console,kafkatopic,kafkauser,kafka,kafkanodepool -n "${KAFKA_NAMESPACE}" --all --ignore-not-found --timeout=120s || true
+
+echo "Deleting namespace '${KAFKA_NAMESPACE}' (Kafka + Console instance)..."
+kubectl delete namespace "${KAFKA_NAMESPACE}" --ignore-not-found --timeout=120s || {
+  echo "Namespace '${KAFKA_NAMESPACE}' didn't terminate in time — clearing any stuck finalizers and retrying..." >&2
+  for r in $(kubectl get kafkatopic,kafkauser,kafka -n "${KAFKA_NAMESPACE}" -o name 2>/dev/null); do
+    kubectl patch "${r}" -n "${KAFKA_NAMESPACE}" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+  done
+  kubectl delete namespace "${KAFKA_NAMESPACE}" --ignore-not-found
+}
+
+echo "Deleting namespace '${OPERATOR_NAMESPACE}' (Strimzi + Console operator + Subscription)..."
+kubectl delete namespace "${OPERATOR_NAMESPACE}" --ignore-not-found
+
+if kubectl get crd catalogsources.operators.coreos.com >/dev/null 2>&1; then
+  if command -v operator-sdk >/dev/null 2>&1; then
+    echo "Uninstalling OLM via operator-sdk..."
+    operator-sdk olm uninstall
+  else
+    echo "OLM is installed but 'operator-sdk' isn't available to cleanly uninstall it." >&2
+    echo "Install it (e.g. 'brew install operator-sdk') and re-run with --keep-cluster," >&2
+    echo "or run without --keep-cluster to delete the whole cluster instead." >&2
+    exit 1
+  fi
+fi
+
+echo ""
+echo "Partial teardown complete. Cluster '${CLUSTER_NAME}' and ingress-nginx are still running."

--- a/systemtests/cluster-setup/kind/lib/env.sh
+++ b/systemtests/cluster-setup/kind/lib/env.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Shared config for kind/*.sh. Source, don't execute.
+
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+CLUSTER_NAME="${CLUSTER_NAME:-console-local}"
+INGRESS_HTTP_PORT="${INGRESS_HTTP_PORT:-80}"
+INGRESS_HTTPS_PORT="${INGRESS_HTTPS_PORT:-443}"
+CONSOLE_CLUSTER_DOMAIN="${CONSOLE_CLUSTER_DOMAIN:-127.0.0.1.nip.io}"
+
+case "${CONTAINER_ENGINE}" in
+  podman) export KIND_EXPERIMENTAL_PROVIDER=podman ;;
+  docker) unset KIND_EXPERIMENTAL_PROVIDER ;;
+  *)
+    echo "Unsupported CONTAINER_ENGINE=${CONTAINER_ENGINE} (expected 'podman' or 'docker')" >&2
+    exit 1
+    ;;
+esac
+
+KIND_CONTEXT="kind-${CLUSTER_NAME}"
+CLUSTER_ENV_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.cluster-env"
+
+# Podman machine sizing (only relevant when CONTAINER_ENGINE=podman). Defaults
+# to (host CPUs - 1) and (host memory - 4GB headroom) so macOS itself isn't
+# starved; override with PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY (MB).
+detect_default_cpus() {
+  local total
+  total=$(sysctl -n hw.ncpu)
+  if [ "${total}" -gt 1 ]; then
+    echo $(( total - 1 ))
+  else
+    echo "${total}"
+  fi
+}
+
+detect_default_memory_mb() {
+  local total_mb headroom_mb=4096
+  total_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+  if [ "${total_mb}" -gt "${headroom_mb}" ]; then
+    echo $(( total_mb - headroom_mb ))
+  else
+    echo "${total_mb}"
+  fi
+}
+
+PODMAN_MACHINE_CPUS="${PODMAN_MACHINE_CPUS:-$(detect_default_cpus)}"
+PODMAN_MACHINE_MEMORY="${PODMAN_MACHINE_MEMORY:-$(detect_default_memory_mb)}"
+
+# Ensures a podman machine exists and is running. Only sizes it (via
+# PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY) on first-time init — an existing
+# machine is never resized automatically, since that requires stopping it
+# (killing anything running inside, including the kind cluster).
+ensure_podman_machine() {
+  local name state cpus mem
+
+  name=$(podman machine list --format json | jq -r '.[0].Name // empty')
+
+  if [ -z "${name}" ]; then
+    echo "No podman machine found — initializing 'podman-machine-default' with ${PODMAN_MACHINE_CPUS} CPUs / ${PODMAN_MACHINE_MEMORY}MB memory..."
+    podman machine init --rootful --cpus "${PODMAN_MACHINE_CPUS}" --memory "${PODMAN_MACHINE_MEMORY}"
+    podman machine start
+    return
+  fi
+
+  state=$(podman machine inspect "${name}" | jq -r '.[0].State')
+  if [ "${state}" != "running" ]; then
+    echo "Starting existing podman machine '${name}'..."
+    podman machine start "${name}"
+  fi
+
+  cpus=$(podman machine inspect "${name}" | jq -r '.[0].Resources.CPUs')
+  mem=$(podman machine inspect "${name}" | jq -r '.[0].Resources.Memory')
+  if [ "${cpus}" != "${PODMAN_MACHINE_CPUS}" ] || [ "${mem}" != "${PODMAN_MACHINE_MEMORY}" ]; then
+    echo "Note: podman machine '${name}' is already sized at ${cpus} CPUs / ${mem}MB memory (requested ${PODMAN_MACHINE_CPUS}/${PODMAN_MACHINE_MEMORY}MB). Not resizing an existing machine automatically." >&2
+    echo "  To resize: podman machine stop ${name} && podman machine set --cpus ${PODMAN_MACHINE_CPUS} --memory ${PODMAN_MACHINE_MEMORY} ${name} && podman machine start ${name}" >&2
+  fi
+}

--- a/systemtests/cluster-setup/kind/lib/env.sh
+++ b/systemtests/cluster-setup/kind/lib/env.sh
@@ -3,17 +3,18 @@
 
 OS_NAME="$(uname -s)"
 
-# Auto-detect the container engine if not explicitly set: prefer podman,
-# fall back to docker, so this works out of the box on machines that only
-# have one of the two installed (common on Linux, where docker is often
-# the default with no podman in sight).
+# Auto-detect the container engine if not explicitly set: prefer docker,
+# fall back to podman. kind only ever supports these two, and docker has
+# been the more reliable of the two in practice (podman has repeatedly
+# needed workarounds: the ip_tables kernel module requirement on Linux,
+# and PID-limit crashes under a full Kafka+Console workload).
 if [ -z "${CONTAINER_ENGINE:-}" ]; then
-  if command -v podman >/dev/null 2>&1; then
-    CONTAINER_ENGINE="podman"
-  elif command -v docker >/dev/null 2>&1; then
+  if command -v docker >/dev/null 2>&1; then
     CONTAINER_ENGINE="docker"
+  elif command -v podman >/dev/null 2>&1; then
+    CONTAINER_ENGINE="podman"
   else
-    echo "Neither podman nor docker found in PATH. Install one, or set CONTAINER_ENGINE explicitly." >&2
+    echo "Neither docker nor podman found in PATH. Install one, or set CONTAINER_ENGINE explicitly." >&2
     exit 1
   fi
 fi
@@ -106,5 +107,33 @@ ensure_podman_machine() {
   if [ "${cpus}" != "${PODMAN_MACHINE_CPUS}" ] || [ "${mem}" != "${PODMAN_MACHINE_MEMORY}" ]; then
     echo "Note: podman machine '${name}' is already sized at ${cpus} CPUs / ${mem}MB memory (requested ${PODMAN_MACHINE_CPUS}/${PODMAN_MACHINE_MEMORY}MB). Not resizing an existing machine automatically." >&2
     echo "  To resize: podman machine stop ${name} && podman machine set --cpus ${PODMAN_MACHINE_CPUS} --memory ${PODMAN_MACHINE_MEMORY} ${name} && podman machine start ${name}" >&2
+  fi
+}
+
+# On native Linux with rootless podman, kube-proxy/ingress-nginx need the
+# host's ip_tables kernel module loaded — rootless containers can't load
+# kernel modules themselves (no CAP_SYS_MODULE), so a missing module
+# surfaces confusingly later as ingress-nginx/kube-proxy failing, not as an
+# obvious "module missing" error. Check up front and fail fast instead.
+# No-op on macOS (podman machine VM, handled by ensure_podman_machine) and
+# on rootful podman/docker (which don't hit this).
+check_linux_rootless_podman_ip_tables() {
+  if [ "${OS_NAME}" != "Linux" ] || [ "${CONTAINER_ENGINE}" != "podman" ]; then
+    return 0
+  fi
+
+  if [ "$(podman info --format json | jq -r .host.security.rootless)" != "true" ]; then
+    return 0
+  fi
+
+  if [ -z "$(lsmod | grep ^ip_tables)" ]; then
+    echo "podman is running rootless on Linux, but the 'ip_tables' kernel module isn't loaded." >&2
+    echo "Rootless containers can't load kernel modules themselves (no CAP_SYS_MODULE), and" >&2
+    echo "kube-proxy/ingress-nginx need it on the host - without it, ingress setup fails." >&2
+    echo "" >&2
+    echo "Fix:" >&2
+    echo "  sudo modprobe ip_tables" >&2
+    echo "  echo ip_tables | sudo tee /etc/modules-load.d/ip_tables.conf   # persist across reboots" >&2
+    exit 1
   fi
 }

--- a/systemtests/cluster-setup/kind/lib/env.sh
+++ b/systemtests/cluster-setup/kind/lib/env.sh
@@ -1,7 +1,23 @@
 #!/usr/bin/env bash
 # Shared config for kind/*.sh. Source, don't execute.
 
-CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+OS_NAME="$(uname -s)"
+
+# Auto-detect the container engine if not explicitly set: prefer podman,
+# fall back to docker, so this works out of the box on machines that only
+# have one of the two installed (common on Linux, where docker is often
+# the default with no podman in sight).
+if [ -z "${CONTAINER_ENGINE:-}" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    CONTAINER_ENGINE="podman"
+  elif command -v docker >/dev/null 2>&1; then
+    CONTAINER_ENGINE="docker"
+  else
+    echo "Neither podman nor docker found in PATH. Install one, or set CONTAINER_ENGINE explicitly." >&2
+    exit 1
+  fi
+fi
+
 CLUSTER_NAME="${CLUSTER_NAME:-console-local}"
 INGRESS_HTTP_PORT="${INGRESS_HTTP_PORT:-80}"
 INGRESS_HTTPS_PORT="${INGRESS_HTTPS_PORT:-443}"
@@ -19,12 +35,19 @@ esac
 KIND_CONTEXT="kind-${CLUSTER_NAME}"
 CLUSTER_ENV_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.cluster-env"
 
-# Podman machine sizing (only relevant when CONTAINER_ENGINE=podman). Defaults
-# to (host CPUs - 1) and (host memory - 4GB headroom) so macOS itself isn't
+# Podman machine sizing (only relevant on macOS, where podman needs a VM to
+# run containers at all — native Linux podman doesn't). Defaults to (host
+# CPUs - 1) and (host memory - 4GB headroom) so the host itself isn't
 # starved; override with PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY (MB).
+# Portable: prefers Linux-native tools (nproc, /proc/meminfo), falls back
+# to macOS's sysctl.
 detect_default_cpus() {
   local total
-  total=$(sysctl -n hw.ncpu)
+  if command -v nproc >/dev/null 2>&1; then
+    total=$(nproc)
+  else
+    total=$(sysctl -n hw.ncpu)
+  fi
   if [ "${total}" -gt 1 ]; then
     echo $(( total - 1 ))
   else
@@ -34,7 +57,11 @@ detect_default_cpus() {
 
 detect_default_memory_mb() {
   local total_mb headroom_mb=4096
-  total_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+  if [ -r /proc/meminfo ]; then
+    total_mb=$(( $(awk '/^MemTotal:/ {print $2}' /proc/meminfo) / 1024 ))
+  else
+    total_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+  fi
   if [ "${total_mb}" -gt "${headroom_mb}" ]; then
     echo $(( total_mb - headroom_mb ))
   else
@@ -45,11 +72,18 @@ detect_default_memory_mb() {
 PODMAN_MACHINE_CPUS="${PODMAN_MACHINE_CPUS:-$(detect_default_cpus)}"
 PODMAN_MACHINE_MEMORY="${PODMAN_MACHINE_MEMORY:-$(detect_default_memory_mb)}"
 
-# Ensures a podman machine exists and is running. Only sizes it (via
-# PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY) on first-time init — an existing
-# machine is never resized automatically, since that requires stopping it
-# (killing anything running inside, including the kind cluster).
+# Ensures a podman machine exists and is running — but only on macOS.
+# Native Linux podman talks to the local system directly; there's no VM to
+# create or manage, so this is a no-op there regardless of CONTAINER_ENGINE.
+# Only sizes the machine (via PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY) on
+# first-time init — an existing machine is never resized automatically,
+# since that requires stopping it (killing anything running inside,
+# including the kind cluster).
 ensure_podman_machine() {
+  if [ "${OS_NAME}" != "Darwin" ]; then
+    return 0
+  fi
+
   local name state cpus mem
 
   name=$(podman machine list --format json | jq -r '.[0].Name // empty')

--- a/systemtests/cluster-setup/minikube/.gitignore
+++ b/systemtests/cluster-setup/minikube/.gitignore
@@ -1,0 +1,5 @@
+.cluster-env
+.port-forward.pid
+.port-forward.log
+.tunnel.pid
+.tunnel.log

--- a/systemtests/cluster-setup/minikube/create-cluster.sh
+++ b/systemtests/cluster-setup/minikube/create-cluster.sh
@@ -25,6 +25,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 source ./lib/env.sh
 
+check_linux_rootless_podman_ip_tables
+
 if [ "${CONTAINER_ENGINE}" = "podman" ]; then
   ensure_podman_machine
 fi

--- a/systemtests/cluster-setup/minikube/create-cluster.sh
+++ b/systemtests/cluster-setup/minikube/create-cluster.sh
@@ -163,7 +163,20 @@ wait_for_http() {
   return 1
 }
 
-kubectl apply -f "${SMOKE_MANIFEST}"
+# The SSL-passthrough patch above replaces the ingress-nginx-controller pod.
+# `kubectl rollout status` only confirms the new pod passed its /healthz
+# readiness probe — it says nothing about kube-proxy having programmed the
+# new pod's IP into the ingress-nginx-controller-admission Service's
+# dataplane yet. Applying this Ingress (which goes through that validating
+# webhook) can land in that gap and get "connection refused". Retry instead
+# of guessing a fixed delay — the apply is idempotent.
+for attempt in $(seq 1 15); do
+  if kubectl apply -f "${SMOKE_MANIFEST}"; then
+    break
+  fi
+  [ "${attempt}" -eq 15 ] && { echo "Failed to apply smoke test manifest after retries" >&2; exit 1; }
+  sleep 2
+done
 kubectl wait --for=condition=ready pod -l app=cluster-setup-smoke-test --timeout=180s -n "${SMOKE_NAMESPACE}"
 
 echo "Checking http://${SMOKE_HOST}:${SMOKE_HTTP_PORT}/ (ingress-nginx reload can take up to ~30s)..."

--- a/systemtests/cluster-setup/minikube/create-cluster.sh
+++ b/systemtests/cluster-setup/minikube/create-cluster.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Creates (or reuses) a local minikube cluster with the ingress addon,
+# exposes ingress-nginx to the host via a persistent `kubectl port-forward`
+# on non-privileged local ports (default 8080/8443, no sudo needed) unless
+# a tunnel (see enable-tunnel.sh) is already active, and verifies the whole
+# exposure path actually works with a throwaway smoke test before declaring
+# success.
+#
+# Why not the same approach as ../kind/ ? Confirmed empirically on this
+# machine:
+#   - minikube's ingress addon uses a NodePort Service, not hostPort
+#     binding like kind's ingress-nginx does. Direct NodePort access from
+#     macOS to the minikube node IP (e.g. curl 192.168.49.2:30674) times
+#     out — matches long-standing upstream minikube/docker-driver-on-macOS
+#     issues, reproduced here, not just a theoretical concern.
+#   - `minikube tunnel` CAN make ingress-nginx reachable portlessly at
+#     127.0.0.1 (patch the Service to type LoadBalancer first — tunnel only
+#     manages LoadBalancer services, not NodePort), but binding ports <1024
+#     requires sudo. See enable-tunnel.sh for that path if you need
+#     portless URLs (e.g. for OIDC/auth redirect flows).
+#
+# See ~/claude-docs/streamshub-local-sts/README.md for the full
+# investigation and the original decision to build ../kind/ first.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./lib/env.sh
+
+if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+  ensure_podman_machine
+fi
+
+if minikube status -p "${MINIKUBE_PROFILE}" >/dev/null 2>&1; then
+  echo "minikube profile '${MINIKUBE_PROFILE}' already running, skipping create"
+else
+  echo "Creating minikube cluster '${MINIKUBE_PROFILE}' (driver=${CONTAINER_ENGINE})..."
+  minikube start -p "${MINIKUBE_PROFILE}" \
+    --driver="${CONTAINER_ENGINE}" \
+    --addons=ingress
+fi
+
+kubectl config use-context "${MINIKUBE_PROFILE}" >/dev/null
+
+echo "Waiting for ingress-nginx controller (first-time image pulls can take several minutes)..."
+kubectl -n ingress-nginx wait --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller --timeout=600s
+
+if [ "$(kubectl get deployment -n ingress-nginx ingress-nginx-controller -ojson | \
+        jq -r '.spec.template.spec.containers[0].args | index("--enable-ssl-passthrough")')" = "null" ]; then
+  echo "Enabling SSL passthrough on ingress-nginx (required for Kafka's secure listener)..."
+  kubectl patch deployment -n ingress-nginx ingress-nginx-controller \
+    --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
+  kubectl -n ingress-nginx rollout status deployment/ingress-nginx-controller --timeout=120s
+fi
+
+TUNNEL_ACTIVE=false
+if [ -f "${TUNNEL_PID_FILE}" ] && kill -0 "$(cat "${TUNNEL_PID_FILE}")" 2>/dev/null; then
+  echo "minikube tunnel is already running (pid $(cat "${TUNNEL_PID_FILE}")) — skipping port-forward, portless access is active"
+  TUNNEL_ACTIVE=true
+elif [ -f "${PORT_FORWARD_PID_FILE}" ] && kill -0 "$(cat "${PORT_FORWARD_PID_FILE}")" 2>/dev/null; then
+  echo "Port-forward already running (pid $(cat "${PORT_FORWARD_PID_FILE}"))"
+else
+  echo "Starting background port-forward: localhost:${LOCAL_HTTP_PORT}/${LOCAL_HTTPS_PORT} -> ingress-nginx-controller..."
+  nohup kubectl --context "${MINIKUBE_PROFILE}" port-forward -n ingress-nginx svc/ingress-nginx-controller \
+    "${LOCAL_HTTP_PORT}:80" "${LOCAL_HTTPS_PORT}:443" \
+    > "${PORT_FORWARD_LOG_FILE}" 2>&1 &
+  echo $! > "${PORT_FORWARD_PID_FILE}"
+  sleep 3
+  kill -0 "$(cat "${PORT_FORWARD_PID_FILE}")" 2>/dev/null \
+    || { echo "port-forward failed to start, check ${PORT_FORWARD_LOG_FILE}" >&2; exit 1; }
+fi
+
+cat > "${CLUSTER_ENV_FILE}" <<EOF
+export CONSOLE_CLUSTER_DOMAIN=${CONSOLE_CLUSTER_DOMAIN}
+export KUBECONTEXT=${MINIKUBE_PROFILE}
+export LOCAL_HTTP_PORT=${LOCAL_HTTP_PORT}
+export LOCAL_HTTPS_PORT=${LOCAL_HTTPS_PORT}
+EOF
+
+if [ "${TUNNEL_ACTIVE}" = true ]; then
+  SMOKE_HTTP_PORT=80
+  SMOKE_HTTPS_PORT=443
+else
+  SMOKE_HTTP_PORT="${LOCAL_HTTP_PORT}"
+  SMOKE_HTTPS_PORT="${LOCAL_HTTPS_PORT}"
+fi
+
+# --- Verify the exposure path actually works end to end --------------------
+echo ""
+echo "Verifying exposure path with a smoke test..."
+SMOKE_NAMESPACE="default"
+SMOKE_HOST="echo.${CONSOLE_CLUSTER_DOMAIN}"
+SMOKE_MANIFEST=$(mktemp)
+cleanup_smoke_test() {
+  kubectl delete -f "${SMOKE_MANIFEST}" --ignore-not-found >/dev/null 2>&1 || true
+  rm -f "${SMOKE_MANIFEST}"
+}
+trap cleanup_smoke_test EXIT
+
+cat > "${SMOKE_MANIFEST}" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-setup-smoke-test
+  namespace: ${SMOKE_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: cluster-setup-smoke-test}
+  template:
+    metadata:
+      labels: {app: cluster-setup-smoke-test}
+    spec:
+      containers:
+        - name: echo-server
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          args: ["netexec", "--http-port=8080"]
+          ports: [{containerPort: 8080}]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-setup-smoke-test
+  namespace: ${SMOKE_NAMESPACE}
+spec:
+  selector: {app: cluster-setup-smoke-test}
+  ports: [{port: 80, targetPort: 8080}]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cluster-setup-smoke-test
+  namespace: ${SMOKE_NAMESPACE}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ${SMOKE_HOST}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cluster-setup-smoke-test
+                port: {number: 80}
+EOF
+
+# ingress-nginx reloads its config asynchronously, so a freshly-created
+# Ingress can 404/503/refuse connections for up to ~30s before routing works.
+wait_for_http() {
+  local url="$1"
+  local curl_opts="$2"
+  local attempt
+  for attempt in $(seq 1 30); do
+    if curl -fsS ${curl_opts} --max-time 5 "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for ${url} to become reachable" >&2
+  return 1
+}
+
+kubectl apply -f "${SMOKE_MANIFEST}"
+kubectl wait --for=condition=ready pod -l app=cluster-setup-smoke-test --timeout=180s -n "${SMOKE_NAMESPACE}"
+
+echo "Checking http://${SMOKE_HOST}:${SMOKE_HTTP_PORT}/ (ingress-nginx reload can take up to ~30s)..."
+wait_for_http "http://${SMOKE_HOST}:${SMOKE_HTTP_PORT}/" ""
+echo "Checking https://${SMOKE_HOST}:${SMOKE_HTTPS_PORT}/ ..."
+wait_for_http "https://${SMOKE_HOST}:${SMOKE_HTTPS_PORT}/" "-k"
+if [ "${TUNNEL_ACTIVE}" = true ]; then
+  echo "Smoke test passed: macOS -> sudo minikube tunnel -> ingress-nginx -> pod is working (minikube)."
+else
+  echo "Smoke test passed: macOS -> kubectl port-forward -> ingress-nginx -> pod is working (minikube)."
+fi
+
+cleanup_smoke_test
+trap - EXIT
+
+echo ""
+echo "Cluster ready. To use it in this shell:"
+echo "  source ${CLUSTER_ENV_FILE}"
+echo ""
+echo "CONSOLE_CLUSTER_DOMAIN=${CONSOLE_CLUSTER_DOMAIN}"
+echo "kubectl context: ${MINIKUBE_PROFILE}"
+if [ "${TUNNEL_ACTIVE}" = true ]; then
+  echo "Access via https://<name>.${CONSOLE_CLUSTER_DOMAIN}/ (portless, via minikube tunnel)"
+else
+  echo "Access via https://<name>.${CONSOLE_CLUSTER_DOMAIN}:${LOCAL_HTTPS_PORT}/ (note the :${LOCAL_HTTPS_PORT} — run enable-tunnel.sh for portless access)"
+fi
+if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+  echo "podman machine sizing: PODMAN_MACHINE_CPUS=${PODMAN_MACHINE_CPUS} PODMAN_MACHINE_MEMORY=${PODMAN_MACHINE_MEMORY}MB (only applied on first-time machine init)"
+fi

--- a/systemtests/cluster-setup/minikube/delete-cluster.sh
+++ b/systemtests/cluster-setup/minikube/delete-cluster.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Tears down the local minikube setup. Always stops the background
+# port-forward or tunnel first. Default: deletes the entire minikube
+# profile. Pass --keep-cluster to instead remove just the deployed
+# resources (Kafka, Console, Console operator, Strimzi, OLM) while leaving
+# the minikube profile + ingress-nginx running.
+#
+# Usage:
+#   ./delete-cluster.sh                    # delete the whole cluster
+#   ./delete-cluster.sh --keep-cluster      # remove deployed resources only
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./lib/env.sh
+
+KEEP_CLUSTER=false
+KAFKA_NAMESPACE="kafka"
+OPERATOR_NAMESPACE="co-namespace"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep-cluster) KEEP_CLUSTER=true; shift ;;
+    --kafka-namespace) KAFKA_NAMESPACE="$2"; shift 2 ;;
+    --operator-namespace) OPERATOR_NAMESPACE="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 [--keep-cluster] [--kafka-namespace kafka] [--operator-namespace co-namespace]" >&2
+      exit 1
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -f "${PORT_FORWARD_PID_FILE}" ]; then
+  pid=$(cat "${PORT_FORWARD_PID_FILE}")
+  if kill "${pid}" 2>/dev/null; then
+    echo "Stopped port-forward (pid ${pid})"
+  fi
+  rm -f "${PORT_FORWARD_PID_FILE}" "${PORT_FORWARD_LOG_FILE}"
+fi
+
+if [ -f "${TUNNEL_PID_FILE}" ]; then
+  pid=$(cat "${TUNNEL_PID_FILE}")
+  # The tunnel runs as root (via sudo), so a plain `kill` from this
+  # unprivileged script can't touch it. Try non-interactively with cached
+  # sudo credentials first; if that's not available, ask the user.
+  #
+  # Deliberately does NOT remove .tunnel.pid if the kill fails: this file is
+  # the only way create-cluster.sh (in this or a future run) can detect that
+  # an orphaned root-owned tunnel is still alive and squatting on ports
+  # 80/443 — losing that tracking is exactly what caused a real, confusing
+  # failure once already (an old tunnel outlived a cluster recreation,
+  # silently occupying the ports while routing to nothing, while a fresh
+  # cluster's Console showed backend errors that looked network-related but
+  # weren't).
+  if sudo -n kill "${pid}" 2>/dev/null; then
+    echo "Stopped tunnel (pid ${pid})"
+    rm -f "${TUNNEL_PID_FILE}" "${TUNNEL_LOG_FILE}"
+  else
+    echo "Could not stop the root-owned tunnel process (pid ${pid}) without a sudo prompt." >&2
+    echo "Run 'sudo kill ${pid}' yourself, or Ctrl-C the terminal it's running in — it will" >&2
+    echo "otherwise keep running (and holding ports 80/443) even after this cluster is gone." >&2
+  fi
+fi
+
+if [ "${KEEP_CLUSTER}" = false ]; then
+  echo "Deleting minikube profile '${MINIKUBE_PROFILE}' (full teardown)..."
+  minikube delete -p "${MINIKUBE_PROFILE}"
+  rm -f "${CLUSTER_ENV_FILE}"
+  echo "Done."
+  exit 0
+fi
+
+echo "Partial teardown: removing deployed resources, keeping cluster + ingress-nginx..."
+
+# Delete Strimzi/Console custom resources *before* the namespace: if the
+# namespace delete tears down the entity-operator pod before it finishes
+# clearing a KafkaTopic's `strimzi.io/topic-operator` finalizer, the
+# namespace gets stuck in Terminating forever (same issue hit and fixed in
+# ../kind/delete-cluster.sh).
+echo "Deleting Kafka/Console custom resources in '${KAFKA_NAMESPACE}' (avoids a finalizer race with namespace deletion)..."
+kubectl delete console,kafkatopic,kafkauser,kafka,kafkanodepool -n "${KAFKA_NAMESPACE}" --all --ignore-not-found --timeout=120s || true
+
+echo "Deleting namespace '${KAFKA_NAMESPACE}' (Kafka + Console instance)..."
+kubectl delete namespace "${KAFKA_NAMESPACE}" --ignore-not-found --timeout=120s || {
+  echo "Namespace '${KAFKA_NAMESPACE}' didn't terminate in time — clearing any stuck finalizers and retrying..." >&2
+  for r in $(kubectl get kafkatopic,kafkauser,kafka -n "${KAFKA_NAMESPACE}" -o name 2>/dev/null); do
+    kubectl patch "${r}" -n "${KAFKA_NAMESPACE}" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+  done
+  kubectl delete namespace "${KAFKA_NAMESPACE}" --ignore-not-found
+}
+
+echo "Deleting namespace '${OPERATOR_NAMESPACE}' (Strimzi + Console operator + Subscription)..."
+kubectl delete namespace "${OPERATOR_NAMESPACE}" --ignore-not-found
+
+if kubectl get crd catalogsources.operators.coreos.com >/dev/null 2>&1; then
+  if command -v operator-sdk >/dev/null 2>&1; then
+    echo "Uninstalling OLM via operator-sdk..."
+    operator-sdk olm uninstall
+  else
+    echo "OLM is installed but 'operator-sdk' isn't available to cleanly uninstall it." >&2
+    echo "Install it (e.g. 'brew install operator-sdk') and re-run with --keep-cluster," >&2
+    echo "or run without --keep-cluster to delete the whole cluster instead." >&2
+    exit 1
+  fi
+fi
+
+echo ""
+echo "Partial teardown complete. Cluster '${MINIKUBE_PROFILE}' and ingress-nginx are still running."

--- a/systemtests/cluster-setup/minikube/enable-tunnel.sh
+++ b/systemtests/cluster-setup/minikube/enable-tunnel.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Switches ingress-nginx exposure from create-cluster.sh's default
+# (kubectl port-forward on high ports, no sudo needed) to portless access
+# via `minikube tunnel` — matching kind's UX (no :8443 suffix in URLs,
+# needed e.g. for OIDC/auth redirect flows that assume no port).
+#
+# `minikube tunnel` only manages Services of type LoadBalancer (not
+# NodePort, which is what the ingress addon creates by default), and
+# binding privileged ports 80/443 requires sudo. This script handles that
+# itself via `sudo -v` — you'll be prompted for your password once, right
+# here, then the rest runs unattended. Run this script directly (don't
+# prefix the whole thing with `sudo` yourself — only the one command that
+# actually needs it is elevated).
+#
+# Usage: ./enable-tunnel.sh
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./lib/env.sh
+
+if [ -f "${PORT_FORWARD_PID_FILE}" ]; then
+  pid=$(cat "${PORT_FORWARD_PID_FILE}")
+  kill "${pid}" 2>/dev/null || true
+  rm -f "${PORT_FORWARD_PID_FILE}" "${PORT_FORWARD_LOG_FILE}"
+  echo "Stopped the kubectl port-forward (pid ${pid}) — the tunnel replaces it."
+fi
+
+if [ -f "${TUNNEL_PID_FILE}" ] && kill -0 "$(cat "${TUNNEL_PID_FILE}")" 2>/dev/null; then
+  echo "Tunnel already running (pid $(cat "${TUNNEL_PID_FILE}")), skipping start"
+else
+  echo "Patching ingress-nginx-controller Service to type LoadBalancer..."
+  kubectl -n ingress-nginx patch svc ingress-nginx-controller -p '{"spec":{"type":"LoadBalancer"}}'
+
+  echo ""
+  echo "minikube tunnel needs to bind privileged ports 80/443, which requires sudo."
+  echo "You'll be prompted for your password now (once) — everything after that runs unattended."
+  sudo -v
+
+  echo "Starting background tunnel: sudo minikube tunnel -p ${MINIKUBE_PROFILE}..."
+  nohup sudo minikube tunnel -p "${MINIKUBE_PROFILE}" > "${TUNNEL_LOG_FILE}" 2>&1 &
+  echo $! > "${TUNNEL_PID_FILE}"
+  sleep 3
+  kill -0 "$(cat "${TUNNEL_PID_FILE}")" 2>/dev/null \
+    || { echo "tunnel failed to start, check ${TUNNEL_LOG_FILE}" >&2; exit 1; }
+fi
+
+cat > "${CLUSTER_ENV_FILE}" <<EOF
+export CONSOLE_CLUSTER_DOMAIN=${CONSOLE_CLUSTER_DOMAIN}
+export KUBECONTEXT=${MINIKUBE_PROFILE}
+EOF
+
+echo ""
+echo "Waiting for the tunnel to actually bind (EXTERNAL-IP -> 127.0.0.1)..."
+ext_ip=""
+for i in $(seq 1 20); do
+  ext_ip=$(kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  [ "${ext_ip}" = "127.0.0.1" ] && break
+  sleep 2
+done
+
+if [ "${ext_ip}" = "127.0.0.1" ]; then
+  echo ""
+  echo "Portless access ready: https://<name>.${CONSOLE_CLUSTER_DOMAIN}/"
+else
+  echo ""
+  echo "Tunnel process started but EXTERNAL-IP isn't 127.0.0.1 yet — check ${TUNNEL_LOG_FILE}" >&2
+  echo "(kubectl -n ingress-nginx get svc ingress-nginx-controller to check current status)" >&2
+fi

--- a/systemtests/cluster-setup/minikube/lib/env.sh
+++ b/systemtests/cluster-setup/minikube/lib/env.sh
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
 # Shared config for minikube/*.sh. Source, don't execute.
 
-CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+OS_NAME="$(uname -s)"
+
+# Auto-detect the container engine if not explicitly set: prefer podman,
+# fall back to docker, so this works out of the box on machines that only
+# have one of the two installed (common on Linux, where docker is often
+# the default with no podman in sight).
+if [ -z "${CONTAINER_ENGINE:-}" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    CONTAINER_ENGINE="podman"
+  elif command -v docker >/dev/null 2>&1; then
+    CONTAINER_ENGINE="docker"
+  else
+    echo "Neither podman nor docker found in PATH. Install one, or set CONTAINER_ENGINE explicitly." >&2
+    exit 1
+  fi
+fi
+
 CLUSTER_NAME="${CLUSTER_NAME:-console-minikube}"
 CONSOLE_CLUSTER_DOMAIN="${CONSOLE_CLUSTER_DOMAIN:-127.0.0.1.nip.io}"
 
-# minikube's ingress addon exposes a NodePort Service, and direct NodePort
-# access to the minikube node IP times out from macOS (confirmed on this
-# machine, matches long-standing upstream minikube issues on docker/podman
-# drivers). We expose it instead via a persistent `kubectl port-forward` on
-# these (non-privileged, no sudo needed) local ports. See
-# ~/claude-docs/streamshub-local-sts/README.md for the full investigation,
-# including a portless (sudo-tunnel) alternative if you need it (e.g. for
-# OIDC/auth flows that assume no port in the redirect URL).
+# minikube's ingress addon exposes a NodePort Service. On macOS, direct
+# NodePort access to the minikube node IP times out (Docker/Podman Desktop
+# run the engine inside a VM), so we expose it via a persistent
+# `kubectl port-forward` on these (non-privileged, no sudo needed) local
+# ports instead. On native Linux, the node IP is normally directly
+# reachable and this port-forward isn't strictly necessary — but it works
+# there too, so it's used uniformly on both OSes rather than branching.
 LOCAL_HTTP_PORT="${LOCAL_HTTP_PORT:-8080}"
 LOCAL_HTTPS_PORT="${LOCAL_HTTPS_PORT:-8443}"
 
@@ -32,15 +47,20 @@ PORT_FORWARD_LOG_FILE="${CLUSTER_ROOT}/.port-forward.log"
 TUNNEL_PID_FILE="${CLUSTER_ROOT}/.tunnel.pid"
 TUNNEL_LOG_FILE="${CLUSTER_ROOT}/.tunnel.log"
 
-# Podman machine sizing (only relevant when CONTAINER_ENGINE=podman). Same
-# logic as ../kind/lib/env.sh, duplicated rather than sourced to keep this
-# folder fully independent (per instructions: don't touch/depend on the
-# kind setup's internals). Defaults to (host CPUs - 1) and (host memory
-# - 4GB headroom); override with PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY
-# (MB).
+# Podman machine sizing (only relevant on macOS, where podman needs a VM to
+# run containers at all — native Linux podman doesn't). Same logic as
+# ../kind/lib/env.sh, duplicated rather than sourced to keep this folder
+# fully independent. Defaults to (host CPUs - 1) and (host memory - 4GB
+# headroom); override with PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY (MB).
+# Portable: prefers Linux-native tools (nproc, /proc/meminfo), falls back
+# to macOS's sysctl.
 detect_default_cpus() {
   local total
-  total=$(sysctl -n hw.ncpu)
+  if command -v nproc >/dev/null 2>&1; then
+    total=$(nproc)
+  else
+    total=$(sysctl -n hw.ncpu)
+  fi
   if [ "${total}" -gt 1 ]; then
     echo $(( total - 1 ))
   else
@@ -50,7 +70,11 @@ detect_default_cpus() {
 
 detect_default_memory_mb() {
   local total_mb headroom_mb=4096
-  total_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+  if [ -r /proc/meminfo ]; then
+    total_mb=$(( $(awk '/^MemTotal:/ {print $2}' /proc/meminfo) / 1024 ))
+  else
+    total_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+  fi
   if [ "${total_mb}" -gt "${headroom_mb}" ]; then
     echo $(( total_mb - headroom_mb ))
   else
@@ -61,7 +85,14 @@ detect_default_memory_mb() {
 PODMAN_MACHINE_CPUS="${PODMAN_MACHINE_CPUS:-$(detect_default_cpus)}"
 PODMAN_MACHINE_MEMORY="${PODMAN_MACHINE_MEMORY:-$(detect_default_memory_mb)}"
 
+# Ensures a podman machine exists and is running — but only on macOS.
+# Native Linux podman talks to the local system directly; there's no VM to
+# create or manage, so this is a no-op there regardless of CONTAINER_ENGINE.
 ensure_podman_machine() {
+  if [ "${OS_NAME}" != "Darwin" ]; then
+    return 0
+  fi
+
   local name state cpus mem
 
   name=$(podman machine list --format json | jq -r '.[0].Name // empty')

--- a/systemtests/cluster-setup/minikube/lib/env.sh
+++ b/systemtests/cluster-setup/minikube/lib/env.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Shared config for minikube/*.sh. Source, don't execute.
+
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+CLUSTER_NAME="${CLUSTER_NAME:-console-minikube}"
+CONSOLE_CLUSTER_DOMAIN="${CONSOLE_CLUSTER_DOMAIN:-127.0.0.1.nip.io}"
+
+# minikube's ingress addon exposes a NodePort Service, and direct NodePort
+# access to the minikube node IP times out from macOS (confirmed on this
+# machine, matches long-standing upstream minikube issues on docker/podman
+# drivers). We expose it instead via a persistent `kubectl port-forward` on
+# these (non-privileged, no sudo needed) local ports. See
+# ~/claude-docs/streamshub-local-sts/README.md for the full investigation,
+# including a portless (sudo-tunnel) alternative if you need it (e.g. for
+# OIDC/auth flows that assume no port in the redirect URL).
+LOCAL_HTTP_PORT="${LOCAL_HTTP_PORT:-8080}"
+LOCAL_HTTPS_PORT="${LOCAL_HTTPS_PORT:-8443}"
+
+case "${CONTAINER_ENGINE}" in
+  podman|docker) ;;
+  *)
+    echo "Unsupported CONTAINER_ENGINE=${CONTAINER_ENGINE} (expected 'podman' or 'docker')" >&2
+    exit 1
+    ;;
+esac
+
+MINIKUBE_PROFILE="${CLUSTER_NAME}"
+CLUSTER_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER_ENV_FILE="${CLUSTER_ROOT}/.cluster-env"
+PORT_FORWARD_PID_FILE="${CLUSTER_ROOT}/.port-forward.pid"
+PORT_FORWARD_LOG_FILE="${CLUSTER_ROOT}/.port-forward.log"
+TUNNEL_PID_FILE="${CLUSTER_ROOT}/.tunnel.pid"
+TUNNEL_LOG_FILE="${CLUSTER_ROOT}/.tunnel.log"
+
+# Podman machine sizing (only relevant when CONTAINER_ENGINE=podman). Same
+# logic as ../kind/lib/env.sh, duplicated rather than sourced to keep this
+# folder fully independent (per instructions: don't touch/depend on the
+# kind setup's internals). Defaults to (host CPUs - 1) and (host memory
+# - 4GB headroom); override with PODMAN_MACHINE_CPUS/PODMAN_MACHINE_MEMORY
+# (MB).
+detect_default_cpus() {
+  local total
+  total=$(sysctl -n hw.ncpu)
+  if [ "${total}" -gt 1 ]; then
+    echo $(( total - 1 ))
+  else
+    echo "${total}"
+  fi
+}
+
+detect_default_memory_mb() {
+  local total_mb headroom_mb=4096
+  total_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+  if [ "${total_mb}" -gt "${headroom_mb}" ]; then
+    echo $(( total_mb - headroom_mb ))
+  else
+    echo "${total_mb}"
+  fi
+}
+
+PODMAN_MACHINE_CPUS="${PODMAN_MACHINE_CPUS:-$(detect_default_cpus)}"
+PODMAN_MACHINE_MEMORY="${PODMAN_MACHINE_MEMORY:-$(detect_default_memory_mb)}"
+
+ensure_podman_machine() {
+  local name state cpus mem
+
+  name=$(podman machine list --format json | jq -r '.[0].Name // empty')
+
+  if [ -z "${name}" ]; then
+    echo "No podman machine found — initializing 'podman-machine-default' with ${PODMAN_MACHINE_CPUS} CPUs / ${PODMAN_MACHINE_MEMORY}MB memory..."
+    podman machine init --rootful --cpus "${PODMAN_MACHINE_CPUS}" --memory "${PODMAN_MACHINE_MEMORY}"
+    podman machine start
+    return
+  fi
+
+  state=$(podman machine inspect "${name}" | jq -r '.[0].State')
+  if [ "${state}" != "running" ]; then
+    echo "Starting existing podman machine '${name}'..."
+    podman machine start "${name}"
+  fi
+
+  cpus=$(podman machine inspect "${name}" | jq -r '.[0].Resources.CPUs')
+  mem=$(podman machine inspect "${name}" | jq -r '.[0].Resources.Memory')
+  if [ "${cpus}" != "${PODMAN_MACHINE_CPUS}" ] || [ "${mem}" != "${PODMAN_MACHINE_MEMORY}" ]; then
+    echo "Note: podman machine '${name}' is already sized at ${cpus} CPUs / ${mem}MB memory (requested ${PODMAN_MACHINE_CPUS}/${PODMAN_MACHINE_MEMORY}MB). Not resizing an existing machine automatically." >&2
+    echo "  To resize: podman machine stop ${name} && podman machine set --cpus ${PODMAN_MACHINE_CPUS} --memory ${PODMAN_MACHINE_MEMORY} ${name} && podman machine start ${name}" >&2
+  fi
+}

--- a/systemtests/cluster-setup/minikube/lib/env.sh
+++ b/systemtests/cluster-setup/minikube/lib/env.sh
@@ -3,17 +3,25 @@
 
 OS_NAME="$(uname -s)"
 
-# Auto-detect the container engine if not explicitly set: prefer podman,
-# fall back to docker, so this works out of the box on machines that only
-# have one of the two installed (common on Linux, where docker is often
-# the default with no podman in sight).
+# Auto-detect the minikube driver if not explicitly set. Minikube's own
+# driver docs (https://minikube.sigs.k8s.io/docs/drivers/) list docker as
+# preferred on both platforms; podman is still marked experimental on
+# both. Prefer docker, then the platform's VM-based driver (vfkit on
+# macOS, kvm2 on Linux), with podman only as a last resort — confirmed
+# painful in practice: the ip_tables kernel module requirement, PID-limit
+# crashes under a full Kafka+Console workload, and a rootless-podman
+# failure hit directly against minikube.
 if [ -z "${CONTAINER_ENGINE:-}" ]; then
-  if command -v podman >/dev/null 2>&1; then
-    CONTAINER_ENGINE="podman"
-  elif command -v docker >/dev/null 2>&1; then
+  if command -v docker >/dev/null 2>&1; then
     CONTAINER_ENGINE="docker"
+  elif [ "${OS_NAME}" = "Darwin" ] && command -v vfkit >/dev/null 2>&1; then
+    CONTAINER_ENGINE="vfkit"
+  elif [ "${OS_NAME}" = "Linux" ] && command -v virsh >/dev/null 2>&1; then
+    CONTAINER_ENGINE="kvm2"
+  elif command -v podman >/dev/null 2>&1; then
+    CONTAINER_ENGINE="podman"
   else
-    echo "Neither podman nor docker found in PATH. Install one, or set CONTAINER_ENGINE explicitly." >&2
+    echo "No supported minikube driver found (docker, vfkit/kvm2, or podman). Install one, or set CONTAINER_ENGINE explicitly." >&2
     exit 1
   fi
 fi
@@ -32,9 +40,9 @@ LOCAL_HTTP_PORT="${LOCAL_HTTP_PORT:-8080}"
 LOCAL_HTTPS_PORT="${LOCAL_HTTPS_PORT:-8443}"
 
 case "${CONTAINER_ENGINE}" in
-  podman|docker) ;;
+  docker|podman|vfkit|kvm2) ;;
   *)
-    echo "Unsupported CONTAINER_ENGINE=${CONTAINER_ENGINE} (expected 'podman' or 'docker')" >&2
+    echo "Unsupported CONTAINER_ENGINE=${CONTAINER_ENGINE} (expected 'docker', 'podman', 'vfkit', or 'kvm2')" >&2
     exit 1
     ;;
 esac
@@ -115,5 +123,33 @@ ensure_podman_machine() {
   if [ "${cpus}" != "${PODMAN_MACHINE_CPUS}" ] || [ "${mem}" != "${PODMAN_MACHINE_MEMORY}" ]; then
     echo "Note: podman machine '${name}' is already sized at ${cpus} CPUs / ${mem}MB memory (requested ${PODMAN_MACHINE_CPUS}/${PODMAN_MACHINE_MEMORY}MB). Not resizing an existing machine automatically." >&2
     echo "  To resize: podman machine stop ${name} && podman machine set --cpus ${PODMAN_MACHINE_CPUS} --memory ${PODMAN_MACHINE_MEMORY} ${name} && podman machine start ${name}" >&2
+  fi
+}
+
+# On native Linux with rootless podman, kube-proxy/ingress-nginx need the
+# host's ip_tables kernel module loaded — rootless containers can't load
+# kernel modules themselves (no CAP_SYS_MODULE), so a missing module
+# surfaces confusingly later as ingress-nginx/kube-proxy failing, not as an
+# obvious "module missing" error. Check up front and fail fast instead.
+# No-op on macOS (podman machine VM, handled by ensure_podman_machine) and
+# on rootful podman/docker (which don't hit this).
+check_linux_rootless_podman_ip_tables() {
+  if [ "${OS_NAME}" != "Linux" ] || [ "${CONTAINER_ENGINE}" != "podman" ]; then
+    return 0
+  fi
+
+  if [ "$(podman info --format json | jq -r .host.security.rootless)" != "true" ]; then
+    return 0
+  fi
+
+  if [ -z "$(lsmod | grep ^ip_tables)" ]; then
+    echo "podman is running rootless on Linux, but the 'ip_tables' kernel module isn't loaded." >&2
+    echo "Rootless containers can't load kernel modules themselves (no CAP_SYS_MODULE), and" >&2
+    echo "kube-proxy/ingress-nginx need it on the host - without it, ingress setup fails." >&2
+    echo "" >&2
+    echo "Fix:" >&2
+    echo "  sudo modprobe ip_tables" >&2
+    echo "  echo ip_tables | sudo tee /etc/modules-load.d/ip_tables.conf   # persist across reboots" >&2
+    exit 1
   fi
 }

--- a/systemtests/config.yaml
+++ b/systemtests/config.yaml
@@ -30,7 +30,7 @@ CONSOLE_INSTALL_TYPE: olm
 # Name of the CatalogSource for Console Operator
 CONSOLE_OLM_CATALOG_SOURCE_NAME: console-source
 # Namespace where lies the CatalogSource for Console Operator
-CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE: openshift-marketplace
+CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE: olm
 # Image of the CatalogSource to deploy for Console Operator. If empty (default), STs assume a CatalogSource
 # with the name/namespace above already exists on the cluster. If set, STs will create one from this image
 # (unless a CatalogSource with that name/namespace already exists).
@@ -48,7 +48,7 @@ STRIMZI_OPERATOR_VERSION: 1.0.0
 # 1. URL - released console-operator.yaml
 # 2. Local path that is relative to the root project dir
 # 3. Local path that is absolute
-CONSOLE_OPERATOR_BUNDLE_URL: https://github.com/streamshub/console/releases/download/0.12.4/streamshub-console-operator.yaml
+CONSOLE_OPERATOR_BUNDLE_URL: https://github.com/streamshub/console/releases/download/0.12.6/streamshub-console-operator.yaml
 # -------------------------------------------
 # Kroxy
 # -------------------------------------------


### PR DESCRIPTION
This PR adds systemtests/cluster-setup/ - a small set of ready-to-run scripts that provision a local Kubernetes cluster for console-operator systemtests, so nobody has to sit down and work out cluster networking, OLM installation, or Strimzi/Kafka/Console wiring from scratch just to test something locally.

 Whats added:
 - kind - the recommended option. Maps ports 80/443 straight to the host at cluster-creation time and binds ingress-nginx via hostPort, so everything is reachable portlessly with no sudo and no background process to babysit. This matters especially on macOS, where Docker Desktop/Podman Desktop/Colima run the container engine inside a hidden VM, so a plain minikube setup (systemtests/scripts/setup-minikube.sh, which assumes the node IP is directly reachable — true on Linux CI, not true on macOS) doesn't work out of the box.
  - minikube - an alternative for anyone who wants minikube specifically. Includes a script to switch to portless access via minikube tunnel (one sudo prompt, everything else automated) for parity with kind's UX.
   - common - cluster-agnostic scripts (setup-catalogsource.sh, deploy-example-console.sh) that install OLM + catalogSource and deploy Strimzi, a Kafka cluster, the Console operator, and a Console instance, using the project's existing examples/kafka and examples/console quickstart manifests.

All scripts are idempotent (safe to re-run), include teardown scripts (full or --keep-cluster), and auto-detect podman vs. docker so the same scripts work on both macOS and Linux.

Note: minikube/create-cluster.sh is not a replacement for systemtests/scripts/setup-minikube.sh
They solve different problems. systemtests/scripts/setup-minikube.sh builds the Console images from source and pushes them into the cluster's registry - it's part of the CI build pipeline. minikube/create-cluster.sh does none of that: it only provisions the cluster itself (starts minikube, sets up ingress + SSL passthrough, exposes it to the host) and expects you to point it at an already-built operator image via common/setup-catalogsource.sh. These scripts assume you already know how to build and push your own images (or using a published ones) - building/pushing images is intentionally outside their scope in case you just want to setup a cluster.

PR also includes a small systemtests/config.yaml tweak: default CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE from openshift-marketplace to olm (matches this setup's default on non-OCP clusters), and bumps the referenced console-operator bundle version.