### PR TITLE
Update Node chart colors

### DIFF
--- a/api/src/main/webui/src/components/kafka/nodes/charts/ChartNodeStorageUsage.tsx
+++ b/api/src/main/webui/src/components/kafka/nodes/charts/ChartNodeStorageUsage.tsx
@@ -5,7 +5,6 @@ import {
   ChartBar,
   ChartLegend,
   ChartStack,
-  ChartThemeColor,
   ChartTooltip,
 } from '@patternfly/react-charts/victory';
 import {
@@ -91,6 +90,11 @@ export function ChartNodeStorageUsage({ nodes }: ChartNodeStorageUsageProps) {
   const legendData = [
     { name: t('nodes.charts.storageUsageSeriesUsed') },
     { name: t('nodes.charts.storageUsageSeriesAvailable') },
+  ];
+
+  const chartColors = [
+    '#E5B27F', // used
+    '#7FB2E5' // available
   ];
 
   // Compute 5 evenly-spaced, round tick values from 0 to maxCapacity.
@@ -182,11 +186,10 @@ export function ChartNodeStorageUsage({ nodes }: ChartNodeStorageUsageProps) {
         ariaTitle={t('nodes.charts.storageUsageAriaTitle')}
         legendPosition="bottom-left"
         legendComponent={
-          <ChartLegend orientation="horizontal" data={legendData} itemsPerRow={2} />
+          <ChartLegend orientation="horizontal" data={legendData} itemsPerRow={2} colorScale={chartColors} />
         }
         padding={padding}
         domainPadding={{ x: [edgePadding, edgePadding] }}
-        themeColor={ChartThemeColor.multiOrdered}
         width={width}
         height={calculatedChartHeight}
         legendAllowWrap={true}
@@ -209,6 +212,7 @@ export function ChartNodeStorageUsage({ nodes }: ChartNodeStorageUsageProps) {
         <ChartAxis />
         <ChartStack
           labelComponent={<ChartTooltip constrainToVisibleArea />}
+          colorScale={chartColors}
         >
           <ChartBar
             data={usedData}

--- a/api/src/main/webui/src/components/kafka/nodes/charts/ChartPartitionDistribution.tsx
+++ b/api/src/main/webui/src/components/kafka/nodes/charts/ChartPartitionDistribution.tsx
@@ -5,7 +5,6 @@ import {
   ChartBar,
   ChartLegend,
   ChartStack,
-  ChartThemeColor,
   ChartTooltip,
 } from '@patternfly/react-charts/victory';
 import { Alert } from '@patternfly/react-core';
@@ -55,6 +54,11 @@ export function ChartPartitionDistribution({ nodes }: ChartPartitionDistribution
     { name: t('nodes.charts.partitionDistributionSeriesLeaders') },
   ];
 
+  const chartColors = [
+    '#876FD4', // replicas
+    '#63993D' // leaders
+  ];
+
   // Configure custom spacing dimensions
   const barWidth = 20;     // Thickness of each individual bar
   const innerPadding = 16;  // Distance between bars in pixels
@@ -87,11 +91,10 @@ export function ChartPartitionDistribution({ nodes }: ChartPartitionDistribution
         ariaTitle={t('nodes.charts.partitionDistributionAriaTitle')}
         legendPosition="bottom-left"
         legendComponent={
-          <ChartLegend orientation="horizontal" data={legendData} itemsPerRow={2} />
+          <ChartLegend orientation="horizontal" data={legendData} itemsPerRow={2} colorScale={chartColors} />
         }
         padding={padding}
         domainPadding={{ x: [edgePadding, edgePadding] }}
-        themeColor={ChartThemeColor.multiOrdered}
         width={width}
         height={calculatedChartHeight}
         legendAllowWrap={true}
@@ -108,7 +111,7 @@ export function ChartPartitionDistribution({ nodes }: ChartPartitionDistribution
           horizontal
         />
         <ChartAxis />
-        <ChartStack>
+        <ChartStack colorScale={chartColors}>
           <ChartBar
             data={replicasData}
             barWidth={barWidth}


### PR DESCRIPTION
Update the node storage and partition distribution chart colors.

<img width="1638" height="766" alt="image" src="https://github.com/user-attachments/assets/b554e2df-58a6-4838-8713-c121bf7d55cd" />
