### PR TITLE
Enable heading link generation in the docs

### DIFF
--- a/docs/sources/attributes.adoc
+++ b/docs/sources/attributes.adoc
@@ -7,7 +7,7 @@
 :idprefix:
 :imagesdir: images
 :numbered:
-:sectanchors!:
+:sectanchors:
 :sectnums:
 :source-highlighter: highlightjs
 :toc: left


### PR DESCRIPTION
At some point, in the dim distant past, we disabled the generation of anchor links for the headings in the docs. This means we cannot link to specific parts of the docs on the main streamshub site (which pull the docs from this repo).

Having asked around I can't establish why this was disabled, so the PR re-enables it and maybe the reason will be come clear?