### PR TITLE
Prevent mixed content redirect following successful Kafka cluster login

### DIFF
--- a/api/src/main/java/com/github/streamshub/console/api/security/ConsoleAuthenticationMechanism.java
+++ b/api/src/main/java/com/github/streamshub/console/api/security/ConsoleAuthenticationMechanism.java
@@ -78,6 +78,7 @@ public class ConsoleAuthenticationMechanism implements HttpAuthenticationMechani
                         .cookieName("streamshub-console-kafka-" + clusterId)
                         .cookiePath(securedPath)
                         .cookieSameSite(CookieSameSite.STRICT)
+                        .loginPage(null) // disables redirect after login
                         .landingPage(null)
                         .build();
     }

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/utils/playwright/PwUtils.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/utils/playwright/PwUtils.java
@@ -17,10 +17,13 @@ import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Locator.GetByRoleOptions;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.TimeoutError;
 import com.microsoft.playwright.Tracing;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import com.microsoft.playwright.options.WaitUntilState;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -702,10 +705,17 @@ public class PwUtils {
         tcc.page().navigate(baseUrl);
 
         // Login with user in the modal (note: these selectors might need updating for modal-based login)
-        waitForLocatorAndFill(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_NAME_INPUT, kafkaUser);
-        waitForLocatorAndFill(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_PASSWORD_INPUT, password);
-        waitForLocatorAndClick(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_LOGIN_BUTTON);
-        Utils.sleepWait(TimeConstants.UI_COMPONENT_REACTION_INTERVAL_SHORT);
+        var loginModal = tcc.page().getByRole(AriaRole.DIALOG);
+        PlaywrightAssertions.assertThat(loginModal).isVisible();
+        loginModal.locator("form input#username").fill(kafkaUser);
+        loginModal.locator("form input#password").fill(password);
+        loginModal.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Login")).click();
+
+        //waitForLocatorAndFill(tcc, "form input#username", kafkaUser);
+        //waitForLocatorAndFill(tcc, "form input#password", password);
+        //waitForLocatorAndClick(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_LOGIN_BUTTON);
+        //Utils.sleepWait(TimeConstants.UI_COMPONENT_REACTION_INTERVAL_SHORT);
+
         // Wait for overview page
         waitForUrl(tcc, PwPageUrls.getOverviewPage(tcc, tcc.kafkaName()), true);
         LOGGER.info("Successfully logged into Console with Kafka credentials");

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/utils/playwright/PwUtils.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/utils/playwright/PwUtils.java
@@ -711,11 +711,6 @@ public class PwUtils {
         loginModal.locator("form input#password").fill(password);
         loginModal.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Login")).click();
 
-        //waitForLocatorAndFill(tcc, "form input#username", kafkaUser);
-        //waitForLocatorAndFill(tcc, "form input#password", password);
-        //waitForLocatorAndClick(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_LOGIN_BUTTON);
-        //Utils.sleepWait(TimeConstants.UI_COMPONENT_REACTION_INTERVAL_SHORT);
-
         // Wait for overview page
         waitForUrl(tcc, PwPageUrls.getOverviewPage(tcc, tcc.kafkaName()), true);
         LOGGER.info("Successfully logged into Console with Kafka credentials");

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/utils/playwright/PwUtils.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/utils/playwright/PwUtils.java
@@ -706,8 +706,6 @@ public class PwUtils {
         waitForLocatorAndFill(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_PASSWORD_INPUT, password);
         waitForLocatorAndClick(tcc, CssSelectors.PAGES_KAFKA_CREDENTIALS_LOGIN_BUTTON);
         Utils.sleepWait(TimeConstants.UI_COMPONENT_REACTION_INTERVAL_SHORT);
-        // TODO: remove once fixed
-        PwUtils.reload(tcc);
         // Wait for overview page
         waitForUrl(tcc, PwPageUrls.getOverviewPage(tcc, tcc.kafkaName()), true);
         LOGGER.info("Successfully logged into Console with Kafka credentials");

--- a/systemtests/src/main/java/com/github/streamshub/systemtests/utils/resourceutils/ClusterUtils.java
+++ b/systemtests/src/main/java/com/github/streamshub/systemtests/utils/resourceutils/ClusterUtils.java
@@ -35,12 +35,21 @@ public class ClusterUtils {
     }
 
     public static String getClusterDomain() {
+        String domain;
+
         if (isOcp()) {
-            String domain = "apps." + ResourceUtils.getKubeResource(DNS.class, "cluster").getSpec().getBaseDomain();
+            domain = "apps." + ResourceUtils.getKubeResource(DNS.class, "cluster").getSpec().getBaseDomain();
             LOGGER.trace("Resolved OpenShift cluster domain: {}", domain);
-            return domain;
+        } else {
+            domain = Environment.CONSOLE_CLUSTER_DOMAIN;
+
+            if (domain.isBlank()) {
+                throw new IllegalStateException("Environment variable CONSOLE_CLUSTER_DOMAIN must be set for non-OpenShift clusters");
+            }
+
+            LOGGER.trace("Using configured cluster domain: {}", domain);
         }
-        LOGGER.trace("Using configured cluster domain: {}", Environment.CONSOLE_CLUSTER_DOMAIN);
-        return Environment.CONSOLE_CLUSTER_DOMAIN;
+
+        return domain;
     }
 }


### PR DESCRIPTION
Fixes #2728 

The problem seen in the tests was due to a redirect being issued by Quarkus to a default `/login.html`. The protocol in the redirect URL is `http`, but the tests use the Console via an ingress with TLS/HTTPS enabled. In this case, the browser rejects the login response because it is "mixed content" - an HTTPS response that contains an HTTP redirect header. The solution here is to disable the redirect entirely (we don't need it anyway) when building the form authentication mechanism for the Kafka cluster.

This PR also includes a small change in the system tests to ensure that the Kube cluster domain is provide for non-OCP scenarios.