### PR TITLE
Upgrade to React Router v8

### DIFF
--- a/api/src/main/webui/package-lock.json
+++ b/api/src/main/webui/package-lock.json
@@ -27,7 +27,7 @@
         "react-dom": "^19.2.8",
         "react-i18next": "^17.0.11",
         "react-json-view-lite": "^2.5.0",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.0.0",
         "victory": "^37.3.6",
         "zustand": "^5.0.14"
       },
@@ -997,9 +997,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,9 +1014,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1031,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,9 +1048,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1077,9 +1065,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,9 +1082,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1748,18 +1730,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3423,41 +3398,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/resize-observer-polyfill": {
@@ -3518,12 +3476,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shallow-equal": {
       "version": "1.2.1",

--- a/api/src/main/webui/package.json
+++ b/api/src/main/webui/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^19.2.8",
     "react-i18next": "^17.0.11",
     "react-json-view-lite": "^2.5.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.0.0",
     "victory": "^37.3.6",
     "zustand": "^5.0.14"
   },

--- a/api/src/main/webui/src/App.tsx
+++ b/api/src/main/webui/src/App.tsx
@@ -3,7 +3,7 @@
  * Provides the main layout and outlet for child routes
  */
 
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { AppLayoutProvider } from '@/components/app/AppLayoutProvider';
 import { ThemeProvider } from '@/components/app/ThemeProvider';
 import { KafkaAuthProvider } from '@/components/auth/KafkaAuthProvider';

--- a/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
+++ b/api/src/main/webui/src/components/auth/KafkaAuthProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { KafkaLoginModal } from './KafkaLoginModal';
 import { QueryErrorHandler } from './QueryErrorHandler';

--- a/api/src/main/webui/src/components/common/ResourceListDataView.tsx
+++ b/api/src/main/webui/src/components/common/ResourceListDataView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   DataView,

--- a/api/src/main/webui/src/components/home/ClustersDataView.tsx
+++ b/api/src/main/webui/src/components/home/ClustersDataView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Button,

--- a/api/src/main/webui/src/components/kafka/ClusterSwitcher.tsx
+++ b/api/src/main/webui/src/components/kafka/ClusterSwitcher.tsx
@@ -22,7 +22,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { ArrowRightIcon, HomeIcon } from '@patternfly/react-icons';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useRef, useState } from 'react';
 import { KafkaCluster } from '@/api/types';

