### PR TITLE
[ST] Tests can handle creating catalogsource

### DIFF
--- a/systemtests/CONFIGURATION.md
+++ b/systemtests/CONFIGURATION.md
@@ -52,6 +52,7 @@ mvn -pl systemtests verify -DskipSTs=false
 | `CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE` | `olm`                         | Namespace of the CatalogSource. |
 | `CONSOLE_OLM_PACKAGE_NAME` | `streamshub-console-operator` | Package name in the operator catalog. |
 | `CONSOLE_OLM_CHANNEL_NAME` | `alpha`                       | Subscription channel. |
+| `CONSOLE_OLM_CATALOG_SOURCE_IMAGE` | _(empty)_                     | When set, tests create the CatalogSource automatically using this image before installing the operator, instead of requiring it to be deployed manually. |
 
 Use OLM when testing on OpenShift or validating the operator bundle/catalog.
 

--- a/systemtests/RUNNING_TESTS.md
+++ b/systemtests/RUNNING_TESTS.md
@@ -138,7 +138,14 @@ This must be set **before** running tests — the image is used when tests deplo
 
 **Use case:** testing on OpenShift, or validating the operator bundle/catalog.
 
-A CatalogSource can be deplyed in the cluster manually using commands below.
+A CatalogSource can be deployed in the cluster manually using commands below, but STs can handle the creation when you set env `CONSOLE_OLM_CATALOG_SOURCE_IMAGE`.
+
+**Let tests create it automatically by using:**
+
+```yaml
+# config.yaml
+CONSOLE_OLM_CATALOG_SOURCE_IMAGE: quay.io/streamshub/console-operator-catalog:latest
+```
 
 **On OpenShift**, the marketplace namespace already exists:
 

--- a/systemtests/config.yaml
+++ b/systemtests/config.yaml
@@ -33,6 +33,10 @@ CONSOLE_CLUSTER_DOMAIN: "192.168.49.2.nip.io"
 CONSOLE_OLM_CATALOG_SOURCE_NAME: console-source
 # Namespace where lies the CatalogSource for Console Operator
 CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE: openshift-marketplace
+# Image of the CatalogSource to deploy for Console Operator. If empty (default), STs assume a CatalogSource
+# with the name/namespace above already exists on the cluster. If set, STs will create one from this image
+# (unless a CatalogSource with that name/namespace already exists).
+CONSOLE_OLM_CATALOG_SOURCE_IMAGE: ""
 # Package name of the console operator
 CONSOLE_OLM_PACKAGE_NAME: streamshub-console-operator
 # OLM channel for selecting the Operator version

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/Environment.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/Environment.java
@@ -44,6 +44,7 @@ public class Environment {
     public static final String CONSOLE_OLM_PACKAGE_NAME = ENVS.getOrDefault("CONSOLE_OLM_PACKAGE_NAME", "streamshub-console-operator");
     public static final String CONSOLE_OLM_CHANNEL_NAME = ENVS.getOrDefault("CONSOLE_OLM_CHANNEL_NAME", "alpha");
     public static final String CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE = ENVS.getOrDefault("CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE", Constants.OPENSHIFT_MARKETPLACE_NAMESPACE);
+    public static final String CONSOLE_OLM_CATALOG_SOURCE_IMAGE = ENVS.getOrDefault("CONSOLE_OLM_CATALOG_SOURCE_IMAGE", "");
 
     // Logs and debug
     public static final boolean CLEANUP_ENVIRONMENT = ENVS.getOrDefault("CLEANUP_ENVIRONMENT", Boolean::parseBoolean, true);

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/setup/console/OlmConfig.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/setup/console/OlmConfig.java
@@ -11,6 +11,8 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroup;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroupBuilder;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSource;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSourceBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.ClusterServiceVersion;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionBuilder;
@@ -26,6 +28,7 @@ public class OlmConfig extends InstallConfig {
     private String packageName = Environment.CONSOLE_OLM_PACKAGE_NAME;
     private String catalogSourceName = Environment.CONSOLE_OLM_CATALOG_SOURCE_NAME;
     private String catalogSourceNamespace = Environment.CONSOLE_OLM_CATALOG_SOURCE_NAMESPACE;
+    private String catalogSourceImage = Environment.CONSOLE_OLM_CATALOG_SOURCE_IMAGE;
     private String channelName = Environment.CONSOLE_OLM_CHANNEL_NAME;
     private String subscriptionName = Constants.CONSOLE_OLM_SUBSCRIPTION_NAME;
 
@@ -47,6 +50,12 @@ public class OlmConfig extends InstallConfig {
             !Environment.DELETE_CONSOLE_OPERATOR_BEFORE_INSTALL) {
             LOGGER.info("Console Operator deployment '{}' already exists in namespace '{}', skipping OLM install", deploymentName, deploymentNamespace);
             return;
+        }
+
+        if (!catalogSourceImage.isEmpty() &&
+            ResourceUtils.getKubeResource(CatalogSource.class, catalogSourceNamespace, catalogSourceName) == null) {
+            LOGGER.info("Creating CatalogSource '{}' in namespace '{}' using image '{}'", catalogSourceName, catalogSourceNamespace, catalogSourceImage);
+            KubeResourceManager.get().createOrUpdateResourceWithWait(getOlmCatalogSource());
         }
 
         LOGGER.info("Creating OLM OperatorGroup and Subscription '{}' for package '{}' in namespace '{}'", subscriptionName, packageName, deploymentNamespace);
@@ -104,6 +113,21 @@ public class OlmConfig extends InstallConfig {
         this.channelName = channelName;
         LOGGER.info("Bumping Console Operator Subscription '{}' to channel '{}' in namespace '{}'", subscriptionName, channelName, deploymentNamespace);
         KubeResourceManager.get().createOrUpdateResourceWithWait(getOlmSubscription());
+    }
+
+    private CatalogSource getOlmCatalogSource() {
+        return new CatalogSourceBuilder()
+            .withNewMetadata()
+                .withName(catalogSourceName)
+                .withNamespace(catalogSourceNamespace)
+            .endMetadata()
+            .withNewSpec()
+                .withDisplayName("StreamsHub")
+                .withImage(catalogSourceImage)
+                .withPublisher("StreamsHub")
+                .withSourceType("grpc")
+            .endSpec()
+            .build();
     }
 
     private Subscription getOlmSubscription() {


### PR DESCRIPTION
In past, user had to deploy their own catalogsource for running OLM tests, now they can pass a value if they want to let STs handle this operation. If no image is specified or catalog exists, tests simply skip creating the catalogsource.