### PR TITLE
Operator Test: Use server-side apply to update PkceRequired flag

### DIFF
--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerSecurityTest.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerSecurityTest.java
@@ -370,8 +370,9 @@ class ConsoleReconcilerSecurityTest extends ConsoleReconcilerTestBase {
         });
 
         console = client.resource(console).get();
-        client.resource(console).edit(c -> {
-            return new ConsoleBuilder(c)
+        console.getMetadata().setManagedFields(null);
+
+        client.resource(new ConsoleBuilder(console)
                     .editSpec()
                         .editSecurity()
                             .editOidc()
@@ -379,8 +380,8 @@ class ConsoleReconcilerSecurityTest extends ConsoleReconcilerTestBase {
                             .endOidc()
                         .endSecurity()
                     .endSpec()
-                    .build();
-        });
+                .build())
+            .serverSideApply();
 
         assertConsoleConfig(consoleConfig -> {
             var securityConfig = consoleConfig.getSecurity();


### PR DESCRIPTION
This PR changes an operator test to use SSA to update the CR's PkceRequired flag. This avoids a test failure caused by a race condition between the test and the operator updating the CR that results in HTTP status 409.