--- a/api/src/main/webui/src/components/kafka/KafkaClusterSidebar.tsx
+++ b/api/src/main/webui/src/components/kafka/KafkaClusterSidebar.tsx
@@ -5,7 +5,7 @@
 
 import { Nav, NavItem, NavList, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { NavLink, useParams, useLocation } from 'react-router-dom';
+import { NavLink, useParams, useLocation } from 'react-router';
 import { useAppLayout } from '@/components/app/AppLayoutProvider';
 
 interface NavItemConfig {

--- a/api/src/main/webui/src/components/kafka/connect/ConnectClustersTable.tsx
+++ b/api/src/main/webui/src/components/kafka/connect/ConnectClustersTable.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Toolbar,
   ToolbarContent,

--- a/api/src/main/webui/src/components/kafka/connect/ConnectorsTable.tsx
+++ b/api/src/main/webui/src/components/kafka/connect/ConnectorsTable.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Toolbar,
   ToolbarContent,

--- a/api/src/main/webui/src/components/kafka/groups/GroupsTable.tsx
+++ b/api/src/main/webui/src/components/kafka/groups/GroupsTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Label,
   LabelGroup,

--- a/api/src/main/webui/src/components/kafka/groups/LagTable.tsx
+++ b/api/src/main/webui/src/components/kafka/groups/LagTable.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import {
   EmptyState,
   EmptyStateBody,

--- a/api/src/main/webui/src/components/kafka/nodes/NodesTable.tsx
+++ b/api/src/main/webui/src/components/kafka/nodes/NodesTable.tsx
@@ -37,7 +37,7 @@ import {
   useControllerStatusLabels,
 } from './NodeStatusLabel';
 import { formatNumber } from '@/utils/format';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 interface NodesTableProps {
   kafkaId: string;

--- a/api/src/main/webui/src/components/kafka/nodes/RebalancesTable.tsx
+++ b/api/src/main/webui/src/components/kafka/nodes/RebalancesTable.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { formatDateTime } from '@/utils/dateTime';
 import {
   Table,

--- a/api/src/main/webui/src/components/kafka/overview/ClusterCard.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/ClusterCard.tsx
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Card,

--- a/api/src/main/webui/src/components/kafka/overview/RecentTopicsCard.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/RecentTopicsCard.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Card,

--- a/api/src/main/webui/src/components/kafka/overview/TopicsPartitionsCard.tsx
+++ b/api/src/main/webui/src/components/kafka/overview/TopicsPartitionsCard.tsx
@@ -7,7 +7,7 @@
  * - Status breakdown (fully replicated, under-replicated, offline)
  */
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Card,

--- a/api/src/main/webui/src/components/kafka/topics/TopicsDataView.tsx
+++ b/api/src/main/webui/src/components/kafka/topics/TopicsDataView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ThProps } from '@patternfly/react-table';
 import { UseQueryResult } from '@tanstack/react-query';

--- a/api/src/main/webui/src/components/kafka/users/UsersTable.tsx
+++ b/api/src/main/webui/src/components/kafka/users/UsersTable.tsx
@@ -3,7 +3,7 @@
  * Displays a table of Kafka users with filtering and sorting
  */
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Table,

--- a/api/src/main/webui/src/main.tsx
+++ b/api/src/main/webui/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { router } from './routes';
 import './i18n/config';

--- a/api/src/main/webui/src/pages/ErrorPage.tsx
+++ b/api/src/main/webui/src/pages/ErrorPage.tsx
@@ -2,7 +2,7 @@
  * Error Page - Displayed when routing errors occur
  */
 
-import { useRouteError, isRouteErrorResponse } from 'react-router-dom';
+import { useRouteError, isRouteErrorResponse } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Page,

--- a/api/src/main/webui/src/pages/kafka/KafkaLayout.tsx
+++ b/api/src/main/webui/src/pages/kafka/KafkaLayout.tsx
@@ -2,7 +2,7 @@
  * Kafka Layout - Wrapper for Kafka cluster pages
  */
 
-import { Outlet, useParams, useLocation, Link } from 'react-router-dom';
+import { Outlet, useParams, useLocation, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Page,

--- a/api/src/main/webui/src/pages/kafka/connect/ConnectClustersTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/connect/ConnectClustersTab.tsx
@@ -4,7 +4,7 @@
  * Displays the connect clusters table
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { PageSection } from '@patternfly/react-core';
 import { ConnectClustersTable } from '@/components/kafka/connect/ConnectClustersTable';
 

--- a/api/src/main/webui/src/pages/kafka/connect/ConnectConnectorsTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/connect/ConnectConnectorsTab.tsx
@@ -4,7 +4,7 @@
  * Displays the connectors table
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { PageSection } from '@patternfly/react-core';
 import { ConnectorsTable } from '@/components/kafka/connect/ConnectorsTable';
 

--- a/api/src/main/webui/src/pages/kafka/connect/ConnectPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/connect/ConnectPage.tsx
@@ -4,7 +4,7 @@
  * Main page for Kafka Connect with tabs for Connectors and Connect Clusters
  */
 
-import { useParams, useNavigate, useLocation, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/connect/detail/ConnectClusterDetailPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/connect/detail/ConnectClusterDetailPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import {
   PageSection,
   Tabs,

--- a/api/src/main/webui/src/pages/kafka/connect/detail/ConnectorDetailPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/connect/detail/ConnectorDetailPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   PageSection,
   Title,

--- a/api/src/main/webui/src/pages/kafka/groups/GroupsPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/groups/GroupsPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/groups/detail/GroupConfigurationTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/groups/detail/GroupConfigurationTab.tsx
@@ -2,7 +2,7 @@
  * Group Configuration Tab - Shows configuration settings for a consumer group
  */
 
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useState, useMemo, useCallback } from 'react';
 import {

--- a/api/src/main/webui/src/pages/kafka/groups/detail/GroupDetailPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/groups/detail/GroupDetailPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState } from 'react';
-import { useParams, useNavigate, useLocation, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/groups/detail/GroupMembersTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/groups/detail/GroupMembersTab.tsx
@@ -2,7 +2,7 @@
  * Group Members Tab - Shows members of a consumer group
  */
 
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/nodes/NodesOverviewTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/nodes/NodesOverviewTab.tsx
@@ -2,7 +2,7 @@
  * Nodes Overview Tab - Shows node distribution chart and nodes table
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/nodes/NodesPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/nodes/NodesPage.tsx
@@ -2,7 +2,7 @@
  * Nodes Page - Shows Kafka nodes with Overview and Rebalance tabs
  */
 
-import { useParams, useNavigate, useLocation, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/nodes/NodesRebalancesTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/nodes/NodesRebalancesTab.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/nodes/detail/NodeConfigurationTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/nodes/detail/NodeConfigurationTab.tsx
@@ -2,7 +2,7 @@
  * Node Configuration Tab - Shows configuration settings for a Kafka node/broker
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useState, useMemo, useCallback } from 'react';
 import {

--- a/api/src/main/webui/src/pages/kafka/nodes/detail/NodeDetailPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/nodes/detail/NodeDetailPage.tsx
@@ -2,7 +2,7 @@
  * Node Detail Page - Shows details for a specific Kafka node/broker
  */
 
-import { useParams, useNavigate, useLocation, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/overview/KafkaOverview.tsx
+++ b/api/src/main/webui/src/pages/kafka/overview/KafkaOverview.tsx
@@ -9,7 +9,7 @@
  * - Metrics charts (placeholder for now)
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/topics/TopicsPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/TopicsPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useCallback, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/topics/detail/TopicConfigurationTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/detail/TopicConfigurationTab.tsx
@@ -2,7 +2,7 @@
  * Topic Configuration Tab - Shows configuration settings for a topic
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useState, useMemo, useCallback } from 'react';
 import {

--- a/api/src/main/webui/src/pages/kafka/topics/detail/TopicDetailPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/detail/TopicDetailPage.tsx
@@ -2,7 +2,7 @@
  * Topic Detail Page - Shows detailed information about a topic with tabs
  */
 
-import { useParams, useNavigate, useLocation, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useEffect } from 'react';
 import {

--- a/api/src/main/webui/src/pages/kafka/topics/detail/TopicGroupsTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/detail/TopicGroupsTab.tsx
@@ -2,7 +2,7 @@
  * Topic Groups Tab - Shows groups for a topic
  */
 
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import {

--- a/api/src/main/webui/src/pages/kafka/topics/detail/TopicMessagesTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/detail/TopicMessagesTab.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/topics/detail/TopicPartitionsTab.tsx
+++ b/api/src/main/webui/src/pages/kafka/topics/detail/TopicPartitionsTab.tsx
@@ -2,7 +2,7 @@
  * Topic Partitions Tab - Shows partition information for a topic
  */
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useState, useMemo, useEffect } from 'react';
 import {

--- a/api/src/main/webui/src/pages/kafka/users/UsersPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/users/UsersPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/pages/kafka/users/detail/UserDetailPage.tsx
+++ b/api/src/main/webui/src/pages/kafka/users/detail/UserDetailPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,

--- a/api/src/main/webui/src/routes/index.tsx
+++ b/api/src/main/webui/src/routes/index.tsx
@@ -2,7 +2,7 @@
  * React Router configuration
  */
 
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate } from 'react-router';
 import App from '../App';
 
 // Root pages


### PR DESCRIPTION
## Summary

This PR upgrades the UI to React Router v8 by replacing `react-router-dom` with `react-router` and updating imports to match the v8 package structure.

### Changes

* Replaced the `react-router-dom` dependency with `react-router`.
* Updated `RouterProvider` to import from `react-router/dom`.
* Updated all remaining imports from `react-router-dom` to `react-router`.
* Updated `package-lock.json`.

### Validation

* ✅ `npm install`
* ✅ `npm run build`
* ✅ `npm run lint`
* ✅ Verified there are no remaining `react-router-dom` imports.
