### PR TITLE
fix: ignore Apicurio 3 split packages in Quarkus ARC

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -60,7 +60,7 @@ quarkus.container-image.labels."org.opencontainers.image.revision"=${git.revisio
 quarkus.arc.unremovable-types=com.github.streamshub.console.api.**
 # Apicurio's Jackson customizer is distributed in a common jar by mistake
 quarkus.arc.exclude-types=io.apicurio.registry.rest.JacksonDateTimeCustomizer
-quarkus.arc.ignored-split-packages=io.apicurio.registry.content.*,io.apicurio.registry.rules.*,
+quarkus.arc.ignored-split-packages=io.apicurio.registry.content.*,io.apicurio.registry.rules.*,io.apicurio.registry.client.*,io.apicurio.registry.serde.*,
 
 quarkus.index-dependency.kafka-clients.group-id=org.apache.kafka
 quarkus.index-dependency.kafka-clients.artifact-id=kafka-clients


### PR DESCRIPTION
## Summary
After the Apicurio 2.x → 3.x upgrade, `SplitPackageProcessor` warns because several packages now live in multiple artifacts:

- `io.apicurio.registry.client` / `client.common` / `client.common.auth`
- `io.apicurio.registry.serde.protobuf` / `serde.protobuf.ref`
- `io.apicurio.registry.serde.avro`

This updates `quarkus.arc.ignored-split-packages` in `api/src/main/resources/application.properties` to keep the existing `content.*` and `rules.*` ignores and add `client.*` and `serde.*`.

Replaces #2866 (same change, DCO Signed-off-by on the commit).

## Test plan
- [ ] Build the API module and confirm the `Detected a split package usage` warnings for those Apicurio 3 packages are gone
- [ ] Existing `content.*` / `rules.*` ignores still present

Closes #2855
