### PR TITLE
Restrict CI checks to changes that effect code only

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,12 +4,26 @@ on:
     branches:
       - 'main'
       - '[0-9]+.[0-9]+.x'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'dco.txt'
+      - '.gitignore'
+      - '.snyk'
   pull_request:
     branches:
       - 'main'
       - '[0-9]+.[0-9]+.x'
       - 'systemtests'
     types: [ opened, reopened, synchronize ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'dco.txt'
+      - '.gitignore'
+      - '.snyk'
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently, the CI will run all tests for _any_ change in the repo, even for changes to files that have no effect on the operation of the Console or its operator (like docs updates). 

This PR adds ignore paths for non-functional files and folders in the repo so that changes to them won't trigger the testing pipelines.  