### PR TITLE
Operator test: add retries for Console CR updates

### DIFF
--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerSecurityTest.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerSecurityTest.java
@@ -370,18 +370,15 @@ class ConsoleReconcilerSecurityTest extends ConsoleReconcilerTestBase {
         });
 
         // Enable PKCE
-        client.resources(Console.class)
-            .inNamespace(console.getMetadata().getNamespace())
-            .withName(console.getMetadata().getName())
-            .edit(c -> new ConsoleBuilder(c)
-                    .editSpec()
-                        .editSecurity()
-                            .editOidc()
-                                .withPkceRequired()
-                            .endOidc()
-                        .endSecurity()
-                    .endSpec()
-                .build());
+        edit(console, c -> new ConsoleBuilder(c)
+                .editSpec()
+                    .editSecurity()
+                        .editOidc()
+                            .withPkceRequired(true)
+                        .endOidc()
+                    .endSecurity()
+                .endSpec()
+            .build());
 
         assertConsoleConfig(consoleConfig -> {
             var securityConfig = consoleConfig.getSecurity();
@@ -390,18 +387,16 @@ class ConsoleReconcilerSecurityTest extends ConsoleReconcilerTestBase {
             assertEquals(stateSecret.get(), oidc.getStateSecret());
         });
 
-        console = client.resource(console).get();
-        client.resource(console).edit(c -> {
-            return new ConsoleBuilder(c)
-                    .editSpec()
-                        .editSecurity()
-                            .editOidc()
-                                .withPkceRequired(false)
-                            .endOidc()
-                        .endSecurity()
-                    .endSpec()
-                    .build();
-        });
+        // Disable PKCE
+        edit(console, c -> new ConsoleBuilder(c)
+                .editSpec()
+                    .editSecurity()
+                        .editOidc()
+                            .withPkceRequired(false)
+                        .endOidc()
+                    .endSecurity()
+                .endSpec()
+            .build());
 
         assertConsoleConfig(consoleConfig -> {
             var securityConfig = consoleConfig.getSecurity();

--- a/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTestBase.java
+++ b/operator/src/test/java/com/github/streamshub/console/ConsoleReconcilerTestBase.java
@@ -10,8 +10,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import jakarta.inject.Inject;
 
@@ -37,6 +39,7 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion;
@@ -544,5 +547,29 @@ abstract class ConsoleReconcilerTestBase {
                 .inNamespace(consoleCR.getMetadata().getNamespace())
                 .withName("%s-console-secret".formatted(consoleCR.getMetadata().getName()))
                 .get();
+    }
+
+    <T extends HasMetadata> T edit(T resource, UnaryOperator<T> editor) {
+        @SuppressWarnings("unchecked")
+        Class<T> resourceType = (Class<T>) resource.getClass();
+
+        return await()
+            .atMost(5, TimeUnit.SECONDS)
+            .ignoreExceptionsMatching(thrown -> {
+                if (thrown instanceof KubernetesClientException kce) {
+                    return Optional.ofNullable(kce.getStatus())
+                        .map(Status::getCode)
+                        .map(Integer.valueOf(409)::equals)
+                        .orElse(false);
+                }
+
+                return false;
+            })
+            .until(
+                () -> client.resources(resourceType)
+                    .inNamespace(resource.getMetadata().getNamespace())
+                    .withName(resource.getMetadata().getName())
+                    .edit(editor),
+                Objects::nonNull);
     }
 }


### PR DESCRIPTION
This test has proven to be persistently flaky. This PR adds retries to both of the attempts to update the PKCE flag in the Console CR so that HTTP/409 is ignored for several tries.